### PR TITLE
feat(tcp-connector): add AimX TCP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ version = "0.6.0"
 dependencies = [
  "aimdb-core",
  "aimdb-serial-connector",
+ "aimdb-tcp-connector",
  "aimdb-tokio-adapter",
  "aimdb-uds-connector",
  "anyhow",
@@ -287,6 +288,23 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "aimdb-tcp-connector"
+version = "0.1.0"
+dependencies = [
+ "aimdb-core",
+ "aimdb-embassy-adapter",
+ "aimdb-tokio-adapter",
+ "defmt 1.0.1",
+ "embassy-net",
+ "embedded-io-async 0.7.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "aimdb-websocket-connector",
     "aimdb-uds-connector",
     "aimdb-serial-connector",
+    "aimdb-tcp-connector",
     "aimdb-ws-protocol",
     "aimdb-wasm-adapter",
     "tools/aimdb-cli",

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,8 @@ build:
 	cargo build --package aimdb-uds-connector
 	@printf "$(YELLOW)  → Building serial connector (tokio)$(NC)\n"
 	cargo build --package aimdb-serial-connector --no-default-features --features "tokio-runtime"
+	@printf "$(YELLOW)  → Building TCP connector (tokio)$(NC)\n"
+	cargo build --package aimdb-tcp-connector --no-default-features --features "tokio-runtime"
 	@printf "$(YELLOW)  → Building WASM adapter$(NC)\n"
 	cargo build --package aimdb-wasm-adapter --target wasm32-unknown-unknown --features "wasm-runtime"
 	@printf "$(YELLOW)  → Building benchmarking infrastructure (host-only, incl. benches)$(NC)\n"
@@ -133,6 +135,8 @@ test:
 	cargo test --package aimdb-client
 	@printf "$(YELLOW)  → Testing aimdb-client (endpoint resolver, serial transport arm)$(NC)\n"
 	cargo test --package aimdb-client --no-default-features --features "transport-serial"
+	@printf "$(YELLOW)  → Testing aimdb-client (endpoint resolver, TCP transport arm)$(NC)\n"
+	cargo test --package aimdb-client --no-default-features --features "transport-tcp"
 	@printf "$(YELLOW)  → Testing tokio adapter$(NC)\n"
 	cargo test --package aimdb-tokio-adapter --features "tokio-runtime,tracing"
 	@printf "$(YELLOW)  → Testing tokio adapter (with observability)$(NC)\n"
@@ -169,10 +173,12 @@ test:
 	cargo test --package aimdb-serial-connector --no-default-features --features "_test-tokio"
 	@printf "$(YELLOW)  → Testing serial connector (embassy: COBS framing + client-engine smoke on the EmbassyAdapter clock)$(NC)\n"
 	cargo test --package aimdb-serial-connector --no-default-features --features "embassy-runtime"
+	@printf "$(YELLOW)  → Testing TCP connector (tokio: length-prefix framing + AimX loopback)$(NC)\n"
+	cargo test --package aimdb-tcp-connector --no-default-features --features "_test-tokio"
 
 fmt:
 	@printf "$(GREEN)Formatting code (workspace members only)...$(NC)\n"
-	@for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest-async aimdb-bench; do \
+	@for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest-async aimdb-bench; do \
 		printf "$(YELLOW)  → Formatting $$pkg$(NC)\n"; \
 		cargo fmt -p $$pkg 2>/dev/null || true; \
 	done
@@ -181,7 +187,7 @@ fmt:
 fmt-check:
 	@printf "$(GREEN)Checking code formatting (workspace members only)...$(NC)\n"
 	@FAILED=0; \
-	for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest-async aimdb-bench; do \
+	for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest-async aimdb-bench; do \
 		printf "$(YELLOW)  → Checking $$pkg$(NC)\n"; \
 		if ! cargo fmt -p $$pkg -- --check 2>&1; then \
 			printf "$(RED)❌ Formatting check failed for $$pkg$(NC)\n"; \
@@ -222,12 +228,16 @@ clippy:
 	cargo clippy --package aimdb-client --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on client library (serial transport arm)$(NC)\n"
 	cargo clippy --package aimdb-client --no-default-features --features "transport-serial" --all-targets -- -D warnings
+	@printf "$(YELLOW)  → Clippy on client library (TCP transport arm)$(NC)\n"
+	cargo clippy --package aimdb-client --no-default-features --features "transport-tcp" --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on codegen library$(NC)\n"
 	cargo clippy --package aimdb-codegen --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on CLI tools$(NC)\n"
 	cargo clippy --package aimdb-cli --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on CLI tools (serial transport)$(NC)\n"
 	cargo clippy --package aimdb-cli --features "transport-serial" --all-targets -- -D warnings
+	@printf "$(YELLOW)  → Clippy on CLI tools (TCP transport)$(NC)\n"
+	cargo clippy --package aimdb-cli --features "transport-tcp" --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on MCP server$(NC)\n"
 	cargo clippy --package aimdb-mcp --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on MCP server (serial transport)$(NC)\n"
@@ -256,6 +266,12 @@ clippy:
 	cargo clippy --package aimdb-serial-connector --target thumbv7em-none-eabihf --no-default-features --features "embassy-runtime" -- -D warnings
 	@printf "$(YELLOW)  → Clippy on serial connector (embassy + defmt)$(NC)\n"
 	cargo clippy --package aimdb-serial-connector --target thumbv7em-none-eabihf --no-default-features --features "embassy-runtime,defmt" -- -D warnings
+	@printf "$(YELLOW)  → Clippy on TCP connector (tokio)$(NC)\n"
+	cargo clippy --package aimdb-tcp-connector --no-default-features --features "_test-tokio" --all-targets -- -D warnings
+	@printf "$(YELLOW)  → Clippy on TCP connector (embassy)$(NC)\n"
+	cargo clippy --package aimdb-tcp-connector --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features "embassy-runtime" -- -D warnings
+	@printf "$(YELLOW)  → Clippy on TCP connector (embassy + defmt)$(NC)\n"
+	cargo clippy --package aimdb-tcp-connector --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features "embassy-runtime,defmt" -- -D warnings
 	@printf "$(YELLOW)  → Clippy on WASM adapter$(NC)\n"
 	cargo clippy --package aimdb-wasm-adapter --target wasm32-unknown-unknown --features "wasm-runtime" -- -D warnings
 	@printf "$(YELLOW)  → Clippy on benchmarking infrastructure (host-only, incl. benches)$(NC)\n"
@@ -348,6 +364,10 @@ test-embedded:
 	cargo check --package aimdb-serial-connector --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features "embassy-runtime"
 	@printf "$(YELLOW)  → Checking aimdb-serial-connector (Embassy + defmt) on thumbv7em-none-eabihf target$(NC)\n"
 	cargo check --package aimdb-serial-connector --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features "embassy-runtime,defmt"
+	@printf "$(YELLOW)  → Checking aimdb-tcp-connector (Embassy TCP client) on thumbv7em-none-eabihf target$(NC)\n"
+	cargo check --package aimdb-tcp-connector --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features "embassy-runtime"
+	@printf "$(YELLOW)  → Checking aimdb-tcp-connector (Embassy TCP client + defmt) on thumbv7em-none-eabihf target$(NC)\n"
+	cargo check --package aimdb-tcp-connector --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features "embassy-runtime,defmt"
 
 ## Example projects
 examples:

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ See the [MCP server docs](tools/aimdb-mcp/) for Claude Desktop and other editors
 | **MQTT** — `aimdb-mqtt-connector` | ✅ Ready | std, no_std |
 | **KNX** — `aimdb-knx-connector` | ✅ Ready | std, no_std |
 | **WebSocket** — `aimdb-websocket-connector` | ✅ Ready | std, wasm |
+| **TCP** — `aimdb-tcp-connector` | ✅ Ready | std, no_std client |
 | **Kafka** | 📋 Planned | std |
 | **Modbus** | 📋 Planned | std, no_std |
 

--- a/aimdb-client/Cargo.toml
+++ b/aimdb-client/Cargo.toml
@@ -18,6 +18,7 @@ observability = ["aimdb-core/observability"]
 # compiled in is rejected at resolve time.
 transport-uds = ["dep:aimdb-uds-connector"]
 transport-serial = ["dep:aimdb-serial-connector"]
+transport-tcp = ["dep:aimdb-tcp-connector"]
 
 [dependencies]
 # Core dependencies - protocol types from aimdb-core. `connector-session`
@@ -32,6 +33,9 @@ aimdb-core = { version = "1.1.0", path = "../aimdb-core", features = [
 # behind its `transport-*` feature so a binary links only what it needs.
 aimdb-uds-connector = { version = "0.1.0", path = "../aimdb-uds-connector", optional = true }
 aimdb-serial-connector = { version = "0.1.0", path = "../aimdb-serial-connector", default-features = false, features = [
+    "tokio-runtime",
+], optional = true }
+aimdb-tcp-connector = { version = "0.1.0", path = "../aimdb-tcp-connector", default-features = false, features = [
     "tokio-runtime",
 ], optional = true }
 

--- a/aimdb-client/README.md
+++ b/aimdb-client/README.md
@@ -8,7 +8,8 @@ Internal client library for the AimX remote access protocol (v2 NDJSON wire).
 implementation for the AimX remote access protocol. It enables programmatic
 connections to running AimDB instances over a transport picked at runtime via
 a `scheme://` endpoint URL — Unix domain sockets (`unix://PATH` / `uds://PATH`,
-or a bare path) and serial (`serial://DEVICE?baud=N`).
+or a bare path), serial (`serial://DEVICE?baud=N`), and TCP
+(`tcp://HOST:PORT`, behind the `transport-tcp` feature).
 
 **This library is used by:**
 - `tools/aimdb-cli` - Command-line interface for AimDB
@@ -70,6 +71,9 @@ See these tools for real-world usage patterns.
 ```bash
 # Run tests
 cargo test -p aimdb-client
+
+# Run TCP endpoint resolver tests
+cargo test -p aimdb-client --no-default-features --features transport-tcp
 
 # Start test server
 cargo run --example remote-access-demo

--- a/aimdb-client/src/endpoint.rs
+++ b/aimdb-client/src/endpoint.rs
@@ -5,15 +5,13 @@
 //! Two layers, deliberately split so the grammar is testable without any
 //! transport compiled in:
 //! - [`parse_endpoint`] — **pure, feature-independent**. Recognizes the scheme
-//!   grammar (`unix://` / `uds://` / `serial://`, plus a bare path as `unix://`
-//!   shorthand) into a [`ParsedEndpoint`]. An unknown scheme is rejected here.
+//!   grammar (`unix://` / `uds://` / `serial://` / `tcp://host:port`, plus a
+//!   bare path as `unix://` shorthand) into a [`ParsedEndpoint`]. An unknown
+//!   scheme is rejected here.
 //! - [`dial`] — builds the concrete [`Dialer`] for a parsed endpoint, under the
 //!   matching `transport-*` feature. A scheme whose transport isn't compiled into
 //!   this binary is rejected here (distinct from "unknown scheme").
 //!
-//! TCP is intentionally absent for now (tracked separately); adding it is a new
-//! [`Scheme`] arm plus a `dial` branch.
-
 use aimdb_core::session::Dialer;
 
 use crate::error::{ClientError, ClientResult};
@@ -23,7 +21,7 @@ pub const DEFAULT_SERIAL_BAUD: u32 = 115_200;
 
 /// Schemes the resolver's *grammar* understands, independent of which transports
 /// are compiled in. Used to phrase the "unknown scheme" error.
-const KNOWN_SCHEMES: &[&str] = &["unix", "uds", "serial"];
+const KNOWN_SCHEMES: &[&str] = &["unix", "uds", "serial", "tcp"];
 
 /// The transport family an endpoint names. Always compiled (it is grammar, not a
 /// capability) — whether a given variant can actually be dialed depends on the
@@ -34,6 +32,8 @@ pub enum Scheme {
     Unix,
     /// A serial/UART device (`serial://`).
     Serial,
+    /// A TCP endpoint (`tcp://host:port`).
+    Tcp,
 }
 
 /// A parsed endpoint: the transport family plus its target and any transport
@@ -42,7 +42,7 @@ pub enum Scheme {
 pub struct ParsedEndpoint {
     /// Which transport family this endpoint names.
     pub scheme: Scheme,
-    /// The transport target — a socket path (`Unix`) or device path (`Serial`).
+    /// The transport target — a socket path, serial device path, or host:port.
     pub target: String,
     /// Serial baud from `?baud=N`, if given (`Serial` only; [`dial`] defaults it
     /// to [`DEFAULT_SERIAL_BAUD`]).
@@ -54,7 +54,8 @@ pub struct ParsedEndpoint {
 /// - `unix://PATH` / `uds://PATH` → [`Scheme::Unix`].
 /// - a bare path (no `scheme://`) → [`Scheme::Unix`] (the shorthand).
 /// - `serial://PATH` (optionally `?baud=N`) → [`Scheme::Serial`].
-/// - anything else (e.g. `tcp://…`) → [`ClientError::UnsupportedEndpoint`].
+/// - `tcp://HOST:PORT` → [`Scheme::Tcp`].
+/// - anything else → [`ClientError::UnsupportedEndpoint`].
 pub fn parse_endpoint(endpoint: &str) -> ClientResult<ParsedEndpoint> {
     let endpoint = endpoint.trim();
     if endpoint.is_empty() {
@@ -89,6 +90,14 @@ pub fn parse_endpoint(endpoint: &str) -> ClientResult<ParsedEndpoint> {
                 scheme: Scheme::Serial,
                 target: path.to_string(),
                 baud,
+            })
+        }
+        "tcp" => {
+            require_tcp_target(endpoint, rest)?;
+            Ok(ParsedEndpoint {
+                scheme: Scheme::Tcp,
+                target: rest.to_string(),
+                baud: None,
             })
         }
         other => Err(ClientError::unsupported_endpoint(
@@ -132,6 +141,16 @@ pub fn dial(endpoint: &str) -> ClientResult<Box<dyn Dialer>> {
                 Err(not_built_in(endpoint, "serial", "transport-serial"))
             }
         }
+        Scheme::Tcp => {
+            #[cfg(feature = "transport-tcp")]
+            {
+                Ok(Box::new(aimdb_tcp_connector::TcpDialer::new(parsed.target)))
+            }
+            #[cfg(not(feature = "transport-tcp"))]
+            {
+                Err(not_built_in(endpoint, "tcp", "transport-tcp"))
+            }
+        }
     }
 }
 
@@ -145,6 +164,34 @@ fn require_nonempty(endpoint: &str, target: &str) -> ClientResult<()> {
     } else {
         Ok(())
     }
+}
+
+/// Validate `tcp://host:port`.
+fn require_tcp_target(endpoint: &str, target: &str) -> ClientResult<()> {
+    require_nonempty(endpoint, target)?;
+
+    let Some((host, port)) = target.rsplit_once(':') else {
+        return Err(ClientError::unsupported_endpoint(
+            endpoint,
+            "missing TCP port",
+        ));
+    };
+    if host.is_empty() {
+        return Err(ClientError::unsupported_endpoint(
+            endpoint,
+            "missing TCP host",
+        ));
+    }
+    if port.is_empty() {
+        return Err(ClientError::unsupported_endpoint(
+            endpoint,
+            "missing TCP port",
+        ));
+    }
+    port.parse::<u16>().map_err(|_| {
+        ClientError::unsupported_endpoint(endpoint, format!("invalid TCP port {port:?}"))
+    })?;
+    Ok(())
 }
 
 /// Pull `baud` out of a `serial://` query string (`baud=N[&k=v…]`).
@@ -162,7 +209,11 @@ fn parse_baud(endpoint: &str, query: &str) -> ClientResult<Option<u32>> {
 }
 
 /// A recognized scheme whose transport feature isn't compiled in.
-#[cfg(any(not(feature = "transport-uds"), not(feature = "transport-serial")))]
+#[cfg(any(
+    not(feature = "transport-uds"),
+    not(feature = "transport-serial"),
+    not(feature = "transport-tcp")
+))]
 fn not_built_in(endpoint: &str, scheme: &str, feature: &str) -> ClientError {
     ClientError::unsupported_endpoint(
         endpoint,
@@ -209,12 +260,23 @@ mod tests {
     }
 
     #[test]
+    fn tcp_scheme_parses_host_and_port() {
+        let p = parse_endpoint("tcp://127.0.0.1:7001").expect("parse");
+        assert_eq!(p.scheme, Scheme::Tcp);
+        assert_eq!(p.target, "127.0.0.1:7001");
+
+        let p = parse_endpoint("tcp://localhost:7001").expect("parse");
+        assert_eq!(p.scheme, Scheme::Tcp);
+        assert_eq!(p.target, "localhost:7001");
+    }
+
+    #[test]
     fn malformed_endpoints_are_rejected() {
-        // Unknown scheme.
-        assert!(matches!(
-            parse_endpoint("tcp://host:1234"),
-            Err(ClientError::UnsupportedEndpoint { .. })
-        ));
+        // Malformed TCP.
+        assert!(parse_endpoint("tcp://").is_err());
+        assert!(parse_endpoint("tcp://host").is_err());
+        assert!(parse_endpoint("tcp://:1234").is_err());
+        assert!(parse_endpoint("tcp://host:fast").is_err());
         // Empty + empty target.
         assert!(parse_endpoint("").is_err());
         assert!(parse_endpoint("unix://").is_err());
@@ -225,7 +287,7 @@ mod tests {
     #[test]
     fn dial_rejects_unknown_scheme() {
         assert!(matches!(
-            dial("tcp://host:1234"),
+            dial("http://host:1234"),
             Err(ClientError::UnsupportedEndpoint { .. })
         ));
     }
@@ -250,5 +312,20 @@ mod tests {
     #[test]
     fn dial_builds_a_serial_dialer() {
         assert!(dial("serial:///dev/ttyACM0?baud=115200").is_ok());
+    }
+
+    #[cfg(not(feature = "transport-tcp"))]
+    #[test]
+    fn dial_rejects_tcp_when_not_built_in() {
+        assert!(matches!(
+            dial("tcp://127.0.0.1:7001"),
+            Err(ClientError::UnsupportedEndpoint { .. })
+        ));
+    }
+
+    #[cfg(feature = "transport-tcp")]
+    #[test]
+    fn dial_builds_a_tcp_dialer() {
+        assert!(dial("tcp://127.0.0.1:7001").is_ok());
     }
 }

--- a/aimdb-tcp-connector/Cargo.toml
+++ b/aimdb-tcp-connector/Cargo.toml
@@ -1,0 +1,68 @@
+[package]
+name = "aimdb-tcp-connector"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Length-prefixed TCP transport connector for AimDB remote access (AimX over TCP), tokio + Embassy"
+keywords = ["aimdb", "connector", "tcp", "remote", "embedded"]
+categories = ["network-programming", "embedded", "no-std"]
+
+[features]
+default = ["aimdb-core/alloc"]
+
+std = [
+    "aimdb-core/std",
+    "aimdb-core/alloc",
+    "aimdb-core/connector-session",
+    "aimdb-core/remote",
+    "thiserror",
+]
+
+tokio-runtime = [
+    "std",
+    "aimdb-core/connector-session",
+    "aimdb-core/remote",
+    "dep:tokio",
+]
+
+embassy-runtime = [
+    "aimdb-core/alloc",
+    "aimdb-core/connector-session",
+    "aimdb-core/remote",
+    "dep:aimdb-embassy-adapter",
+    "aimdb-embassy-adapter/connectors",
+    "aimdb-embassy-adapter/embassy-net-support",
+    "dep:embassy-net",
+    "dep:embedded-io-async",
+]
+
+tracing = ["dep:tracing", "aimdb-core/tracing"]
+defmt = ["dep:defmt", "aimdb-core/defmt"]
+
+_test-tokio = ["tokio-runtime", "dep:aimdb-tokio-adapter"]
+
+[dependencies]
+aimdb-core = { version = "1.1.0", path = "../aimdb-core", default-features = false }
+
+tokio = { workspace = true, optional = true, features = ["net", "io-util"] }
+thiserror = { workspace = true, optional = true }
+
+aimdb-embassy-adapter = { version = "0.6.0", path = "../aimdb-embassy-adapter", default-features = false, optional = true }
+embassy-net = { workspace = true, optional = true }
+embedded-io-async = { workspace = true, optional = true }
+
+aimdb-tokio-adapter = { version = "0.6.0", path = "../aimdb-tokio-adapter", optional = true }
+
+tracing = { workspace = true, optional = true }
+defmt = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "io-util", "net"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[[example]]
+name = "tcp_demo"
+required-features = ["_test-tokio"]

--- a/aimdb-tcp-connector/examples/tcp_demo.rs
+++ b/aimdb-tcp-connector/examples/tcp_demo.rs
@@ -1,0 +1,161 @@
+//! Small Tokio demo for `aimdb-tcp-connector`.
+//!
+//! Run from the workspace root:
+//!
+//! ```text
+//! # terminal 1
+//! cargo run -p aimdb-tcp-connector --example tcp_demo --features _test-tokio -- server 127.0.0.1:7001
+//!
+//! # terminal 2
+//! cargo run -p aimdb-tcp-connector --example tcp_demo --features _test-tokio -- client 127.0.0.1:7001
+//!
+//! # write a remote setting, then read it back
+//! cargo run -p aimdb-tcp-connector --example tcp_demo --features _test-tokio -- set 127.0.0.1:7001 42
+//! ```
+//!
+//! This is intentionally host-only. The first TCP PR includes Embassy client
+//! support; Embassy server/examples are follow-up work because they need an
+//! explicit socket/buffer-pool design.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aimdb_core::buffer::BufferCfg;
+use aimdb_core::remote::{AimxConfig, SecurityPolicy};
+use aimdb_core::session::aimx::AimxCodec;
+use aimdb_core::session::{run_client, ClientConfig, Payload};
+use aimdb_core::AimDbBuilder;
+use aimdb_tcp_connector::tokio_transport::{TcpDialer, TcpServer};
+use aimdb_tokio_adapter::{TokioAdapter, TokioRecordRegistrarExt};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Counter {
+    value: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Setting {
+    level: u64,
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mode = args.get(1).map(String::as_str).unwrap_or("client");
+    let endpoint = args
+        .get(2)
+        .cloned()
+        .unwrap_or_else(|| "127.0.0.1:7001".to_string());
+
+    match mode {
+        "server" => run_server(endpoint).await,
+        "client" => run_client_mode(endpoint).await,
+        "set" => {
+            let level = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(42);
+            run_set_mode(endpoint, level).await;
+        }
+        other => {
+            eprintln!("usage: tcp_demo <server|client|set> <host:port> [level]  (got '{other}')");
+            std::process::exit(2);
+        }
+    }
+}
+
+async fn run_server(bind_addr: String) {
+    println!("[server] serving AimX over tcp://{bind_addr} (Ctrl-C to stop)");
+
+    let mut policy = SecurityPolicy::read_write();
+    policy.allow_write_key("setting");
+    let config = AimxConfig::uds_default()
+        .security_policy(policy)
+        .max_connections(8)
+        .max_subs_per_connection(32);
+
+    let mut builder = AimDbBuilder::new()
+        .runtime(Arc::new(TokioAdapter))
+        .with_connector(TcpServer::new(bind_addr).with_config(config));
+    builder.configure::<Counter>("counter", |reg| {
+        reg.buffer(BufferCfg::SingleLatest).with_remote_access();
+    });
+    builder.configure::<Setting>("setting", |reg| {
+        reg.buffer(BufferCfg::SingleLatest).with_remote_access();
+    });
+
+    let (db, runner) = builder.build().await.expect("build db");
+    let db = Arc::new(db);
+    db.set_record_from_json("setting", json!({ "level": 0 }))
+        .expect("seed setting");
+
+    let producer = db.producer::<Counter>("counter").expect("producer");
+    tokio::spawn(async move {
+        let mut value = 0u64;
+        loop {
+            value += 1;
+            producer.produce(Counter { value });
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    });
+
+    runner.run().await;
+}
+
+async fn run_client_mode(endpoint: String) {
+    println!("[client] querying AimX over tcp://{endpoint}");
+    let handle = connect(endpoint);
+
+    match handle.call("record.list", Payload::from(&b"{}"[..])).await {
+        Ok(list) => println!("[client] record.list = {}", String::from_utf8_lossy(&list)),
+        Err(e) => println!("[client] record.list failed: {e:?}"),
+    }
+
+    loop {
+        let params: Payload = serde_json::to_vec(&json!({ "name": "counter" }))
+            .unwrap()
+            .into();
+        match handle.call("record.get", params).await {
+            Ok(v) => println!("[client] counter = {}", String::from_utf8_lossy(&v)),
+            Err(e) => println!("[client] record.get failed: {e:?}"),
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn run_set_mode(endpoint: String, level: u64) {
+    println!("[set] writing setting.level={level} over tcp://{endpoint}");
+    let handle = connect(endpoint);
+
+    let set_params: Payload = serde_json::to_vec(&json!({
+        "name": "setting",
+        "value": { "level": level }
+    }))
+    .unwrap()
+    .into();
+    match handle.call("record.set", set_params).await {
+        Ok(v) => println!("[set] record.set = {}", String::from_utf8_lossy(&v)),
+        Err(e) => println!("[set] record.set failed: {e:?}"),
+    }
+
+    let get_params: Payload = serde_json::to_vec(&json!({ "name": "setting" }))
+        .unwrap()
+        .into();
+    match handle.call("record.get", get_params).await {
+        Ok(v) => println!("[set] record.get = {}", String::from_utf8_lossy(&v)),
+        Err(e) => println!("[set] record.get failed: {e:?}"),
+    }
+}
+
+fn connect(endpoint: String) -> aimdb_core::session::ClientHandle {
+    let (handle, engine) = run_client(
+        TcpDialer::new(endpoint),
+        AimxCodec,
+        ClientConfig {
+            sends_hello: false,
+            ..ClientConfig::default()
+        },
+        Arc::new(TokioAdapter),
+    );
+    tokio::spawn(engine);
+    handle
+}

--- a/aimdb-tcp-connector/src/embassy_transport.rs
+++ b/aimdb-tcp-connector/src/embassy_transport.rs
@@ -1,0 +1,165 @@
+//! Embassy TCP transport (feature `embassy-runtime`).
+//!
+//! This half is client-only for the first TCP PR. `embassy-net` has no
+//! `TcpListener`; a server needs an explicit socket/buffer pool design.
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use aimdb_core::session::aimx::AimxCodec;
+use aimdb_core::session::{BoxFut, Connection, Dialer, PeerInfo, TransportError, TransportResult};
+use aimdb_embassy_adapter::connectors::{EmbassySessionClient, OneShotCell};
+use aimdb_embassy_adapter::SendFutureWrapper;
+use embassy_net::tcp::TcpSocket;
+use embassy_net::{IpEndpoint, Stack};
+use embedded_io_async::Write;
+
+use crate::framing::{encode_frame, FrameAccumulator, HEADER_LEN};
+use crate::DEFAULT_SCHEME;
+
+const READ_CHUNK: usize = 256;
+
+/// A framed AimX connection over one `embassy-net` TCP socket.
+pub struct TcpConnection {
+    socket: TcpSocket<'static>,
+    acc: FrameAccumulator,
+    peer: PeerInfo,
+}
+
+// SAFETY: single-core cooperative Embassy executor; same invariant as
+// `aimdb-embassy-adapter::connectors`.
+unsafe impl Send for TcpConnection {}
+
+impl TcpConnection {
+    /// Wrap an already-connected TCP socket.
+    pub fn new(socket: TcpSocket<'static>) -> Self {
+        Self {
+            socket,
+            acc: FrameAccumulator::new(),
+            peer: PeerInfo::default(),
+        }
+    }
+}
+
+impl Connection for TcpConnection {
+    fn recv(&mut self) -> BoxFut<'_, TransportResult<Option<Vec<u8>>>> {
+        Box::pin(SendFutureWrapper(async move {
+            loop {
+                match self.acc.next_frame() {
+                    Some(Ok(frame)) => return Ok(Some(frame)),
+                    Some(Err(_)) => return Err(TransportError::Io),
+                    None => {}
+                }
+
+                let mut chunk = [0u8; READ_CHUNK];
+                match self.socket.read(&mut chunk).await {
+                    Ok(0) => return Ok(None),
+                    Ok(n) => self.acc.push_bytes(&chunk[..n]),
+                    Err(_) => return Err(TransportError::Io),
+                }
+            }
+        }))
+    }
+
+    fn send<'a>(&'a mut self, frame: &'a [u8]) -> BoxFut<'a, TransportResult<()>> {
+        Box::pin(SendFutureWrapper(async move {
+            let capacity = HEADER_LEN
+                .checked_add(frame.len())
+                .ok_or(TransportError::Io)?;
+            let mut out = Vec::with_capacity(capacity);
+            encode_frame(frame, &mut out).map_err(|_| TransportError::Io)?;
+            write_all(&mut self.socket, &out).await?;
+            self.socket
+                .flush()
+                .await
+                .map_err(|_| TransportError::Closed)
+        }))
+    }
+
+    fn peer(&self) -> &PeerInfo {
+        &self.peer
+    }
+}
+
+async fn write_all<W>(writer: &mut W, mut bytes: &[u8]) -> TransportResult<()>
+where
+    W: Write,
+{
+    while !bytes.is_empty() {
+        let n = writer
+            .write(bytes)
+            .await
+            .map_err(|_| TransportError::Closed)?;
+        if n == 0 {
+            return Err(TransportError::Closed);
+        }
+        bytes = &bytes[n..];
+    }
+    Ok(())
+}
+
+/// A one-shot Embassy TCP dialer.
+pub struct TcpDialer {
+    stack: Stack<'static>,
+    endpoint: IpEndpoint,
+    rx_buffer: OneShotCell<&'static mut [u8]>,
+    tx_buffer: OneShotCell<&'static mut [u8]>,
+}
+
+// SAFETY: single-core cooperative Embassy executor; buffers and stack stay on
+// the same executor task set.
+unsafe impl Send for TcpDialer {}
+// SAFETY: same invariant. Interior mutability is provided by `OneShotCell`.
+unsafe impl Sync for TcpDialer {}
+
+impl TcpDialer {
+    /// Build a one-shot dialer with caller-owned socket buffers.
+    pub fn new(
+        stack: Stack<'static>,
+        endpoint: IpEndpoint,
+        rx_buffer: &'static mut [u8],
+        tx_buffer: &'static mut [u8],
+    ) -> Self {
+        Self {
+            stack,
+            endpoint,
+            rx_buffer: OneShotCell::new(rx_buffer),
+            tx_buffer: OneShotCell::new(tx_buffer),
+        }
+    }
+}
+
+impl Dialer for TcpDialer {
+    fn connect(&self) -> BoxFut<'_, TransportResult<Box<dyn Connection>>> {
+        Box::pin(SendFutureWrapper(async move {
+            let rx = self.rx_buffer.take().ok_or(TransportError::Io)?;
+            let tx = self.tx_buffer.take().ok_or(TransportError::Io)?;
+            let mut socket = TcpSocket::new(self.stack, rx, tx);
+            socket
+                .connect(self.endpoint)
+                .await
+                .map_err(|_| TransportError::Io)?;
+            Ok(Box::new(TcpConnection::new(socket)) as Box<dyn Connection>)
+        }))
+    }
+}
+
+/// Constructs an Embassy session client over TCP.
+pub struct TcpClient;
+
+impl TcpClient {
+    /// Mirror records to/from an AimX peer over TCP.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(
+        stack: Stack<'static>,
+        endpoint: IpEndpoint,
+        rx_buffer: &'static mut [u8],
+        tx_buffer: &'static mut [u8],
+    ) -> EmbassySessionClient<TcpDialer, AimxCodec> {
+        EmbassySessionClient::new(
+            TcpDialer::new(stack, endpoint, rx_buffer, tx_buffer),
+            AimxCodec,
+        )
+        .scheme(DEFAULT_SCHEME)
+    }
+}

--- a/aimdb-tcp-connector/src/framing.rs
+++ b/aimdb-tcp-connector/src/framing.rs
@@ -1,0 +1,93 @@
+//! Bounded length-prefix framing for TCP.
+//!
+//! One logical frame is:
+//!
+//! ```text
+//! u32 big-endian payload length
+//! payload bytes
+//! ```
+//!
+//! The declared length is payload bytes only. Oversized frames are fatal because
+//! length-prefix TCP has no delimiter that would let the receiver safely resync.
+
+use alloc::vec::Vec;
+
+/// Number of bytes in the fixed frame header.
+pub const HEADER_LEN: usize = 4;
+
+/// Default maximum payload size.
+pub const DEFAULT_MAX_FRAME: usize = 64 * 1024;
+
+/// Framing failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameError {
+    /// Payload length exceeded the configured maximum.
+    TooLarge,
+    /// Header plus payload length overflowed the local pointer width.
+    LengthOverflow,
+}
+
+/// Append one length-prefixed frame to `out`.
+pub fn encode_frame(frame: &[u8], out: &mut Vec<u8>) -> Result<(), FrameError> {
+    let len = u32::try_from(frame.len()).map_err(|_| FrameError::LengthOverflow)?;
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(frame);
+    Ok(())
+}
+
+/// Reassembles length-prefixed frames from arbitrary byte chunks.
+pub struct FrameAccumulator {
+    buf: Vec<u8>,
+    max_frame: usize,
+}
+
+impl Default for FrameAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FrameAccumulator {
+    /// A fresh accumulator with [`DEFAULT_MAX_FRAME`] cap.
+    pub fn new() -> Self {
+        Self::with_max_frame(DEFAULT_MAX_FRAME)
+    }
+
+    /// A fresh accumulator with a caller-provided maximum payload size.
+    pub fn with_max_frame(max_frame: usize) -> Self {
+        Self {
+            buf: Vec::new(),
+            max_frame,
+        }
+    }
+
+    /// Append newly read bytes.
+    pub fn push_bytes(&mut self, bytes: &[u8]) {
+        self.buf.extend_from_slice(bytes);
+    }
+
+    /// Pop the next complete frame, if buffered.
+    pub fn next_frame(&mut self) -> Option<Result<Vec<u8>, FrameError>> {
+        if self.buf.len() < HEADER_LEN {
+            return None;
+        }
+
+        let len = u32::from_be_bytes([self.buf[0], self.buf[1], self.buf[2], self.buf[3]]);
+        let len = len as usize;
+        if len > self.max_frame {
+            self.buf.clear();
+            return Some(Err(FrameError::TooLarge));
+        }
+
+        let Some(total) = HEADER_LEN.checked_add(len) else {
+            self.buf.clear();
+            return Some(Err(FrameError::LengthOverflow));
+        };
+        if self.buf.len() < total {
+            return None;
+        }
+
+        self.buf.drain(..HEADER_LEN);
+        Some(Ok(self.buf.drain(..len).collect()))
+    }
+}

--- a/aimdb-tcp-connector/src/lib.rs
+++ b/aimdb-tcp-connector/src/lib.rs
@@ -1,0 +1,54 @@
+//! Length-prefixed TCP transport connector for AimDB remote access.
+//!
+//! This crate contributes only the TCP transport triple plus thin
+//! [`TcpClient`]/[`TcpServer`] sugar. AimX protocol bytes still come from
+//! [`AimxCodec`](aimdb_core::session::aimx::AimxCodec), and the session engines
+//! still live in `aimdb-core`.
+//!
+//! TCP is a byte stream, so the transport frames every AimX envelope as
+//! `u32` big-endian payload length followed by the payload bytes. See
+//! [`framing`].
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+pub mod framing;
+
+#[cfg(feature = "tokio-runtime")]
+pub mod tokio_transport;
+
+#[cfg(feature = "embassy-runtime")]
+pub mod embassy_transport;
+
+/// Default connector scheme.
+///
+/// Record links such as `link_to("tcp://record")` route through this scheme.
+pub const DEFAULT_SCHEME: &str = "tcp";
+
+/// Mark each record named in the policy's writable set as writable, so
+/// `record.list` advertises the writable flag. The dispatch also enforces it.
+#[cfg(feature = "tokio-runtime")]
+pub(crate) fn apply_writable(db: &aimdb_core::AimDb, config: &aimdb_core::remote::AimxConfig) {
+    for key in config.security_policy.writable_records() {
+        if let Some(id) = db.inner().resolve_str(&key) {
+            if let Some(storage) = db.inner().storage(id) {
+                storage.set_writable_erased(true);
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "tokio-runtime", not(feature = "embassy-runtime")))]
+pub use tokio_transport::{TcpClient, TcpConnection, TcpDialer, TcpListener, TcpServer};
+
+#[cfg(all(feature = "tokio-runtime", feature = "embassy-runtime"))]
+pub use embassy_transport::{TcpClient as EmbassyTcpClient, TcpConnection as EmbassyTcpConnection};
+#[cfg(all(feature = "tokio-runtime", feature = "embassy-runtime"))]
+pub use tokio_transport::{
+    TcpClient as TokioTcpClient, TcpConnection as TokioTcpConnection, TcpDialer, TcpListener,
+    TcpServer as TokioTcpServer,
+};
+
+#[cfg(all(feature = "embassy-runtime", not(feature = "tokio-runtime")))]
+pub use embassy_transport::{TcpClient, TcpConnection};

--- a/aimdb-tcp-connector/src/tokio_transport.rs
+++ b/aimdb-tcp-connector/src/tokio_transport.rs
@@ -1,0 +1,302 @@
+//! Tokio TCP transport (feature `tokio-runtime`).
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::{TcpListener as TokioTcpListener, TcpStream};
+
+use aimdb_core::connector::ConnectorBuilder;
+use aimdb_core::remote::{AimxConfig, SecurityPolicy};
+use aimdb_core::session::aimx::{AimxCodec, AimxDispatch};
+use aimdb_core::session::{
+    BoxFut, Connection, Dialer, Dispatch, Listener, PeerInfo, SessionClientConnector,
+    SessionConfig, SessionLimits, SessionServerConnector, TransportError, TransportResult,
+};
+use aimdb_core::{AimDb, DbError, DbResult};
+
+use crate::framing::{encode_frame, FrameAccumulator, DEFAULT_MAX_FRAME, HEADER_LEN};
+use crate::DEFAULT_SCHEME;
+
+type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+type BuildFuture<'a> = Pin<Box<dyn Future<Output = DbResult<Vec<BoxFuture>>> + Send + 'a>>;
+
+const READ_CHUNK: usize = 1024;
+
+/// A framed TCP connection.
+pub struct TcpConnection<S> {
+    stream: S,
+    acc: FrameAccumulator,
+    peer: PeerInfo,
+}
+
+impl<S> TcpConnection<S> {
+    /// Wrap an already-connected async stream with default frame limits.
+    pub fn new(stream: S) -> Self {
+        Self::with_max_frame(stream, DEFAULT_MAX_FRAME)
+    }
+
+    /// Wrap an already-connected async stream with a caller-provided frame cap.
+    pub fn with_max_frame(stream: S, max_frame: usize) -> Self {
+        Self {
+            stream,
+            acc: FrameAccumulator::with_max_frame(max_frame),
+            peer: PeerInfo::default(),
+        }
+    }
+
+    fn with_peer(mut self, peer: PeerInfo) -> Self {
+        self.peer = peer;
+        self
+    }
+}
+
+impl<S> Connection for TcpConnection<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    fn recv(&mut self) -> BoxFut<'_, TransportResult<Option<Vec<u8>>>> {
+        Box::pin(async move {
+            loop {
+                match self.acc.next_frame() {
+                    Some(Ok(frame)) => return Ok(Some(frame)),
+                    Some(Err(_)) => return Err(TransportError::Io),
+                    None => {}
+                }
+
+                let mut chunk = [0u8; READ_CHUNK];
+                match self.stream.read(&mut chunk).await {
+                    Ok(0) => return Ok(None),
+                    Ok(n) => self.acc.push_bytes(&chunk[..n]),
+                    Err(_) => return Err(TransportError::Io),
+                }
+            }
+        })
+    }
+
+    fn send<'a>(&'a mut self, frame: &'a [u8]) -> BoxFut<'a, TransportResult<()>> {
+        Box::pin(async move {
+            let capacity = HEADER_LEN
+                .checked_add(frame.len())
+                .ok_or(TransportError::Io)?;
+            let mut out = Vec::with_capacity(capacity);
+            encode_frame(frame, &mut out).map_err(|_| TransportError::Io)?;
+            self.stream
+                .write_all(&out)
+                .await
+                .map_err(|_| TransportError::Closed)?;
+            self.stream
+                .flush()
+                .await
+                .map_err(|_| TransportError::Closed)
+        })
+    }
+
+    fn peer(&self) -> &PeerInfo {
+        &self.peer
+    }
+}
+
+/// The initiating side: dials a TCP endpoint on each connect.
+#[derive(Clone)]
+pub struct TcpDialer {
+    endpoint: String,
+    max_frame: usize,
+}
+
+impl TcpDialer {
+    /// Dial `endpoint`, for example `127.0.0.1:7001`.
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            max_frame: DEFAULT_MAX_FRAME,
+        }
+    }
+
+    /// Set maximum frame payload size.
+    pub fn max_frame(mut self, max_frame: usize) -> Self {
+        self.max_frame = max_frame;
+        self
+    }
+}
+
+impl Dialer for TcpDialer {
+    fn connect(&self) -> BoxFut<'_, TransportResult<Box<dyn Connection>>> {
+        Box::pin(async move {
+            let stream = TcpStream::connect(&self.endpoint)
+                .await
+                .map_err(|_| TransportError::Io)?;
+            let peer_addr = stream.peer_addr().ok().map(|a| a.to_string());
+            let mut peer = PeerInfo::default();
+            peer.peer_addr = peer_addr;
+            Ok(
+                Box::new(TcpConnection::with_max_frame(stream, self.max_frame).with_peer(peer))
+                    as Box<dyn Connection>,
+            )
+        })
+    }
+}
+
+/// The accepting side.
+pub struct TcpListener {
+    inner: TokioTcpListener,
+    max_frame: usize,
+}
+
+impl TcpListener {
+    /// Wrap an already-bound listener.
+    pub fn new(inner: TokioTcpListener) -> Self {
+        Self {
+            inner,
+            max_frame: DEFAULT_MAX_FRAME,
+        }
+    }
+
+    /// Set maximum frame payload size.
+    pub fn max_frame(mut self, max_frame: usize) -> Self {
+        self.max_frame = max_frame;
+        self
+    }
+}
+
+impl Listener for TcpListener {
+    fn accept(&mut self) -> BoxFut<'_, TransportResult<Box<dyn Connection>>> {
+        Box::pin(async move {
+            let (stream, addr) = self.inner.accept().await.map_err(|_| TransportError::Io)?;
+            let mut peer = PeerInfo::default();
+            peer.peer_addr = Some(addr.to_string());
+            Ok(
+                Box::new(TcpConnection::with_max_frame(stream, self.max_frame).with_peer(peer))
+                    as Box<dyn Connection>,
+            )
+        })
+    }
+}
+
+/// Constructs a TCP session client connector.
+pub struct TcpClient;
+
+impl TcpClient {
+    /// Mirror records to/from an AimX peer over TCP.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(endpoint: impl Into<String>) -> SessionClientConnector<TcpDialer, AimxCodec> {
+        SessionClientConnector::new(TcpDialer::new(endpoint), AimxCodec).scheme(DEFAULT_SCHEME)
+    }
+}
+
+/// Accepts AimX connections over TCP.
+pub struct TcpServer {
+    bind_addr: String,
+    config: AimxConfig,
+    scheme: String,
+    max_frame: usize,
+}
+
+impl TcpServer {
+    /// Serve AimX on `bind_addr`.
+    ///
+    /// Prefer loopback addresses such as `127.0.0.1:7001` unless the deployment
+    /// provides its own network-layer protection.
+    pub fn new(bind_addr: impl Into<String>) -> Self {
+        Self {
+            bind_addr: bind_addr.into(),
+            config: AimxConfig::uds_default(),
+            scheme: DEFAULT_SCHEME.to_string(),
+            max_frame: DEFAULT_MAX_FRAME,
+        }
+    }
+
+    /// Use a prepared [`AimxConfig`] for limits and security policy.
+    pub fn with_config(mut self, config: AimxConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Set the security policy.
+    pub fn security_policy(mut self, policy: SecurityPolicy) -> Self {
+        self.config = self.config.security_policy(policy);
+        self
+    }
+
+    /// Maximum concurrently served connections.
+    pub fn max_connections(mut self, max: usize) -> Self {
+        self.config = self.config.max_connections(max);
+        self
+    }
+
+    /// Maximum live subscriptions per connection.
+    pub fn max_subs_per_connection(mut self, max: usize) -> Self {
+        self.config = self.config.max_subs_per_connection(max);
+        self
+    }
+
+    /// Maximum TCP frame payload size.
+    pub fn max_frame(mut self, max_frame: usize) -> Self {
+        self.max_frame = max_frame;
+        self
+    }
+
+    /// Override the scheme this connector registers.
+    pub fn scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.scheme = scheme.into();
+        self
+    }
+}
+
+impl ConnectorBuilder for TcpServer {
+    fn build<'a>(&'a self, db: &'a AimDb) -> BuildFuture<'a> {
+        let bind_addr = self.bind_addr.clone();
+        let config = self.config.clone();
+        let scheme = self.scheme.clone();
+        let max_frame = self.max_frame;
+        Box::pin(async move {
+            let session_config = SessionConfig {
+                limits: SessionLimits {
+                    max_connections: config.max_connections,
+                    max_subs_per_connection: config.max_subs_per_connection,
+                },
+                reads_hello: false,
+                acks_subscribe: false,
+            };
+            let bind_config = bind_addr.clone();
+            let dispatch_config = config;
+            let connector = SessionServerConnector::new(
+                move || bind_tcp_listener(&bind_config, max_frame),
+                AimxCodec,
+                move |db: &AimDb| -> Arc<dyn Dispatch> {
+                    crate::apply_writable(db, &dispatch_config);
+                    Arc::new(AimxDispatch::new(
+                        Arc::new(db.clone()),
+                        dispatch_config.clone(),
+                    ))
+                },
+                session_config,
+            )
+            .scheme(scheme);
+            connector.build(db).await
+        })
+    }
+
+    fn scheme(&self) -> &str {
+        &self.scheme
+    }
+}
+
+fn bind_tcp_listener(addr: &str, max_frame: usize) -> DbResult<TcpListener> {
+    let listener = std::net::TcpListener::bind(addr).map_err(|e| DbError::IoWithContext {
+        context: "Failed to bind TCP listener".to_string(),
+        source: e,
+    })?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| DbError::IoWithContext {
+            context: "Failed to set TCP listener nonblocking".to_string(),
+            source: e,
+        })?;
+    let listener = TokioTcpListener::from_std(listener).map_err(|e| DbError::IoWithContext {
+        context: "Failed to create Tokio TCP listener".to_string(),
+        source: e,
+    })?;
+    Ok(TcpListener::new(listener).max_frame(max_frame))
+}

--- a/aimdb-tcp-connector/tests/framing.rs
+++ b/aimdb-tcp-connector/tests/framing.rs
@@ -1,0 +1,84 @@
+use aimdb_tcp_connector::framing::{encode_frame, FrameAccumulator, FrameError};
+
+fn drain(acc: &mut FrameAccumulator) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    while let Some(frame) = acc.next_frame() {
+        out.push(frame.expect("valid frame"));
+    }
+    out
+}
+
+#[test]
+fn single_frame_roundtrips() {
+    let payload = br#"{"t":"req","id":1,"method":"record.list"}"#;
+    let mut wire = Vec::new();
+    encode_frame(payload, &mut wire).expect("encode");
+
+    let mut acc = FrameAccumulator::new();
+    acc.push_bytes(&wire);
+    assert_eq!(drain(&mut acc), vec![payload.to_vec()]);
+}
+
+#[test]
+fn survives_byte_by_byte_delivery() {
+    let payload = b"hello";
+    let mut wire = Vec::new();
+    encode_frame(payload, &mut wire).expect("encode");
+
+    let mut acc = FrameAccumulator::new();
+    for b in wire {
+        acc.push_bytes(&[b]);
+    }
+    assert_eq!(drain(&mut acc), vec![payload.to_vec()]);
+}
+
+#[test]
+fn many_frames_across_arbitrary_chunks() {
+    let payloads = [b"one".as_slice(), b"two".as_slice(), b"three".as_slice()];
+    let mut wire = Vec::new();
+    for payload in payloads {
+        encode_frame(payload, &mut wire).expect("encode");
+    }
+
+    for chunk in 1..wire.len() {
+        let mut acc = FrameAccumulator::new();
+        for part in wire.chunks(chunk) {
+            acc.push_bytes(part);
+        }
+        assert_eq!(
+            drain(&mut acc),
+            payloads.iter().map(|p| p.to_vec()).collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn waits_for_partial_header_and_payload() {
+    let mut wire = Vec::new();
+    encode_frame(b"abcdef", &mut wire).expect("encode");
+
+    let mut acc = FrameAccumulator::new();
+    acc.push_bytes(&wire[..2]);
+    assert!(acc.next_frame().is_none());
+    acc.push_bytes(&wire[2..7]);
+    assert!(acc.next_frame().is_none());
+    acc.push_bytes(&wire[7..]);
+    assert_eq!(acc.next_frame().unwrap().unwrap(), b"abcdef");
+}
+
+#[test]
+fn rejects_oversized_frame_before_payload_arrives() {
+    let mut acc = FrameAccumulator::with_max_frame(4);
+    acc.push_bytes(&5u32.to_be_bytes());
+    assert_eq!(acc.next_frame(), Some(Err(FrameError::TooLarge)));
+}
+
+#[test]
+fn empty_payload_roundtrips() {
+    let mut wire = Vec::new();
+    encode_frame(b"", &mut wire).expect("encode");
+
+    let mut acc = FrameAccumulator::new();
+    acc.push_bytes(&wire);
+    assert_eq!(acc.next_frame().unwrap().unwrap(), b"");
+}

--- a/aimdb-tcp-connector/tests/tokio_roundtrip.rs
+++ b/aimdb-tcp-connector/tests/tokio_roundtrip.rs
@@ -1,0 +1,88 @@
+#![cfg(feature = "_test-tokio")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aimdb_core::buffer::BufferCfg;
+use aimdb_core::remote::AimxConfig;
+use aimdb_core::session::aimx::{AimxCodec, AimxDispatch};
+use aimdb_core::session::{
+    run_client, serve, ClientConfig, Dispatch, Payload, SessionConfig, SessionLimits,
+};
+use aimdb_core::AimDbBuilder;
+use aimdb_tcp_connector::tokio_transport::{TcpDialer, TcpListener};
+use aimdb_tokio_adapter::{TokioAdapter, TokioRecordRegistrarExt};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Setting {
+    level: u64,
+}
+
+#[tokio::test]
+async fn aimx_roundtrips_over_tcp_loopback() {
+    let mut builder = AimDbBuilder::new().runtime(Arc::new(TokioAdapter));
+    builder.configure::<Setting>("setting", |reg| {
+        reg.buffer(BufferCfg::SingleLatest).with_remote_access();
+    });
+    let (db, runner) = builder.build().await.expect("build db");
+    let db = Arc::new(db);
+    tokio::spawn(runner.run());
+    db.set_record_from_json("setting", json!({ "level": 42 }))
+        .expect("seed setting");
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind tcp");
+    let addr = listener.local_addr().expect("local addr");
+
+    let dispatch: Arc<dyn Dispatch> =
+        Arc::new(AimxDispatch::new(db.clone(), AimxConfig::uds_default()));
+    let session_config = SessionConfig {
+        limits: SessionLimits {
+            max_connections: 1,
+            max_subs_per_connection: 8,
+        },
+        reads_hello: false,
+        acks_subscribe: false,
+    };
+    tokio::spawn(serve(
+        TcpListener::new(listener),
+        Arc::new(AimxCodec),
+        dispatch,
+        session_config,
+    ));
+
+    let client_config = ClientConfig {
+        sends_hello: false,
+        ..ClientConfig::default()
+    };
+    let (handle, engine) = run_client(
+        TcpDialer::new(addr.to_string()),
+        AimxCodec,
+        client_config,
+        Arc::new(TokioAdapter),
+    );
+    tokio::spawn(engine);
+
+    let params: Payload = serde_json::to_vec(&json!({ "name": "setting" }))
+        .unwrap()
+        .into();
+    let reply = tokio::time::timeout(Duration::from_secs(5), handle.call("record.get", params))
+        .await
+        .expect("rpc within timeout")
+        .expect("rpc ok");
+    let value: serde_json::Value = serde_json::from_slice(&reply).expect("json reply");
+    assert_eq!(value, json!({ "level": 42 }));
+
+    let list = tokio::time::timeout(
+        Duration::from_secs(5),
+        handle.call("record.list", Payload::from(&b"{}"[..])),
+    )
+    .await
+    .expect("rpc within timeout")
+    .expect("rpc ok");
+    let records: serde_json::Value = serde_json::from_slice(&list).expect("json reply");
+    assert!(records.as_array().is_some_and(|a| !a.is_empty()));
+}

--- a/tools/aimdb-cli/Cargo.toml
+++ b/tools/aimdb-cli/Cargo.toml
@@ -59,6 +59,9 @@ yaml = ["serde_yaml"]
 # Add the serial transport to the endpoint resolver, so `--connect serial://…`
 # works. Off by default (pulls tokio-serial → libudev on Linux).
 transport-serial = ["aimdb-client/transport-serial"]
+# Add the TCP transport to the endpoint resolver, so `--connect tcp://HOST:PORT`
+# works.
+transport-tcp = ["aimdb-client/transport-tcp"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/tools/aimdb-cli/README.md
+++ b/tools/aimdb-cli/README.md
@@ -295,6 +295,7 @@ records pick one for links:
 | `unix:///tmp/aimdb.sock` / `uds:///tmp/aimdb.sock` | Unix domain socket |
 | `/tmp/aimdb.sock` (bare path) | Unix domain socket (the `unix://` shorthand) |
 | `serial:///dev/ttyACM0?baud=115200` | Serial/UART (requires the `transport-serial` build feature) |
+| `tcp://127.0.0.1:7001` | TCP (requires the `transport-tcp` build feature) |
 
 ```bash
 # Explicit endpoint
@@ -305,6 +306,9 @@ aimdb --connect /tmp/aimdb.sock record list
 
 # Serial board (CLI built with --features transport-serial)
 aimdb --connect serial:///dev/ttyACM0?baud=115200 record list
+
+# TCP endpoint (CLI built with --features transport-tcp)
+aimdb --connect tcp://127.0.0.1:7001 record list
 ```
 
 An unknown scheme — or one whose transport isn't compiled into this binary — is
@@ -334,6 +338,7 @@ building:
 
 ```bash
 cargo build --release -p aimdb-cli --features transport-serial
+cargo build --release -p aimdb-cli --features transport-tcp
 ```
 
 ## Error Handling

--- a/tools/aimdb-cli/src/main.rs
+++ b/tools/aimdb-cli/src/main.rs
@@ -22,7 +22,8 @@ struct Cli {
     command: Command,
 
     /// Endpoint of the AimDB instance: a `scheme://` URL (`unix://PATH`,
-    /// `serial://DEVICE?baud=N`) or a bare path (the `unix://` shorthand).
+    /// `serial://DEVICE?baud=N`, `tcp://HOST:PORT`) or a bare path (the
+    /// `unix://` shorthand).
     /// Falls back to the `AIMDB_CONNECT` env var, then auto-discovery.
     #[arg(long, global = true)]
     connect: Option<String>,


### PR DESCRIPTION
## Description
Adds `aimdb-tcp-connector`, a thin AimX-over-TCP transport built on the shared session engine.

This PR includes:
- bounded `u32` big-endian length-prefixed TCP framing
- Tokio TCP client/server transport support
- Embassy TCP client support over `embassy-net` with caller-owned socket buffers
-  `aimdb-client` `transport-tcp` support for `tcp://host:port`
- CLI `transport-tcp` passthrough
- a small Tokio `tcp_demo` example for local server/client/set smoke testing

Note: Embassy TCP server support is intentionally left for an immediate follow-up, as discussed on #121. I’ll also add richer follow-up examples there, especially around embassy/server socket-buffer ownership.

## Related Issue
- Closes #121

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
