### PR TITLE
feat(core): wire .transform() and .transform_join() into stage profiling

### DIFF
--- a/aimdb-core/src/profiling/info.rs
+++ b/aimdb-core/src/profiling/info.rs
@@ -56,6 +56,7 @@ impl RecordProfilingMetrics {
             ("source", self.sources()),
             ("tap", self.taps()),
             ("link", self.links()),
+            ("transform", self.transforms()),
         ] {
             for (i, entry) in stages.iter().enumerate() {
                 out.push(StageProfilingInfo::from_entry(kind, i, entry));

--- a/aimdb-core/src/profiling/record_profiling.rs
+++ b/aimdb-core/src/profiling/record_profiling.rs
@@ -32,8 +32,6 @@ pub struct RecordProfilingMetrics {
     sources: Vec<StageEntry>,
     taps: Vec<StageEntry>,
     links: Vec<StageEntry>,
-    /// Reserved for `.transform()` instrumentation (not yet wired).
-    #[allow(dead_code)]
     transforms: Vec<StageEntry>,
 }
 
@@ -66,6 +64,10 @@ impl RecordProfilingMetrics {
         Self::push(&mut self.links)
     }
 
+    pub fn push_transform(&mut self) -> (usize, Arc<StageMetrics>) {
+        Self::push(&mut self.transforms)
+    }
+
     fn push(vec: &mut Vec<StageEntry>) -> (usize, Arc<StageMetrics>) {
         let idx = vec.len();
         let entry = StageEntry::new();
@@ -89,6 +91,11 @@ impl RecordProfilingMetrics {
         self.links.get(idx)
     }
 
+    /// The transform stage at `idx`, if registered.
+    pub fn transform(&self, idx: usize) -> Option<&StageEntry> {
+        self.transforms.get(idx)
+    }
+
     /// Number of registered tap stages.
     pub fn tap_count(&self) -> usize {
         self.taps.len()
@@ -107,6 +114,10 @@ impl RecordProfilingMetrics {
     /// All link stages, in registration order.
     pub fn links(&self) -> &[StageEntry] {
         &self.links
+    }
+
+    pub fn transforms(&self) -> &[StageEntry] {
+        &self.transforms
     }
 
     /// Assigns a name to a previously registered stage. No-op if `idx` is out of range.
@@ -173,5 +184,57 @@ mod tests {
         m.reset_all();
         assert_eq!(src.call_count(), 0);
         assert_eq!(tap.call_count(), 0);
+    }
+
+    #[test]
+    fn push_transform_records_metrics_and_reports_call_count() {
+        let mut m = RecordProfilingMetrics::new();
+        let (idx, metrics) = m.push_transform();
+        assert_eq!(idx, 0);
+        for v in [10u64, 30, 20] {
+            metrics.record(v);
+        }
+        let entry = m.transform(0).expect("transform stage registered");
+        assert_eq!(entry.metrics.call_count(), 3);
+        assert_eq!(entry.metrics.total_time_ns(), 60);
+        assert_eq!(entry.metrics.min_time_ns(), 10);
+        assert_eq!(entry.metrics.max_time_ns(), 30);
+        assert_eq!(m.transforms().len(), 1);
+    }
+
+    #[test]
+    fn set_stage_name_transform_lands_on_correct_index() {
+        let mut m = RecordProfilingMetrics::new();
+        // Interleave with other stage kinds so index namespaces don't collide.
+        let _ = m.push_source();
+        let _ = m.push_transform();
+        let _ = m.push_transform();
+        m.set_stage_name(StageKind::Transform, 1, "second_transform");
+
+        assert_eq!(m.transform(0).unwrap().name, None);
+        assert_eq!(
+            m.transform(1).unwrap().name.as_deref(),
+            Some("second_transform")
+        );
+        // Naming a transform must not leak into the source namespace.
+        assert_eq!(m.source(0).unwrap().name, None);
+    }
+
+    #[test]
+    fn adjacent_record_profiling_metrics_do_not_cross_talk() {
+        let mut a = RecordProfilingMetrics::new();
+        let mut b = RecordProfilingMetrics::new();
+        let (_, metrics_a) = a.push_transform();
+        let (_, metrics_b) = b.push_transform();
+
+        metrics_a.record(100);
+
+        assert_eq!(a.transform(0).unwrap().metrics.call_count(), 1);
+        assert_eq!(
+            b.transform(0).unwrap().metrics.call_count(),
+            0,
+            "recording on one record's transform stage must not affect another record's"
+        );
+        assert_eq!(metrics_b.call_count(), 0);
     }
 }

--- a/aimdb-core/src/transform/join.rs
+++ b/aimdb-core/src/transform/join.rs
@@ -247,7 +247,7 @@ where
         JoinPipeline {
             spawn_factory: Box::new(move |_| TransformDescriptor {
                 input_keys: input_keys_for_descriptor,
-                build_fn: Box::new(move |producer, db, output_key| {
+                build_fn: Box::new(move |producer, db, output_key, _profiling| {
                     build_join_collected(db, inputs, producer, handler, output_key)
                 }),
             }),

--- a/aimdb-core/src/transform/mod.rs
+++ b/aimdb-core/src/transform/mod.rs
@@ -22,6 +22,8 @@ pub mod single;
 // Public re-exports
 pub use single::{StatefulTransformBuilder, TransformBuilder, TransformPipeline};
 
+#[cfg(feature = "observability")]
+use crate::{profiling::Clock, StageMetrics};
 pub use join::{JoinBuilder, JoinEventRx, JoinPipeline, JoinTrigger};
 
 // ============================================================================
@@ -36,6 +38,12 @@ pub(crate) struct CollectedTransform {
     pub task_future: BoxFuture<'static, ()>,
     pub fanin_futures: Vec<BoxFuture<'static, ()>>,
 }
+
+#[cfg(feature = "observability")]
+pub(crate) type TransformProfiling = Option<(Arc<StageMetrics>, Clock)>;
+
+#[cfg(not(feature = "observability"))]
+pub(crate) type TransformProfiling = ();
 
 pub(crate) struct TransformDescriptor<T>
 where
@@ -54,6 +62,13 @@ where
     ///   longer carries a `.key()` accessor. Important when
     ///   multiple records share type `T` under different keys.
     #[allow(clippy::type_complexity)]
-    pub build_fn:
-        Box<dyn FnOnce(crate::Producer<T>, Arc<crate::AimDb>, &str) -> CollectedTransform + Send>,
+    pub build_fn: Box<
+        dyn FnOnce(
+                crate::Producer<T>,
+                Arc<crate::AimDb>,
+                &str,
+                TransformProfiling,
+            ) -> CollectedTransform
+            + Send,
+    >,
 }

--- a/aimdb-core/src/transform/single.rs
+++ b/aimdb-core/src/transform/single.rs
@@ -8,7 +8,7 @@ use alloc::{
     vec,
 };
 
-use crate::transform::{CollectedTransform, TransformDescriptor};
+use crate::transform::{CollectedTransform, TransformDescriptor, TransformProfiling};
 
 // ============================================================================
 // TransformBuilder → TransformPipeline
@@ -124,17 +124,20 @@ where
 
     TransformDescriptor {
         input_keys,
-        build_fn: Box::new(move |producer, db, output_key| CollectedTransform {
-            task_future: Box::pin(run_single_transform::<I, O, S>(
-                db,
-                input_key_clone,
-                output_key.to_string(),
-                producer,
-                initial_state,
-                transform_fn,
-            )),
-            fanin_futures: alloc::vec::Vec::new(),
-        }),
+        build_fn: Box::new(
+            move |producer, db, output_key, profiling| CollectedTransform {
+                task_future: Box::pin(run_single_transform::<I, O, S>(
+                    db,
+                    input_key_clone,
+                    output_key.to_string(),
+                    producer,
+                    initial_state,
+                    transform_fn,
+                    profiling,
+                )),
+                fanin_futures: alloc::vec::Vec::new(),
+            },
+        ),
     }
 }
 
@@ -150,6 +153,7 @@ pub(crate) async fn run_single_transform<I, O, S>(
     producer: crate::Producer<O>,
     mut state: S,
     transform_fn: impl Fn(&I, &mut S) -> Option<O> + Send + Sync + 'static,
+    profiling: TransformProfiling,
 ) where
     I: Send + Sync + Clone + Debug + 'static,
     O: Send + Sync + Clone + Debug + 'static,
@@ -183,8 +187,22 @@ pub(crate) async fn run_single_transform<I, O, S>(
     loop {
         match reader.recv().await {
             Ok(input_value) => {
-                if let Some(output_value) = transform_fn(&input_value, &mut state) {
-                    producer.produce(output_value);
+                #[cfg(feature = "observability")]
+                {
+                    let started_ns = profiling.as_ref().map(|(_, clock)| clock());
+                    let output_value = transform_fn(&input_value, &mut state);
+                    if let (Some((metrics, clock)), Some(started_ns)) = (&profiling, started_ns) {
+                        metrics.record(clock().saturating_sub(started_ns));
+                    }
+                    if let Some(output_value) = output_value {
+                        producer.produce(output_value);
+                    }
+                }
+                #[cfg(not(feature = "observability"))]
+                {
+                    if let Some(output_value) = transform_fn(&input_value, &mut state) {
+                        producer.produce(output_value);
+                    }
                 }
             }
             Err(crate::DbError::BufferLagged { .. }) => {

--- a/aimdb-core/src/typed_api.rs
+++ b/aimdb-core/src/typed_api.rs
@@ -560,9 +560,15 @@ where
         let pipeline = build_fn(builder);
         let descriptor = pipeline.into_descriptor();
         self.rec.set_transform(descriptor);
-        // Transform stages are not yet instrumented; track the kind so `.with_name()`
-        // remains coherent (it currently has nowhere to store the name).
-        self.last_stage = Some((StageKind::Transform, 0));
+        #[cfg(feature = "observability")]
+        {
+            let (idx, _) = self.rec.profiling_mut().push_transform();
+            self.last_stage = Some((StageKind::Transform, idx));
+        }
+        #[cfg(not(feature = "observability"))]
+        {
+            self.last_stage = Some((StageKind::Transform, 0));
+        }
         self
     }
 
@@ -579,7 +585,15 @@ where
         let pipeline = build_fn(builder);
         let descriptor = pipeline.into_descriptor();
         self.rec.set_transform(descriptor);
-        self.last_stage = Some((StageKind::Transform, 0));
+        #[cfg(feature = "observability")]
+        {
+            let (idx, _) = self.rec.profiling_mut().push_transform();
+            self.last_stage = Some((StageKind::Transform, idx));
+        }
+        #[cfg(not(feature = "observability"))]
+        {
+            self.last_stage = Some((StageKind::Transform, 0));
+        }
         self
     }
 
@@ -1250,12 +1264,12 @@ mod tests {
     fn dummy_transform_descriptor() -> crate::transform::TransformDescriptor<TestRecord> {
         crate::transform::TransformDescriptor::<TestRecord> {
             input_keys: vec![],
-            build_fn: Box::new(
-                |_p, _db, _output_key| crate::transform::CollectedTransform {
+            build_fn: Box::new(|_p, _db, _output_key, _profiling| {
+                crate::transform::CollectedTransform {
                     task_future: Box::pin(async {}),
                     fanin_futures: vec![],
-                },
-            ),
+                }
+            }),
         }
     }
 

--- a/aimdb-core/src/typed_record.rs
+++ b/aimdb-core/src/typed_record.rs
@@ -714,9 +714,33 @@ impl<T: Send + 'static + Debug + Clone> TypedRecord<T> {
             );
 
             // Create Producer<T> bound to a pre-resolved write handle for this record.
-            let producer = crate::typed_api::Producer::new(self.writer_handle());
+            #[allow(unused_mut)]
+            let mut producer = crate::typed_api::Producer::new(self.writer_handle());
 
-            let collected = (desc.build_fn)(producer, db.clone(), record_key);
+            #[cfg(feature = "observability")]
+            let profiling_arg = {
+                let is_single_input = desc.input_keys.len() == 1;
+
+                let profiling_entry = self.profiling.transforms().first();
+
+                if !is_single_input {
+                    // Join: producer cadence is the throughput proxy — attach it directly.
+                    if let Some(entry) = profiling_entry {
+                        producer.set_profiling(entry.metrics.clone(), db.profiling_clock().clone());
+                    }
+                }
+
+                if is_single_input {
+                    profiling_entry
+                        .map(|entry| (entry.metrics.clone(), db.profiling_clock().clone()))
+                } else {
+                    None
+                }
+            };
+            #[cfg(not(feature = "observability"))]
+            let profiling_arg: crate::transform::TransformProfiling = ();
+
+            let collected = (desc.build_fn)(producer, db.clone(), record_key, profiling_arg);
 
             let mut out = Vec::with_capacity(1 + collected.fanin_futures.len());
             out.push(collected.task_future);

--- a/aimdb-tokio-adapter/tests/stage_profiling.rs
+++ b/aimdb-tokio-adapter/tests/stage_profiling.rs
@@ -95,6 +95,96 @@ async fn source_and_tap_stages_are_timed_and_named() {
     assert_eq!(prof.tap(0).unwrap().metrics.call_count(), 0);
 }
 
+#[derive(Debug, Clone)]
+struct Doubled {
+    value: u64,
+}
+
+const DOUBLED_KEY: &str = "profiling::Doubled";
+
+/// Registers a single-input `.transform()` alongside a fast `.tap()` on the
+/// derived record, and checks that the transform closure itself is timed
+/// (not the producer cadence — see `run_single_transform`) and that its
+/// average is correctly identified as the slower of the two stages.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn transform_stage_is_timed_and_is_the_bottleneck() {
+    let adapter = Arc::new(TokioAdapter);
+    let mut builder = AimDbBuilder::new().runtime(adapter);
+
+    builder.configure::<Reading>(KEY, |reg| {
+        reg.buffer(BufferCfg::SpmcRing { capacity: 32 })
+            .source(|ctx, producer| async move {
+                let mut n = 0u64;
+                loop {
+                    producer.produce(Reading { value: n });
+                    n += 1;
+                    ctx.time().sleep_millis(5).await;
+                }
+            })
+            .with_name("fast_source");
+    });
+
+    builder.configure::<Doubled>(DOUBLED_KEY, |reg| {
+        reg.buffer(BufferCfg::SpmcRing { capacity: 32 })
+            .transform::<Reading, _>(KEY, |b| {
+                b.map(|input: &Reading| {
+                    // Simulate expensive per-value work (wall-clock, synchronous —
+                    // the transform closure has no `.await` point).
+                    std::thread::sleep(Duration::from_millis(15));
+                    Some(Doubled {
+                        value: input.value * 2,
+                    })
+                })
+            })
+            .with_name("slow_doubler")
+            .tap(|_ctx, consumer| async move {
+                let mut reader = consumer.subscribe();
+                while let Ok(doubled) = reader.recv().await {
+                    let _ = doubled.value;
+                }
+            })
+            .with_name("quick_consumer");
+    });
+
+    let (db, runner) = builder.build().await.expect("build");
+    tokio::spawn(runner.run());
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let rec = db
+        .inner()
+        .get_typed_record_by_key::<Doubled>(DOUBLED_KEY)
+        .expect("typed record");
+    let prof = rec.profiling();
+
+    // This record is derived via `.transform()`, not `.source()`.
+    assert!(prof.source(0).is_none());
+
+    let transform = prof.transform(0).expect("transform stage registered");
+    assert_eq!(transform.name.as_deref(), Some("slow_doubler"));
+    let tm = &transform.metrics;
+    assert!(
+        tm.call_count() >= 1,
+        "expected at least one transform invocation recorded, got {}",
+        tm.call_count()
+    );
+    assert!(tm.min_time_ns() <= tm.avg_time_ns());
+    assert!(tm.avg_time_ns() <= tm.max_time_ns());
+
+    let tap = prof.tap(0).expect("tap stage registered");
+    assert_eq!(tap.name.as_deref(), Some("quick_consumer"));
+
+    // The transform closure sleeps ~15ms per call; the tap is a no-op drain
+    // loop. It must be reported as the slowest (bottleneck) stage on this
+    // record.
+    assert!(
+        tm.avg_time_ns() > tap.metrics.avg_time_ns(),
+        "expected transform (slow) avg {} ns > tap (fast) avg {} ns",
+        tm.avg_time_ns(),
+        tap.metrics.avg_time_ns()
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn with_name_is_a_no_op_friendly_builder() {
     // `.with_name()` must always be chainable even on a stage that is never run.

--- a/docs/design/014-M6-stage-profiling.md
+++ b/docs/design/014-M6-stage-profiling.md
@@ -23,6 +23,25 @@
 - `RecordRegistrar::with_name("...")` is always available (no-op without the
   feature). MCP tools: `get_stage_profiling` (incl. bottleneck detection) and
   `reset_stage_profiling`.
+- **Transform stages** (issue #109) split into two timing strategies sharing one
+  `transforms` bucket on `RecordProfilingMetrics`, rather than reusing the
+  source/tap interval trick uniformly:
+  - Single-input `.transform()`: AimDB owns the call boundary directly (unlike
+    `.source()`/`.tap()`, whose callbacks loop internally), so the transform
+    closure itself is timed — wrapped with the runtime clock immediately
+    before/after `transform_fn(&input, &mut state)` inside
+    `run_single_transform`, recording on both `Some(output)` and `None` (a
+    `None` still consumed an input). This is "time per input value processed."
+  - `.transform_join()`: the Design 027 task-model handler owns its own event
+    loop, so per-trigger timing would mean intruding into user code. Instead it
+    reuses the `.source()` producer-cadence trick — `collect_transform_futures`
+    attaches `ProducerProfilingState` to the join's output `Producer<T>`,
+    timing the interval between successive `produce()` calls as a throughput
+    proxy ("average time between successive join outputs").
+  - The rejected alternative was using producer-cadence for single-input
+    transforms too (simpler/unified) — rejected because it conflates closure
+    time with input-wait time, giving a misleading number for the actual
+    bottleneck.
 
 ---
 

--- a/examples/remote-access-demo/README.md
+++ b/examples/remote-access-demo/README.md
@@ -5,10 +5,11 @@ This example demonstrates the AimX v1 remote access protocol with `record.list` 
 ## What It Does
 
 **Server** (`server.rs`):
-- Creates an AimDB instance with 5 record types (Temperature, SystemStatus, UserEvent, Config, AppSettings)
+- Creates an AimDB instance with 6 record types (Temperature, TemperatureFahrenheit, SystemStatus, UserEvent, Config, AppSettings)
 - Enables remote access on Unix domain socket `/tmp/aimdb-demo.sock`
 - Uses ReadWrite security policy (`server::AppSettings` is the only writable key)
 - Drives `Temperature` and `SystemStatus` from in-AimDB `.source()` tasks with named `.tap()` consumers, so the `profiling` feature can time every stage automatically (see [Stage Profiling](#stage-profiling) below)
+- Derives `TemperatureFahrenheit` from `Temperature` via `.transform()`, so the `profiling` feature also times single-input transform stages
 
 **Client** (`client.rs`):
 - Connects to the server via Unix domain socket
@@ -99,12 +100,29 @@ named via `.with_name("...")`:
 | Temperature    | `temp_simulator`     | `temp_logger` (fast)                         |
 | SystemStatus   | `status_simulator`   | `slow_status_processor` (sleeps 100 ms each) |
 
+`TemperatureFahrenheit` is derived from `Temperature` via `.transform()` instead —
+it has no `.source()` of its own:
+
+| Record                 | Transform stage        |
+|------------------------|-------------------------|
+| TemperatureFahrenheit  | `celsius_to_fahrenheit` |
+
+`.source()`/`.tap()` stages are timed as the wall-clock interval *between* calls
+(the actual callback loops internally, so AimDB times the gap between
+`produce()`/`recv()` calls). A single-input `.transform()` stage is timed
+differently: AimDB owns the call boundary directly, so it wraps the transform
+closure itself — `celsius_to_fahrenheit`'s `avg_time_ns` is the per-call cost of
+converting one `Temperature` into one `TemperatureFahrenheit`, not the gap
+between conversions.
+
 Once the server has been running for a few seconds, query stage profiling via the
 `aimdb-mcp` server using the `get_stage_profiling` tool with `record_key="SystemStatus"`.
 The result is a list of `{call_count, avg_time_ns, min_time_ns, max_time_ns, name, ...}`
 entries plus a `bottleneck` field — for SystemStatus the bottleneck will point at
-`slow_status_processor` with an average around 100 ms. Reset the counters between
-windows with the `reset_stage_profiling` tool.
+`slow_status_processor` with an average around 100 ms. Query
+`record_key="TemperatureFahrenheit"` to see the `celsius_to_fahrenheit` transform
+stage reported the same way, with `stage_type: "transform"`. Reset the counters
+between windows with the `reset_stage_profiling` tool.
 
 You can also call the raw RPC method directly:
 

--- a/examples/remote-access-demo/src/server.rs
+++ b/examples/remote-access-demo/src/server.rs
@@ -28,6 +28,16 @@ struct Temperature {
     timestamp: f64, // Unix timestamp as f64 (seconds since epoch with fractional nanoseconds, e.g., 1730379296.123456789)
 }
 
+/// Temperature reading converted to Fahrenheit — derived from `Temperature` via
+/// `.transform()`, demonstrating that single-input transform stages are timed
+/// automatically too (see [Stage Profiling](../README.md#stage-profiling)).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TemperatureFahrenheit {
+    sensor_id: String,
+    fahrenheit: f64,
+    timestamp: f64,
+}
+
 /// System status information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SystemStatus {
@@ -115,6 +125,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_name("temp_logger");
     });
 
+    // TemperatureFahrenheit is derived from Temperature via `.transform()` — no
+    // `.source()` of its own. `.transform()` stages are timed per-call (the
+    // transform closure itself), unlike `.source()`/`.tap()` which time the
+    // interval between calls — see `get_stage_profiling`.
+    builder.configure::<TemperatureFahrenheit>("server::TemperatureFahrenheit", |reg| {
+        reg.buffer(BufferCfg::SpmcRing { capacity: 100 })
+            .with_remote_access()
+            .transform::<Temperature, _>("server::Temperature", |b| {
+                b.map(|t: &Temperature| {
+                    Some(TemperatureFahrenheit {
+                        sensor_id: t.sensor_id.clone(),
+                        fahrenheit: t.celsius * 9.0 / 5.0 + 32.0,
+                        timestamp: t.timestamp,
+                    })
+                })
+            })
+            .with_name("celsius_to_fahrenheit");
+    });
+
     builder.configure::<SystemStatus>("server::SystemStatus", |reg| {
         reg.buffer(BufferCfg::SpmcRing { capacity: 50 })
             .with_remote_access()
@@ -142,8 +171,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (db, runner) = builder.build().await?;
     tokio::spawn(runner.run());
 
-    info!("✅ Database initialized with 5 record types");
+    info!("✅ Database initialized with 6 record types");
     info!("   - Temperature (SpmcRing×100, has producer — drainable 🔄)");
+    info!("   - TemperatureFahrenheit (SpmcRing×100, derived via .transform())");
     info!("   - SystemStatus (SpmcRing×50, has producer — drainable 🔄)");
     info!("   - UserEvent (SpmcRing×100, no data)");
     info!("   - Config (SingleLatest, has producer, NOT writable)");
@@ -188,8 +218,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("   SystemStatus: every 5 seconds");
     info!("");
     info!("📈 Stage profiling is enabled. Query it via the aimdb-mcp tools:");
-    info!("   get_stage_profiling   record_key=\"Temperature\"   → per-stage timing");
-    info!("   reset_stage_profiling                              → clear counters");
+    info!("   get_stage_profiling   record_key=\"Temperature\"           → per-stage timing");
+    info!("   get_stage_profiling   record_key=\"TemperatureFahrenheit\" → transform stage timing");
+    info!("   reset_stage_profiling                                      → clear counters");
     info!("");
     info!("📊 Buffer metrics are enabled. Query via the aimdb-mcp tools:");
     info!("   get_buffer_metrics    record_key=\"SystemStatus\"  → produced/consumed/dropped");


### PR DESCRIPTION
## Description
Single-input transforms time the closure itself (Some and None both recorded); joins reuse the .source() producer-cadence trick since they own their own event loop. Both share one "transform" stage bucket so snapshot()/.with_name() work uniformly. Adds unit + integration tests, a transform-derived record in theremote-access-demo example, and updates the 014-M6 RFC notes.

## Related Issue
- Closes #109 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (`make check`).
- [x] I have updated the documentation accordingly.
