### PR TITLE
Feat/mcp public mode

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,13 +1,8 @@
 {
     "servers": {
-        "aimdb": {
-            "type": "stdio",
-            "command": "/aimdb_ws/aimdb/target/release/aimdb-mcp",
-            "args": [],
-            "env": {
-                "RUST_LOG": "info",
-                "AIMDB_WORKSPACE": "${workspaceFolder}"
-            }
+        "aimdb-weather": {
+            "type": "http",
+            "url": "http://aimdb.dev/mcp"
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **MCP public mode**: New `--public` flag restricts the MCP server to read-only tools for safe internet-facing deployments with SSRF protection ([tools/aimdb-mcp](tools/aimdb-mcp/CHANGELOG.md))
 - **MCP `--socket` flag**: Default socket path can be set at startup, simplifying single-instance workflows ([tools/aimdb-mcp](tools/aimdb-mcp/CHANGELOG.md))
-
-### Changed
-
-- **`rand` 0.8 → 0.10.1**: Upgraded across workspace (`aimdb-data-contracts`, `aimdb-embassy-adapter`, examples). Migrated API: `gen` → `random`, `SmallRng` seed size 16 → 32, added `RngExt` imports.
-- **README**: Reordered quickstart — remote MCP exploration (zero install) is now step 2, local Docker setup moved to step 3.
-
-### Added
-
 - **Context-Aware Deserializers (Design 026)**: Inbound connector deserializers can now receive a `RuntimeContext<R>` for platform-independent timestamps and logging
   - New `.with_deserializer(|ctx, bytes| ...)` API on `InboundConnectorBuilder` provides `RuntimeContext<R>` to deserialization closures
   - New `.with_deserializer_raw(|bytes| ...)` for plain bytes-only deserialization when context is unnecessary
@@ -60,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **aimdb-knx-connector**: Updated router dispatch for new `route()` signature; outbound publishers dispatch via `SerializerKind`
 - **aimdb-websocket-connector**: Updated router dispatch for new `route()` signature; outbound publishers dispatch via `SerializerKind`
 - All connector examples updated to use new `.with_deserializer(|_ctx, bytes| ...)` and `.with_serializer_raw(|value| ...)` signatures
+- **`rand` 0.8 → 0.10.1**: Upgraded across workspace (`aimdb-data-contracts`, `aimdb-embassy-adapter`, examples). Migrated API: `gen` → `random`, `SmallRng` seed size 16 → 32, added `RngExt` imports.
+- **README**: Reordered quickstart — remote MCP exploration (zero install) is now step 2, local Docker setup moved to step 3.
 
 ## [1.0.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP public mode**: New `--public` flag restricts the MCP server to read-only tools for safe internet-facing deployments with SSRF protection ([tools/aimdb-mcp](tools/aimdb-mcp/CHANGELOG.md))
+- **MCP `--socket` flag**: Default socket path can be set at startup, simplifying single-instance workflows ([tools/aimdb-mcp](tools/aimdb-mcp/CHANGELOG.md))
+
+### Changed
+
+- **`rand` 0.8 → 0.10.1**: Upgraded across workspace (`aimdb-data-contracts`, `aimdb-embassy-adapter`, examples). Migrated API: `gen` → `random`, `SmallRng` seed size 16 → 32, added `RngExt` imports.
+- **README**: Reordered quickstart — remote MCP exploration (zero install) is now step 2, local Docker setup moved to step 3.
+
+### Added
+
 - **Context-Aware Deserializers (Design 026)**: Inbound connector deserializers can now receive a `RuntimeContext<R>` for platform-independent timestamps and logging
   - New `.with_deserializer(|ctx, bytes| ...)` API on `InboundConnectorBuilder` provides `RuntimeContext<R>` to deserialization closures
   - New `.with_deserializer_raw(|bytes| ...)` for plain bytes-only deserialization when context is unnecessary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ version = "0.1.0"
 dependencies = [
  "aimdb-core",
  "aimdb-executor",
- "rand 0.8.5",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -130,7 +130,7 @@ dependencies = [
  "futures",
  "futures-core",
  "heapless 0.9.1",
- "rand 0.8.5",
+ "rand 0.10.1",
  "tracing",
  "tracing-test",
 ]
@@ -624,6 +624,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +791,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1044,7 +1064,7 @@ dependencies = [
  "knx-connector-demo-common",
  "micromath",
  "panic-probe",
- "rand 0.8.5",
+ "rand 0.10.1",
  "static_cell",
  "stm32-fmc 0.3.2",
 ]
@@ -1077,7 +1097,7 @@ dependencies = [
  "micromath",
  "mqtt-connector-demo-common",
  "panic-probe",
- "rand 0.8.5",
+ "rand 0.10.1",
  "static_cell",
  "stm32-fmc 0.3.2",
 ]
@@ -1595,8 +1615,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1933,6 +1967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +2007,8 @@ checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2031,6 +2073,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2466,15 +2514,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2482,18 +2525,19 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -2511,9 +2555,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -2688,7 +2729,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2875,6 +2916,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,7 +3033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3708,6 +3755,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,7 +3883,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3916,6 +3978,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver 1.0.28",
+]
+
+[[package]]
 name = "weather-hub"
 version = "0.1.0"
 dependencies = [
@@ -3935,7 +4031,7 @@ version = "0.1.0"
 dependencies = [
  "aimdb-core",
  "aimdb-data-contracts",
- "rand 0.8.5",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -3967,7 +4063,7 @@ dependencies = [
  "aimdb-mqtt-connector",
  "aimdb-tokio-adapter",
  "chrono",
- "rand 0.8.5",
+ "rand 0.10.1",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4002,7 +4098,7 @@ dependencies = [
  "heapless 0.8.0",
  "micromath",
  "panic-probe",
- "rand 0.8.5",
+ "rand 0.10.1",
  "static_cell",
  "stm32-fmc 0.3.2",
  "weather-mesh-common",
@@ -4412,6 +4508,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.108",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver 1.0.28",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "stm32-metapac"
 version = "21.0.0"
-source = "git+https://github.com/embassy-rs/stm32-data-generated?tag=stm32-data-68326d96233978fbbfdc55c29cca8624dab43cd6#714b6bd91a4ca13c5b5b6a14c68a42de790e8b55"
+source = "git+https://github.com/embassy-rs/stm32-data-generated?tag=stm32-data-5f15bbfaf37bd6a6330fec66a3a39de0042d64ac#8da545d80e11594b00efdcc6fb94c70054bee09a"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "aimdb-core",
  "anyhow",
  "chrono",
+ "clap",
  "fs2",
  "once_cell",
  "serde",

--- a/README.md
+++ b/README.md
@@ -180,7 +180,32 @@ Explore a running sensor mesh — no setup required:
 
 > **[aimdb.dev](https://aimdb.dev)** — live weather stations streaming typed contracts across MCU, edge and cloud.
 
-#### 2. Run locally
+#### 2. Explore with AI
+
+Connect an MCP-compatible editor to the live demo and query your data in natural language — no install required:
+
+<p align="center">
+  <img src="assets/copilot-communication.gif" alt="AimDB MCP Live Demo" width="600">
+</p>
+
+Add the remote MCP server to your workspace:
+
+`.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "aimdb-weather": {
+      "type": "http",
+      "url": "http://aimdb.dev/mcp"
+    }
+  }
+}
+```
+
+Then ask: *"What's the current temperature in Munich?"* — see the [MCP server docs](tools/aimdb-mcp/) for Claude Desktop and other editors.
+
+#### 3. Run locally
 
 Spin up a full MCU → edge → cloud mesh with one command:
 
@@ -190,35 +215,6 @@ docker compose up
 ```
 
 This starts three weather stations, an MQTT broker and a central hub — all wired together with typed data contracts.
-
-#### 3. Explore with AI
-
-With the mesh running, connect an MCP-compatible editor to query your data in natural language:
-
-<p align="center">
-  <img src="assets/copilot-communication.gif" alt="AimDB MCP Live Demo" width="600">
-</p>
-
-Install the MCP server and add it to your workspace:
-
-```bash
-cargo install aimdb-mcp
-```
-
-`.vscode/mcp.json`:
-
-```json
-{
-  "servers": {
-    "aimdb": {
-      "type": "stdio",
-      "command": "${userHome}/.cargo/bin/aimdb-mcp"
-    }
-  }
-}
-```
-
-Then ask: *"What's the current temperature from station alpha?"* — see the [MCP server docs](tools/aimdb-mcp/) for Claude Desktop and other editors.
 
 #### 4. Build your own
 

--- a/aimdb-data-contracts/CHANGELOG.md
+++ b/aimdb-data-contracts/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes yet.
+### Changed
+
+- **Dependency update**: Upgraded `rand` from 0.8 to 0.10.1.
 
 ## [0.1.0] - 2026-03-16
 

--- a/aimdb-data-contracts/Cargo.toml
+++ b/aimdb-data-contracts/Cargo.toml
@@ -31,7 +31,7 @@ aimdb-core = { version = "1.0.0", path = "../aimdb-core", optional = true, defau
 aimdb-executor = { version = "0.1.0", path = "../aimdb-executor", optional = true, default-features = false }
 
 [dependencies.rand]
-version = "0.8"
+version = "0.10.1"
 optional = true
 default-features = false
 features = ["std_rng"]

--- a/aimdb-embassy-adapter/CHANGELOG.md
+++ b/aimdb-embassy-adapter/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes yet.
+### Changed
+
+- **Dev-dependency update**: Upgraded `rand` from 0.8 to 0.10.1.
 
 ## [0.5.0] - 2026-02-21
 

--- a/aimdb-embassy-adapter/Cargo.toml
+++ b/aimdb-embassy-adapter/Cargo.toml
@@ -80,4 +80,4 @@ futures = "0.3"
 tracing-test = "0.2"
 
 # Random number generation for tests
-rand = "0.8"
+rand = "0.10.1"

--- a/deny.toml
+++ b/deny.toml
@@ -24,10 +24,8 @@ version = 2
 yanked = "warn"
 # rustls-pemfile is unmaintained but not vulnerable - waiting for rumqttc to migrate
 # See: https://github.com/rustls/pemfile/issues/61
-# rustls-webpki 0.102.x has no patch (fix only in 0.103.10+) - transitive via rumqttc
 ignore = [
     "RUSTSEC-2025-0134", # rustls-pemfile unmaintained (transitive via rumqttc)
-    "RUSTSEC-2026-0049", # rustls-webpki 0.102.x CRL issue (no patch in 0.102.x line, rumqttc transitive)
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -24,8 +24,10 @@ version = 2
 yanked = "warn"
 # rustls-pemfile is unmaintained but not vulnerable - waiting for rumqttc to migrate
 # See: https://github.com/rustls/pemfile/issues/61
+# rustls-webpki 0.102.x has no patch (fix only in 0.103.10+) - transitive via rumqttc
 ignore = [
     "RUSTSEC-2025-0134", # rustls-pemfile unmaintained (transitive via rumqttc)
+    "RUSTSEC-2026-0049", # rustls-webpki 0.102.x CRL issue (no patch in 0.102.x line, rumqttc transitive)
 ]
 
 [sources]

--- a/examples/embassy-knx-connector-demo/Cargo.toml
+++ b/examples/embassy-knx-connector-demo/Cargo.toml
@@ -84,7 +84,7 @@ stm32-fmc = { workspace = true }
 embedded-alloc = { version = "0.6", features = ["llff"] }
 
 # RNG for unique client IDs
-rand = { version = "0.8", default-features = false, features = ["small_rng"] }
+rand = { version = "0.10.1", default-features = false }
 
 [package.metadata.embassy]
 build = [

--- a/examples/embassy-knx-connector-demo/src/main.rs
+++ b/examples/embassy-knx-connector-demo/src/main.rs
@@ -171,18 +171,18 @@ async fn main(spawner: Spawner) {
             mode: HseMode::BypassDigital,
         });
         config.rcc.pll1 = Some(Pll {
-            source: PllSource::HSE,
-            prediv: PllPreDiv::DIV2,
-            mul: PllMul::MUL125,
-            divp: Some(PllDiv::DIV2),
-            divq: Some(PllDiv::DIV2),
+            source: PllSource::Hse,
+            prediv: PllPreDiv::Div2,
+            mul: PllMul::Mul125,
+            divp: Some(PllDiv::Div2),
+            divq: Some(PllDiv::Div2),
             divr: None,
         });
-        config.rcc.ahb_pre = AHBPrescaler::DIV1;
-        config.rcc.apb1_pre = APBPrescaler::DIV1;
-        config.rcc.apb2_pre = APBPrescaler::DIV1;
-        config.rcc.apb3_pre = APBPrescaler::DIV1;
-        config.rcc.sys = Sysclk::PLL1_P;
+        config.rcc.ahb_pre = AHBPrescaler::Div1;
+        config.rcc.apb1_pre = APBPrescaler::Div1;
+        config.rcc.apb2_pre = APBPrescaler::Div1;
+        config.rcc.apb3_pre = APBPrescaler::Div1;
+        config.rcc.sys = Sysclk::Pll1P;
         config.rcc.voltage_scale = VoltageScale::Scale0;
     }
     let p = embassy_stm32::init(config);

--- a/examples/embassy-mqtt-connector-demo/Cargo.toml
+++ b/examples/embassy-mqtt-connector-demo/Cargo.toml
@@ -85,7 +85,7 @@ stm32-fmc = { workspace = true }
 embedded-alloc = { version = "0.6", features = ["llff"] }
 
 # RNG for unique client IDs
-rand = { version = "0.8", default-features = false, features = ["small_rng"] }
+rand = { version = "0.10.1", default-features = false }
 
 [package.metadata.embassy]
 build = [

--- a/examples/embassy-mqtt-connector-demo/src/main.rs
+++ b/examples/embassy-mqtt-connector-demo/src/main.rs
@@ -220,18 +220,18 @@ async fn main(spawner: Spawner) {
             mode: HseMode::BypassDigital,
         });
         config.rcc.pll1 = Some(Pll {
-            source: PllSource::HSE,
-            prediv: PllPreDiv::DIV2,
-            mul: PllMul::MUL125,
-            divp: Some(PllDiv::DIV2),
-            divq: Some(PllDiv::DIV2),
+            source: PllSource::Hse,
+            prediv: PllPreDiv::Div2,
+            mul: PllMul::Mul125,
+            divp: Some(PllDiv::Div2),
+            divq: Some(PllDiv::Div2),
             divr: None,
         });
-        config.rcc.ahb_pre = AHBPrescaler::DIV1;
-        config.rcc.apb1_pre = APBPrescaler::DIV1;
-        config.rcc.apb2_pre = APBPrescaler::DIV1;
-        config.rcc.apb3_pre = APBPrescaler::DIV1;
-        config.rcc.sys = Sysclk::PLL1_P;
+        config.rcc.ahb_pre = AHBPrescaler::Div1;
+        config.rcc.apb1_pre = APBPrescaler::Div1;
+        config.rcc.apb2_pre = APBPrescaler::Div1;
+        config.rcc.apb3_pre = APBPrescaler::Div1;
+        config.rcc.sys = Sysclk::Pll1P;
         config.rcc.voltage_scale = VoltageScale::Scale0;
     }
     let p = embassy_stm32::init(config);

--- a/examples/weather-mesh-demo/weather-mesh-common/Cargo.toml
+++ b/examples/weather-mesh-demo/weather-mesh-common/Cargo.toml
@@ -21,6 +21,6 @@ aimdb-core = { path = "../../../aimdb-core", default-features = false, features 
 aimdb-data-contracts = { path = "../../../aimdb-data-contracts", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-rand = { version = "0.8", optional = true, default-features = false, features = [
+rand = { version = "0.10.1", optional = true, default-features = false, features = [
     "std_rng",
 ] }

--- a/examples/weather-mesh-demo/weather-mesh-common/src/contracts/humidity.rs
+++ b/examples/weather-mesh-demo/weather-mesh-common/src/contracts/humidity.rs
@@ -10,6 +10,8 @@ use aimdb_data_contracts::Linkable;
 
 #[cfg(feature = "simulatable")]
 use aimdb_data_contracts::{Simulatable, SimulationConfig};
+#[cfg(feature = "simulatable")]
+use rand::RngExt;
 
 /// Humidity sensor reading
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -70,12 +72,12 @@ impl Simulatable for Humidity {
         // Random walk: small delta from previous value, clamped to valid range
         let current = match previous {
             Some(prev) => {
-                let delta = (rng.gen::<f32>() - 0.5) * variation * step;
+                let delta = (rng.random::<f32>() - 0.5) * variation * step;
                 (prev.percent + delta + trend)
                     .clamp(0.0, 100.0)
                     .clamp(base - variation, base + variation)
             }
-            None => base + (rng.gen::<f32>() - 0.5) * variation,
+            None => base + (rng.random::<f32>() - 0.5) * variation,
         };
 
         Humidity {

--- a/examples/weather-mesh-demo/weather-mesh-common/src/contracts/location.rs
+++ b/examples/weather-mesh-demo/weather-mesh-common/src/contracts/location.rs
@@ -10,6 +10,8 @@ use aimdb_data_contracts::Linkable;
 
 #[cfg(feature = "simulatable")]
 use aimdb_data_contracts::{Simulatable, SimulationConfig};
+#[cfg(feature = "simulatable")]
+use rand::RngExt;
 
 /// GPS location reading
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -93,8 +95,8 @@ impl Simulatable for GpsLocation {
         // Random walk from previous position or start near base
         let (lat, lon) = match previous {
             Some(prev) => {
-                let lat_delta = (rng.gen::<f64>() - 0.5) * max_delta * step;
-                let lon_delta = (rng.gen::<f64>() - 0.5) * max_delta * step;
+                let lat_delta = (rng.random::<f64>() - 0.5) * max_delta * step;
+                let lon_delta = (rng.random::<f64>() - 0.5) * max_delta * step;
                 let new_lat =
                     (prev.latitude + lat_delta).clamp(base_lat - max_delta, base_lat + max_delta);
                 let new_lon =
@@ -102,8 +104,8 @@ impl Simulatable for GpsLocation {
                 (new_lat, new_lon)
             }
             None => {
-                let lat = base_lat + (rng.gen::<f64>() - 0.5) * max_delta;
-                let lon = base_lon + (rng.gen::<f64>() - 0.5) * max_delta;
+                let lat = base_lat + (rng.random::<f64>() - 0.5) * max_delta;
+                let lon = base_lon + (rng.random::<f64>() - 0.5) * max_delta;
                 (lat, lon)
             }
         };
@@ -111,8 +113,8 @@ impl Simulatable for GpsLocation {
         GpsLocation {
             latitude: lat,
             longitude: lon,
-            altitude: Some(200.0 + rng.gen::<f32>() * 10.0),
-            accuracy: Some(5.0 + rng.gen::<f32>() * 10.0),
+            altitude: Some(200.0 + rng.random::<f32>() * 10.0),
+            accuracy: Some(5.0 + rng.random::<f32>() * 10.0),
             timestamp,
         }
     }

--- a/examples/weather-mesh-demo/weather-mesh-common/src/contracts/temperature.rs
+++ b/examples/weather-mesh-demo/weather-mesh-common/src/contracts/temperature.rs
@@ -21,6 +21,8 @@ use aimdb_data_contracts::Linkable;
 
 #[cfg(feature = "simulatable")]
 use aimdb_data_contracts::{Simulatable, SimulationConfig};
+#[cfg(feature = "simulatable")]
+use rand::RngExt;
 
 #[cfg(feature = "migratable")]
 use aimdb_data_contracts::{MigrationError, MigrationStep};
@@ -208,10 +210,10 @@ impl Simulatable for TemperatureV2 {
         // Random walk: small delta from previous value, clamped to range
         let current = match previous {
             Some(prev) => {
-                let delta = (rng.gen::<f32>() - 0.5) * variation * step;
+                let delta = (rng.random::<f32>() - 0.5) * variation * step;
                 (prev.celsius + delta + trend).clamp(base - variation, base + variation)
             }
-            None => base + (rng.gen::<f32>() - 0.5) * variation,
+            None => base + (rng.random::<f32>() - 0.5) * variation,
         };
 
         TemperatureV2 {

--- a/examples/weather-mesh-demo/weather-station-beta/Cargo.toml
+++ b/examples/weather-mesh-demo/weather-station-beta/Cargo.toml
@@ -30,5 +30,5 @@ aimdb-mqtt-connector = { path = "../../../aimdb-mqtt-connector", features = [
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-rand = "0.8"
+rand = "0.10.1"
 chrono = "0.4"

--- a/examples/weather-mesh-demo/weather-station-beta/src/main.rs
+++ b/examples/weather-mesh-demo/weather-station-beta/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         // Create RNG (StdRng is Send, ThreadRng is not)
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = rand::rngs::StdRng::from_rng(&mut rand::rng());
         let mut prev_temp: Option<Temperature> = None;
         let mut prev_humidity: Option<Humidity> = None;
 

--- a/examples/weather-mesh-demo/weather-station-gamma/Cargo.toml
+++ b/examples/weather-mesh-demo/weather-station-gamma/Cargo.toml
@@ -88,7 +88,7 @@ stm32-fmc = { workspace = true }
 embedded-alloc = { version = "0.6", features = ["llff"] }
 
 # Random number generation for simulation
-rand = { version = "0.8", default-features = false, features = ["small_rng"] }
+rand = { version = "0.10.1", default-features = false }
 
 [profile.release]
 opt-level = "s"

--- a/examples/weather-mesh-demo/weather-station-gamma/src/main.rs
+++ b/examples/weather-mesh-demo/weather-station-gamma/src/main.rs
@@ -85,7 +85,7 @@ async fn temperature_producer(
         },
     };
 
-    let mut rng = rand::rngs::SmallRng::from_seed([42; 16]);
+    let mut rng = rand::rngs::SmallRng::from_seed([42; 32]);
     let mut prev: Option<Temperature> = None;
 
     loop {
@@ -122,7 +122,7 @@ async fn humidity_producer(
         },
     };
 
-    let mut rng = rand::rngs::SmallRng::from_seed([84; 16]);
+    let mut rng = rand::rngs::SmallRng::from_seed([84; 32]);
     let mut prev: Option<Humidity> = None;
 
     loop {

--- a/examples/weather-mesh-demo/weather-station-gamma/src/main.rs
+++ b/examples/weather-mesh-demo/weather-station-gamma/src/main.rs
@@ -168,18 +168,18 @@ async fn main(spawner: Spawner) {
             mode: HseMode::BypassDigital,
         });
         config.rcc.pll1 = Some(Pll {
-            source: PllSource::HSE,
-            prediv: PllPreDiv::DIV2,
-            mul: PllMul::MUL125,
-            divp: Some(PllDiv::DIV2),
-            divq: Some(PllDiv::DIV2),
+            source: PllSource::Hse,
+            prediv: PllPreDiv::Div2,
+            mul: PllMul::Mul125,
+            divp: Some(PllDiv::Div2),
+            divq: Some(PllDiv::Div2),
             divr: None,
         });
-        config.rcc.ahb_pre = AHBPrescaler::DIV1;
-        config.rcc.apb1_pre = APBPrescaler::DIV1;
-        config.rcc.apb2_pre = APBPrescaler::DIV1;
-        config.rcc.apb3_pre = APBPrescaler::DIV1;
-        config.rcc.sys = Sysclk::PLL1_P;
+        config.rcc.ahb_pre = AHBPrescaler::Div1;
+        config.rcc.apb1_pre = APBPrescaler::Div1;
+        config.rcc.apb2_pre = APBPrescaler::Div1;
+        config.rcc.apb3_pre = APBPrescaler::Div1;
+        config.rcc.sys = Sysclk::Pll1P;
         config.rcc.voltage_scale = VoltageScale::Scale0;
     }
     let p = embassy_stm32::init(config);

--- a/tools/aimdb-mcp/CHANGELOG.md
+++ b/tools/aimdb-mcp/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes yet.
+### Added
+
+- **Public mode** (`--public` flag): Restricts the server to read-only tools (`discover_instances`, `list_records`, `get_record`) for safe internet-facing deployments. Suppresses resources and prompts capabilities. Strips client-supplied `socket_path` arguments to prevent SSRF.
+- **Default socket flag** (`--socket <PATH>`): Sets a default socket path at startup, removing the need for clients to pass `socket_path` on every call. Resolution order: explicit arg → `--socket` → `AIMDB_SOCKET` env var.
+- **CLI argument parsing**: Added `clap` dependency for structured CLI flags.
+- **Comprehensive tests**: Public mode tool filtering, tool rejection, socket stripping, and capability suppression.
 
 ## [0.7.0] - 2026-03-24
 

--- a/tools/aimdb-mcp/Cargo.toml
+++ b/tools/aimdb-mcp/Cargo.toml
@@ -46,6 +46,9 @@ tokio = { version = "1.48", features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+# CLI
+clap = { version = "4", features = ["derive"] }
+
 # Error handling
 anyhow = "1.0"
 thiserror = "1.0"

--- a/tools/aimdb-mcp/src/main.rs
+++ b/tools/aimdb-mcp/src/main.rs
@@ -33,9 +33,8 @@ struct Cli {
 async fn main() {
     let cli = Cli::parse();
 
-    // Expose --socket as AIMDB_SOCKET so all tool code picks it up automatically
     if let Some(ref socket) = cli.socket {
-        std::env::set_var("AIMDB_SOCKET", socket);
+        aimdb_mcp::tools::set_default_socket(socket.clone());
     }
 
     // Initialize tracing

--- a/tools/aimdb-mcp/src/main.rs
+++ b/tools/aimdb-mcp/src/main.rs
@@ -9,11 +9,35 @@ use aimdb_mcp::protocol::{
     JsonRpcResponse, PromptsGetParams, ResourceReadParams, ToolCallParams,
 };
 use aimdb_mcp::{McpServer, StdioTransport};
+use clap::Parser;
 use serde_json::Value;
 use tracing::{debug, error, info, warn};
 
+/// AimDB MCP Server — LLM-powered introspection for AimDB instances.
+#[derive(Parser)]
+#[command(version, about)]
+struct Cli {
+    /// Public mode: expose only read-only tools (discover_instances, list_records, get_record).
+    /// Intended for untrusted / internet-facing endpoints.
+    #[arg(long)]
+    public: bool,
+
+    /// Default Unix socket path for AimDB connections.
+    /// Tools will use this instead of requiring an explicit socket_path argument.
+    /// Equivalent to setting the AIMDB_SOCKET environment variable.
+    #[arg(long, value_name = "PATH")]
+    socket: Option<String>,
+}
+
 #[tokio::main]
 async fn main() {
+    let cli = Cli::parse();
+
+    // Expose --socket as AIMDB_SOCKET so all tool code picks it up automatically
+    if let Some(ref socket) = cli.socket {
+        std::env::set_var("AIMDB_SOCKET", socket);
+    }
+
     // Initialize tracing
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -26,9 +50,15 @@ async fn main() {
     info!("🚀 Starting AimDB MCP Server");
     info!("📡 Protocol: MCP 2025-06-18 over JSON-RPC 2.0");
     info!("🔌 Transport: stdio (NDJSON)");
+    if cli.public {
+        info!("🔒 Public mode: only read-only tools are available");
+    }
+    if let Some(ref socket) = cli.socket {
+        info!("📎 Default socket: {}", socket);
+    }
 
     // Create server and transport
-    let server = McpServer::new();
+    let server = McpServer::new().with_public_mode(cli.public);
     let mut transport = StdioTransport::new();
 
     info!("✅ Server ready, waiting for initialize request...");

--- a/tools/aimdb-mcp/src/server.rs
+++ b/tools/aimdb-mcp/src/server.rs
@@ -965,8 +965,9 @@ mod tests {
 
     #[test]
     fn public_tools_allowlist_is_valid() {
-        // Ensure the allowlist only contains tool names that actually exist
-        // in the dispatch table (catches typos if tools are renamed).
+        // Ensure the allowlist only contains tool names that actually exist in the
+        // dispatch table, catching typos when tools are renamed. This list is a
+        // snapshot — keep it in sync with the match arms in handle_tools_call().
         let known_tools = [
             "discover_instances",
             "list_records",
@@ -1037,21 +1038,52 @@ mod tests {
         assert!(matches!(err, McpError::MethodNotFound(_)));
     }
 
-    #[tokio::test]
-    async fn public_mode_strips_socket_path() {
+    // Helper: assert that an explicit socket_path is stripped in public mode.
+    // The stripping is confirmed by getting InvalidParams (no socket configured)
+    // rather than a connection error to the attacker-supplied path.
+    async fn assert_socket_path_stripped(tool: &str) {
         let server = McpServer::new().with_public_mode(true);
         server.set_state(ServerState::Ready).await;
-        // Pass an explicit socket_path — it should be stripped in public mode,
-        // causing resolve_socket_path to fall back to AIMDB_SOCKET (which is
-        // unset here, so the call fails with InvalidParams, not a connection
-        // to the attacker-supplied path).
         let params = ToolCallParams {
-            name: "list_records".to_string(),
+            name: tool.to_string(),
             arguments: Some(json!({ "socket_path": "/tmp/evil.sock" })),
         };
         let err = server.handle_tools_call(params).await.unwrap_err();
-        // Without AIMDB_SOCKET set, resolve_socket_path returns InvalidParams
-        assert!(matches!(err, McpError::InvalidParams(_)));
+        assert!(
+            matches!(err, McpError::InvalidParams(_)),
+            "expected InvalidParams for {tool}, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn public_mode_strips_socket_path_list_records() {
+        assert_socket_path_stripped("list_records").await;
+    }
+
+    #[tokio::test]
+    async fn public_mode_strips_socket_path_get_record() {
+        assert_socket_path_stripped("get_record").await;
+    }
+
+    #[tokio::test]
+    async fn public_mode_strips_socket_path_discover_instances() {
+        // discover_instances scans the filesystem directly — it doesn't call
+        // resolve_socket_path, so stripping socket_path doesn't cause InvalidParams.
+        // The expected outcome is that the tool runs normally (no instances found in
+        // the test environment), confirming the evil socket_path was not connected to.
+        let server = McpServer::new().with_public_mode(true);
+        server.set_state(ServerState::Ready).await;
+        let params = ToolCallParams {
+            name: "discover_instances".to_string(),
+            arguments: Some(json!({ "socket_path": "/tmp/evil.sock" })),
+        };
+        let result = server.handle_tools_call(params).await;
+        // The tool is allowed (not MethodNotFound) and does not attempt to connect
+        // to the evil socket. Either Ok or a no-instances error are both acceptable.
+        assert!(
+            !matches!(result, Err(McpError::MethodNotFound(_))),
+            "discover_instances should not be blocked in public mode"
+        );
     }
 
     #[tokio::test]

--- a/tools/aimdb-mcp/src/server.rs
+++ b/tools/aimdb-mcp/src/server.rs
@@ -818,9 +818,10 @@ impl McpServer {
             )));
         }
 
-        // In public mode, strip any explicit socket_path so resolve_socket_path
-        // always falls back to the pinned AIMDB_SOCKET env var. This prevents
-        // clients from probing arbitrary Unix sockets on the host.
+        // In public mode, strip any client-supplied socket_path so
+        // resolve_socket_path falls back to the server-pinned --socket flag
+        // or the AIMDB_SOCKET env var (never a client-chosen path).
+        // This prevents clients from probing arbitrary Unix sockets on the host.
         let arguments = if self.public_mode {
             params.arguments.map(|mut v| {
                 if let Some(obj) = v.as_object_mut() {
@@ -895,6 +896,9 @@ impl McpServer {
         if !self.is_ready().await {
             return Err(McpError::NotInitialized);
         }
+        if self.public_mode {
+            return Err(McpError::MethodNotFound("resources/list".to_string()));
+        }
 
         debug!("📋 Handling resources/list");
         resources::list_resources().await
@@ -910,6 +914,9 @@ impl McpServer {
         if !self.is_ready().await {
             return Err(McpError::NotInitialized);
         }
+        if self.public_mode {
+            return Err(McpError::MethodNotFound("resources/read".to_string()));
+        }
 
         debug!("📖 Handling resources/read: {}", params.uri);
         resources::read_resource(&params.uri).await
@@ -921,6 +928,9 @@ impl McpServer {
     pub async fn handle_prompts_list(&self) -> McpResult<PromptsListResult> {
         if !self.is_ready().await {
             return Err(McpError::NotInitialized);
+        }
+        if self.public_mode {
+            return Err(McpError::MethodNotFound("prompts/list".to_string()));
         }
 
         debug!("📋 Listing available prompts");
@@ -939,6 +949,9 @@ impl McpServer {
     ) -> McpResult<PromptsGetResult> {
         if !self.is_ready().await {
             return Err(McpError::NotInitialized);
+        }
+        if self.public_mode {
+            return Err(McpError::MethodNotFound("prompts/get".to_string()));
         }
 
         debug!("📝 Getting prompt: {}", params.name);
@@ -1042,6 +1055,9 @@ mod tests {
     // The stripping is confirmed by getting InvalidParams (no socket configured)
     // rather than a connection error to the attacker-supplied path.
     async fn assert_socket_path_stripped(tool: &str) {
+        // Clear env so it doesn't interfere with the expected InvalidParams result.
+        std::env::remove_var("AIMDB_SOCKET");
+
         let server = McpServer::new().with_public_mode(true);
         server.set_state(ServerState::Ready).await;
         let params = ToolCallParams {

--- a/tools/aimdb-mcp/src/server.rs
+++ b/tools/aimdb-mcp/src/server.rs
@@ -818,6 +818,24 @@ impl McpServer {
             )));
         }
 
+        // In public mode, strip any explicit socket_path so resolve_socket_path
+        // always falls back to the pinned AIMDB_SOCKET env var. This prevents
+        // clients from probing arbitrary Unix sockets on the host.
+        let arguments = if self.public_mode {
+            params.arguments.map(|mut v| {
+                if let Some(obj) = v.as_object_mut() {
+                    obj.remove("socket_path");
+                }
+                v
+            })
+        } else {
+            params.arguments
+        };
+        let params = ToolCallParams {
+            name: params.name,
+            arguments,
+        };
+
         let result = match params.name.as_str() {
             "discover_instances" => tools::discover_instances(params.arguments).await?,
             "list_records" => tools::list_records(params.arguments).await?,
@@ -996,5 +1014,68 @@ mod tests {
     fn public_mode_can_be_enabled() {
         let server = McpServer::new().with_public_mode(true);
         assert!(server.is_public());
+    }
+
+    #[tokio::test]
+    async fn public_mode_filters_tools_list() {
+        let server = McpServer::new().with_public_mode(true);
+        server.set_state(ServerState::Ready).await;
+        let result = server.handle_tools_list().await.unwrap();
+        let names: Vec<&str> = result.tools.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, PUBLIC_TOOLS);
+    }
+
+    #[tokio::test]
+    async fn public_mode_rejects_non_public_tool() {
+        let server = McpServer::new().with_public_mode(true);
+        server.set_state(ServerState::Ready).await;
+        let params = ToolCallParams {
+            name: "set_record".to_string(),
+            arguments: None,
+        };
+        let err = server.handle_tools_call(params).await.unwrap_err();
+        assert!(matches!(err, McpError::MethodNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn public_mode_strips_socket_path() {
+        let server = McpServer::new().with_public_mode(true);
+        server.set_state(ServerState::Ready).await;
+        // Pass an explicit socket_path — it should be stripped in public mode,
+        // causing resolve_socket_path to fall back to AIMDB_SOCKET (which is
+        // unset here, so the call fails with InvalidParams, not a connection
+        // to the attacker-supplied path).
+        let params = ToolCallParams {
+            name: "list_records".to_string(),
+            arguments: Some(json!({ "socket_path": "/tmp/evil.sock" })),
+        };
+        let err = server.handle_tools_call(params).await.unwrap_err();
+        // Without AIMDB_SOCKET set, resolve_socket_path returns InvalidParams
+        assert!(matches!(err, McpError::InvalidParams(_)));
+    }
+
+    #[tokio::test]
+    async fn normal_mode_lists_all_tools() {
+        let server = McpServer::new();
+        server.set_state(ServerState::Ready).await;
+        let result = server.handle_tools_list().await.unwrap();
+        assert!(result.tools.len() > PUBLIC_TOOLS.len());
+    }
+
+    #[tokio::test]
+    async fn public_mode_suppresses_resources_and_prompts() {
+        let server = McpServer::new().with_public_mode(true);
+        let params = InitializeParams {
+            protocol_version: MCP_PROTOCOL_VERSION.to_string(),
+            capabilities: crate::protocol::ClientCapabilities { sampling: None },
+            client_info: crate::protocol::ClientInfo {
+                name: "test".to_string(),
+                version: "0.1".to_string(),
+            },
+        };
+        let result = server.handle_initialize(params).await.unwrap();
+        assert!(result.capabilities.tools.is_some());
+        assert!(result.capabilities.resources.is_none());
+        assert!(result.capabilities.prompts.is_none());
     }
 }

--- a/tools/aimdb-mcp/src/server.rs
+++ b/tools/aimdb-mcp/src/server.rs
@@ -17,6 +17,9 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::debug;
 
+/// Tools exposed in public mode (read-only, safe for untrusted clients).
+const PUBLIC_TOOLS: &[&str] = &["discover_instances", "list_records", "get_record"];
+
 /// MCP server state
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServerState {
@@ -32,6 +35,8 @@ pub enum ServerState {
 pub struct McpServer {
     state: Arc<Mutex<ServerState>>,
     connection_pool: ConnectionPool,
+    /// When true, only PUBLIC_TOOLS are advertised and callable.
+    public_mode: bool,
 }
 
 impl McpServer {
@@ -40,7 +45,19 @@ impl McpServer {
         Self {
             state: Arc::new(Mutex::new(ServerState::Uninitialized)),
             connection_pool: ConnectionPool::new(),
+            public_mode: false,
         }
+    }
+
+    /// Enable public mode: only read-only tools are available.
+    pub fn with_public_mode(mut self, enabled: bool) -> Self {
+        self.public_mode = enabled;
+        self
+    }
+
+    /// Returns true if the server is in public (restricted) mode.
+    pub fn is_public(&self) -> bool {
+        self.public_mode
     }
 
     /// Get the connection pool
@@ -83,17 +100,25 @@ impl McpServer {
         // Initialize session store for architecture agent
         crate::architecture::init_session_store();
 
-        // Build server capabilities
+        // Build server capabilities — in public mode, only tools are available
         let capabilities = ServerCapabilities {
             tools: Some(ToolsCapability {
-                list_changed: Some(false), // Tool list is static for now
+                list_changed: Some(false),
             }),
-            resources: Some(ResourcesCapability {
-                subscribe: Some(false),
-            }),
-            prompts: Some(PromptsCapability {
-                list_changed: Some(false), // Prompt list is static
-            }),
+            resources: if self.public_mode {
+                None
+            } else {
+                Some(ResourcesCapability {
+                    subscribe: Some(false),
+                })
+            },
+            prompts: if self.public_mode {
+                None
+            } else {
+                Some(PromptsCapability {
+                    list_changed: Some(false),
+                })
+            },
         };
 
         // Build server info (version from Cargo.toml)
@@ -122,7 +147,7 @@ impl McpServer {
 
         debug!("📋 Listing available tools");
 
-        let tools = vec![
+        let mut tools = vec![
             Tool {
                 name: "discover_instances".to_string(),
                 description: "Discover all running AimDB instances on the system. Scans /tmp/*.sock and /var/run/aimdb/*.sock for AimDB servers.".to_string(),
@@ -767,6 +792,11 @@ impl McpServer {
             },
         ];
 
+        // In public mode, only expose the allowlisted tools
+        if self.public_mode {
+            tools.retain(|t| PUBLIC_TOOLS.contains(&t.name.as_str()));
+        }
+
         Ok(ToolsListResult { tools })
     }
 
@@ -779,6 +809,14 @@ impl McpServer {
         }
 
         debug!("🛠️  Calling tool: {}", params.name);
+
+        // Reject non-public tools in public mode (defense in depth)
+        if self.public_mode && !PUBLIC_TOOLS.contains(&params.name.as_str()) {
+            return Err(McpError::MethodNotFound(format!(
+                "Unknown tool: {}",
+                params.name
+            )));
+        }
 
         let result = match params.name.as_str() {
             "discover_instances" => tools::discover_instances(params.arguments).await?,
@@ -900,5 +938,63 @@ impl McpServer {
 impl Default for McpServer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_tools_allowlist_is_valid() {
+        // Ensure the allowlist only contains tool names that actually exist
+        // in the dispatch table (catches typos if tools are renamed).
+        let known_tools = [
+            "discover_instances",
+            "list_records",
+            "get_record",
+            "set_record",
+            "get_instance_info",
+            "query_schema",
+            "drain_record",
+            "graph_nodes",
+            "graph_edges",
+            "graph_topo_order",
+            "get_architecture",
+            "propose_add_record",
+            "propose_modify_buffer",
+            "propose_add_connector",
+            "propose_modify_fields",
+            "propose_modify_key_variants",
+            "propose_add_task",
+            "propose_add_binary",
+            "resolve_proposal",
+            "remove_record",
+            "rename_record",
+            "remove_task",
+            "remove_binary",
+            "validate_against_instance",
+            "get_buffer_metrics",
+            "save_memory",
+            "reset_session",
+        ];
+        for tool in PUBLIC_TOOLS {
+            assert!(
+                known_tools.contains(tool),
+                "PUBLIC_TOOLS contains unknown tool: {tool}"
+            );
+        }
+    }
+
+    #[test]
+    fn public_mode_defaults_to_off() {
+        let server = McpServer::new();
+        assert!(!server.is_public());
+    }
+
+    #[test]
+    fn public_mode_can_be_enabled() {
+        let server = McpServer::new().with_public_mode(true);
+        assert!(server.is_public());
     }
 }

--- a/tools/aimdb-mcp/src/tools/mod.rs
+++ b/tools/aimdb-mcp/src/tools/mod.rs
@@ -14,9 +14,17 @@ pub mod schema;
 // Global connection pool (initialized once)
 static CONNECTION_POOL: OnceCell<ConnectionPool> = OnceCell::new();
 
+// Default socket path set by --socket at startup (takes precedence over AIMDB_SOCKET env var)
+static DEFAULT_SOCKET: OnceCell<String> = OnceCell::new();
+
 /// Initialize the connection pool for tools
 pub fn init_connection_pool(pool: ConnectionPool) {
     CONNECTION_POOL.set(pool).ok();
+}
+
+/// Set the default socket path (called once at startup from --socket flag).
+pub fn set_default_socket(path: String) {
+    DEFAULT_SOCKET.set(path).ok();
 }
 
 /// Get the connection pool
@@ -24,16 +32,18 @@ pub(crate) fn connection_pool() -> Option<&'static ConnectionPool> {
     CONNECTION_POOL.get()
 }
 
-/// Resolve the socket path from an explicit argument or the `AIMDB_SOCKET` env var.
+/// Resolve the socket path from an explicit argument, the `--socket` flag, or
+/// the `AIMDB_SOCKET` env var (checked in that order).
 ///
-/// Returns an error if neither is set.
+/// Returns an error if none are set.
 pub(crate) fn resolve_socket_path(explicit: Option<String>) -> crate::error::McpResult<String> {
     explicit
+        .or_else(|| DEFAULT_SOCKET.get().cloned())
         .or_else(|| std::env::var("AIMDB_SOCKET").ok())
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             crate::error::McpError::InvalidParams(
-                "Missing socket_path (pass it explicitly or set AIMDB_SOCKET env var)".into(),
+                "Missing socket_path (pass it explicitly, use --socket, or set AIMDB_SOCKET env var)".into(),
             )
         })
 }


### PR DESCRIPTION
### Added

- **MCP public mode**: New `--public` flag restricts the MCP server to read-only tools for safe internet-facing deployments with SSRF protection ([tools/aimdb-mcp](tools/aimdb-mcp/CHANGELOG.md))
- **MCP `--socket` flag**: Default socket path can be set at startup, simplifying single-instance workflows ([tools/aimdb-mcp](tools/aimdb-mcp/CHANGELOG.md))

### Changed

- **`rand` 0.8 → 0.10.1**: Upgraded across workspace (`aimdb-data-contracts`, `aimdb-embassy-adapter`, examples). Migrated API: `gen` → `random`, `SmallRng` seed size 16 → 32, added `RngExt` imports.
- **README**: Reordered quickstart — remote MCP exploration (zero install) is now step 2, local Docker setup moved to step 3.