### PR TITLE
feat(tcp-connector): add Embassy TCP listener pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,14 +297,11 @@ dependencies = [
  "aimdb-core",
  "aimdb-embassy-adapter",
  "aimdb-tokio-adapter",
- "defmt 1.0.1",
  "embassy-net",
  "embedded-io-async 0.7.0",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ fmt:
 fmt-check:
 	@printf "$(GREEN)Checking code formatting (workspace members only)...$(NC)\n"
 	@FAILED=0; \
-	for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest-async aimdb-bench; do \
+	for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest-async aimdb-bench; do \
 		printf "$(YELLOW)  → Checking $$pkg$(NC)\n"; \
 		if ! cargo fmt -p $$pkg -- --check 2>&1; then \
 			printf "$(RED)❌ Formatting check failed for $$pkg$(NC)\n"; \

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ See the [MCP server docs](tools/aimdb-mcp/) for Claude Desktop and other editors
 | **MQTT** — `aimdb-mqtt-connector` | ✅ Ready | std, no_std |
 | **KNX** — `aimdb-knx-connector` | ✅ Ready | std, no_std |
 | **WebSocket** — `aimdb-websocket-connector` | ✅ Ready | std, wasm |
-| **TCP** — `aimdb-tcp-connector` | ✅ Ready | std, no_std client |
+| **TCP** — `aimdb-tcp-connector` | ✅ Ready | std, no_std |
 | **Kafka** | 📋 Planned | std |
 | **Modbus** | 📋 Planned | std, no_std |
 

--- a/aimdb-client/src/endpoint.rs
+++ b/aimdb-client/src/endpoint.rs
@@ -170,12 +170,42 @@ fn require_nonempty(endpoint: &str, target: &str) -> ClientResult<()> {
 fn require_tcp_target(endpoint: &str, target: &str) -> ClientResult<()> {
     require_nonempty(endpoint, target)?;
 
-    let Some((host, port)) = target.rsplit_once(':') else {
-        return Err(ClientError::unsupported_endpoint(
-            endpoint,
-            "missing TCP port",
-        ));
+    let (host, port) = if let Some(rest) = target.strip_prefix('[') {
+        let Some((host, after_host)) = rest.split_once(']') else {
+            return Err(ClientError::unsupported_endpoint(
+                endpoint,
+                "missing closing bracket for IPv6 TCP host",
+            ));
+        };
+        let Some(port) = after_host.strip_prefix(':') else {
+            return Err(ClientError::unsupported_endpoint(
+                endpoint,
+                "missing TCP port",
+            ));
+        };
+        (host, port)
+    } else {
+        if target.matches(':').count() > 1 {
+            return Err(ClientError::unsupported_endpoint(
+                endpoint,
+                "IPv6 TCP hosts must be bracketed, e.g. tcp://[::1]:7001",
+            ));
+        }
+        let Some((host, port)) = target.split_once(':') else {
+            return Err(ClientError::unsupported_endpoint(
+                endpoint,
+                "missing TCP port",
+            ));
+        };
+        if host.contains(['[', ']']) {
+            return Err(ClientError::unsupported_endpoint(
+                endpoint,
+                "malformed TCP host",
+            ));
+        }
+        (host, port)
     };
+
     if host.is_empty() {
         return Err(ClientError::unsupported_endpoint(
             endpoint,
@@ -268,6 +298,14 @@ mod tests {
         let p = parse_endpoint("tcp://localhost:7001").expect("parse");
         assert_eq!(p.scheme, Scheme::Tcp);
         assert_eq!(p.target, "localhost:7001");
+
+        let p = parse_endpoint("tcp://[::1]:7001").expect("parse");
+        assert_eq!(p.scheme, Scheme::Tcp);
+        assert_eq!(p.target, "[::1]:7001");
+
+        let p = parse_endpoint("tcp://[fe80::1]:7001").expect("parse");
+        assert_eq!(p.scheme, Scheme::Tcp);
+        assert_eq!(p.target, "[fe80::1]:7001");
     }
 
     #[test]
@@ -277,6 +315,10 @@ mod tests {
         assert!(parse_endpoint("tcp://host").is_err());
         assert!(parse_endpoint("tcp://:1234").is_err());
         assert!(parse_endpoint("tcp://host:fast").is_err());
+        assert!(parse_endpoint("tcp://fe80::1").is_err());
+        assert!(parse_endpoint("tcp://[fe80::1]").is_err());
+        assert!(parse_endpoint("tcp://[]:7001").is_err());
+        assert!(parse_endpoint("tcp://[fe80::1:7001").is_err());
         // Empty + empty target.
         assert!(parse_endpoint("").is_err());
         assert!(parse_endpoint("unix://").is_err());

--- a/aimdb-tcp-connector/Cargo.toml
+++ b/aimdb-tcp-connector/Cargo.toml
@@ -17,7 +17,6 @@ std = [
     "aimdb-core/alloc",
     "aimdb-core/connector-session",
     "aimdb-core/remote",
-    "thiserror",
 ]
 
 tokio-runtime = [
@@ -38,8 +37,8 @@ embassy-runtime = [
     "dep:embedded-io-async",
 ]
 
-tracing = ["dep:tracing", "aimdb-core/tracing"]
-defmt = ["dep:defmt", "aimdb-core/defmt"]
+tracing = ["aimdb-core/tracing"]
+defmt = ["aimdb-core/defmt"]
 
 _test-tokio = ["tokio-runtime", "dep:aimdb-tokio-adapter"]
 
@@ -47,16 +46,12 @@ _test-tokio = ["tokio-runtime", "dep:aimdb-tokio-adapter"]
 aimdb-core = { version = "1.1.0", path = "../aimdb-core", default-features = false }
 
 tokio = { workspace = true, optional = true, features = ["net", "io-util"] }
-thiserror = { workspace = true, optional = true }
 
 aimdb-embassy-adapter = { version = "0.6.0", path = "../aimdb-embassy-adapter", default-features = false, optional = true }
 embassy-net = { workspace = true, optional = true }
 embedded-io-async = { workspace = true, optional = true }
 
 aimdb-tokio-adapter = { version = "0.6.0", path = "../aimdb-tokio-adapter", optional = true }
-
-tracing = { workspace = true, optional = true }
-defmt = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "io-util", "net"] }

--- a/aimdb-tcp-connector/src/embassy_transport.rs
+++ b/aimdb-tcp-connector/src/embassy_transport.rs
@@ -1,27 +1,48 @@
 //! Embassy TCP transport (feature `embassy-runtime`).
 //!
-//! This half is client-only for the first TCP PR. `embassy-net` has no
-//! `TcpListener`; a server needs an explicit socket/buffer pool design.
+//! `embassy-net` has no central `TcpListener`; each `TcpSocket` must enter
+//! `accept()` itself. This module therefore models Embassy TCP servers as an
+//! explicit pool of caller-buffered sockets, with one accept/session worker per
+//! active slot.
+//! `connector-io` cannot be reused directly because `TcpSocket::split()` only
+//! yields borrowed halves, while AimDB's `Connection` must own the socket.
 
 use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::future::{poll_fn, Future};
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
 
+use aimdb_core::connector::ConnectorBuilder;
+use aimdb_core::remote::{AimxConfig, SecurityPolicy};
 use aimdb_core::session::aimx::AimxCodec;
-use aimdb_core::session::{BoxFut, Connection, Dialer, PeerInfo, TransportError, TransportResult};
+use aimdb_core::session::{
+    run_session, BoxFut, ClientConfig, Connection, Dialer, Dispatch, Listener, PeerInfo,
+    SessionConfig, SessionLimits, TransportError, TransportResult,
+};
 use aimdb_embassy_adapter::connectors::{EmbassySessionClient, OneShotCell};
 use aimdb_embassy_adapter::SendFutureWrapper;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{IpEndpoint, Stack};
+use embassy_net::{IpEndpoint, IpListenEndpoint, Stack};
 use embedded_io_async::Write;
+
+use aimdb_core::{AimDb, DbResult};
 
 use crate::framing::{encode_frame, FrameAccumulator, HEADER_LEN};
 use crate::DEFAULT_SCHEME;
+
+type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+type BuildFuture<'a> = Pin<Box<dyn Future<Output = DbResult<Vec<BoxFuture>>> + Send + 'a>>;
 
 const READ_CHUNK: usize = 256;
 
 /// A framed AimX connection over one `embassy-net` TCP socket.
 pub struct TcpConnection {
-    socket: TcpSocket<'static>,
+    socket: Option<TcpSocket<'static>>,
+    recycler: Option<Arc<TcpSocketSlot>>,
     acc: FrameAccumulator,
     peer: PeerInfo,
 }
@@ -34,7 +55,17 @@ impl TcpConnection {
     /// Wrap an already-connected TCP socket.
     pub fn new(socket: TcpSocket<'static>) -> Self {
         Self {
-            socket,
+            socket: Some(socket),
+            recycler: None,
+            acc: FrameAccumulator::new(),
+            peer: PeerInfo::default(),
+        }
+    }
+
+    fn reusable(socket: TcpSocket<'static>, recycler: Arc<TcpSocketSlot>) -> Self {
+        Self {
+            socket: Some(socket),
+            recycler: Some(recycler),
             acc: FrameAccumulator::new(),
             peer: PeerInfo::default(),
         }
@@ -44,6 +75,7 @@ impl TcpConnection {
 impl Connection for TcpConnection {
     fn recv(&mut self) -> BoxFut<'_, TransportResult<Option<Vec<u8>>>> {
         Box::pin(SendFutureWrapper(async move {
+            let socket = self.socket.as_mut().ok_or(TransportError::Closed)?;
             loop {
                 match self.acc.next_frame() {
                     Some(Ok(frame)) => return Ok(Some(frame)),
@@ -52,7 +84,7 @@ impl Connection for TcpConnection {
                 }
 
                 let mut chunk = [0u8; READ_CHUNK];
-                match self.socket.read(&mut chunk).await {
+                match socket.read(&mut chunk).await {
                     Ok(0) => return Ok(None),
                     Ok(n) => self.acc.push_bytes(&chunk[..n]),
                     Err(_) => return Err(TransportError::Io),
@@ -63,21 +95,30 @@ impl Connection for TcpConnection {
 
     fn send<'a>(&'a mut self, frame: &'a [u8]) -> BoxFut<'a, TransportResult<()>> {
         Box::pin(SendFutureWrapper(async move {
+            let socket = self.socket.as_mut().ok_or(TransportError::Closed)?;
             let capacity = HEADER_LEN
                 .checked_add(frame.len())
                 .ok_or(TransportError::Io)?;
             let mut out = Vec::with_capacity(capacity);
             encode_frame(frame, &mut out).map_err(|_| TransportError::Io)?;
-            write_all(&mut self.socket, &out).await?;
-            self.socket
-                .flush()
-                .await
-                .map_err(|_| TransportError::Closed)
+            write_all(socket, &out).await?;
+            socket.flush().await.map_err(|_| TransportError::Closed)
         }))
     }
 
     fn peer(&self) -> &PeerInfo {
         &self.peer
+    }
+}
+
+impl Drop for TcpConnection {
+    fn drop(&mut self) {
+        if let Some(mut socket) = self.socket.take() {
+            socket.abort();
+            if let Some(recycler) = &self.recycler {
+                recycler.put(socket);
+            }
+        }
     }
 }
 
@@ -98,33 +139,75 @@ where
     Ok(())
 }
 
-/// A one-shot Embassy TCP dialer.
-pub struct TcpDialer {
-    stack: Stack<'static>,
-    endpoint: IpEndpoint,
-    rx_buffer: OneShotCell<&'static mut [u8]>,
-    tx_buffer: OneShotCell<&'static mut [u8]>,
+struct TcpSocketSlot {
+    socket: RefCell<Option<TcpSocket<'static>>>,
+    waker: RefCell<Option<Waker>>,
 }
 
-// SAFETY: single-core cooperative Embassy executor; buffers and stack stay on
-// the same executor task set.
-unsafe impl Send for TcpDialer {}
-// SAFETY: same invariant. Interior mutability is provided by `OneShotCell`.
-unsafe impl Sync for TcpDialer {}
+// SAFETY: single-core cooperative Embassy executor; the socket and stack stay on
+// the same executor task set, and `RefCell` is never borrowed from another core.
+unsafe impl Send for TcpSocketSlot {}
+// SAFETY: same invariant. This is only shared so the dropped connection can
+// return its socket to the dialer-owned slot.
+unsafe impl Sync for TcpSocketSlot {}
+
+impl TcpSocketSlot {
+    fn new(socket: TcpSocket<'static>) -> Self {
+        Self {
+            socket: RefCell::new(Some(socket)),
+            waker: RefCell::new(None),
+        }
+    }
+
+    fn take(&self) -> Option<TcpSocket<'static>> {
+        self.socket.borrow_mut().take()
+    }
+
+    fn poll_take(&self, cx: &mut Context<'_>) -> Poll<TcpSocket<'static>> {
+        let mut slot = self.socket.borrow_mut();
+        if let Some(socket) = slot.take() {
+            Poll::Ready(socket)
+        } else {
+            drop(slot);
+            *self.waker.borrow_mut() = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    fn put(&self, socket: TcpSocket<'static>) {
+        let mut slot = self.socket.borrow_mut();
+        debug_assert!(slot.is_none(), "Embassy TCP socket returned twice");
+        if slot.is_none() {
+            *slot = Some(socket);
+        }
+        if let Some(waker) = self.waker.borrow_mut().take() {
+            waker.wake();
+        }
+    }
+}
+
+/// A reusable Embassy TCP dialer backed by one caller-owned socket.
+///
+/// Unlike moved-in UART peripherals, `embassy-net` TCP sockets can be reused
+/// after `abort()`/`close()`, so this dialer can redial with the same static
+/// RX/TX buffers.
+pub struct TcpDialer {
+    endpoint: IpEndpoint,
+    socket: Arc<TcpSocketSlot>,
+}
 
 impl TcpDialer {
-    /// Build a one-shot dialer with caller-owned socket buffers.
+    /// Build a reusable dialer with caller-owned socket buffers.
     pub fn new(
         stack: Stack<'static>,
         endpoint: IpEndpoint,
         rx_buffer: &'static mut [u8],
         tx_buffer: &'static mut [u8],
     ) -> Self {
+        let socket = TcpSocket::new(stack, rx_buffer, tx_buffer);
         Self {
-            stack,
             endpoint,
-            rx_buffer: OneShotCell::new(rx_buffer),
-            tx_buffer: OneShotCell::new(tx_buffer),
+            socket: Arc::new(TcpSocketSlot::new(socket)),
         }
     }
 }
@@ -132,15 +215,143 @@ impl TcpDialer {
 impl Dialer for TcpDialer {
     fn connect(&self) -> BoxFut<'_, TransportResult<Box<dyn Connection>>> {
         Box::pin(SendFutureWrapper(async move {
-            let rx = self.rx_buffer.take().ok_or(TransportError::Io)?;
-            let tx = self.tx_buffer.take().ok_or(TransportError::Io)?;
-            let mut socket = TcpSocket::new(self.stack, rx, tx);
-            socket
-                .connect(self.endpoint)
-                .await
-                .map_err(|_| TransportError::Io)?;
-            Ok(Box::new(TcpConnection::new(socket)) as Box<dyn Connection>)
+            let Some(mut socket) = self.socket.take() else {
+                return Err(TransportError::Io);
+            };
+            socket.abort();
+            match socket.connect(self.endpoint).await {
+                Ok(()) => Ok(
+                    Box::new(TcpConnection::reusable(socket, self.socket.clone()))
+                        as Box<dyn Connection>,
+                ),
+                Err(_) => {
+                    socket.abort();
+                    self.socket.put(socket);
+                    Err(TransportError::Io)
+                }
+            }
         }))
+    }
+}
+
+/// An Embassy TCP listener backed by `N` caller-owned sockets.
+///
+/// `embassy-net` requires each `TcpSocket` to enter `accept()` itself, so true
+/// concurrent listening means keeping multiple sockets in accept state at once.
+/// `TcpServer::<N>::with_buffers(...)` drives this listener with one worker per
+/// enabled slot. The `Listener` trait implementation is only for the `N = 1`
+/// compatibility path.
+pub struct TcpListener<const N: usize = 1> {
+    local_endpoint: IpListenEndpoint,
+    slots: [Arc<TcpSocketSlot>; N],
+}
+
+impl TcpListener<1> {
+    /// Build a single-socket listener with caller-owned socket buffers.
+    pub fn new(
+        stack: Stack<'static>,
+        local_endpoint: impl Into<IpListenEndpoint>,
+        rx_buffer: &'static mut [u8],
+        tx_buffer: &'static mut [u8],
+    ) -> Self {
+        Self::with_buffers(stack, local_endpoint, [rx_buffer], [tx_buffer])
+    }
+}
+
+impl<const N: usize> TcpListener<N> {
+    /// Build an N-socket listener pool with caller-owned socket buffers.
+    ///
+    /// Each `(rx_buffers[i], tx_buffers[i])` pair backs one `TcpSocket` and one
+    /// concurrent accept/session worker. Keep `N` aligned with the
+    /// `embassy-net::StackResources<SOCK>` capacity and the RAM budget for the
+    /// chosen RX/TX buffer sizes.
+    pub fn with_buffers(
+        stack: Stack<'static>,
+        local_endpoint: impl Into<IpListenEndpoint>,
+        rx_buffers: [&'static mut [u8]; N],
+        tx_buffers: [&'static mut [u8]; N],
+    ) -> Self {
+        let mut rx_buffers = rx_buffers.into_iter();
+        let mut tx_buffers = tx_buffers.into_iter();
+        let slots = core::array::from_fn(|_| {
+            let rx = rx_buffers
+                .next()
+                .expect("array iterator yields exactly N RX buffers");
+            let tx = tx_buffers
+                .next()
+                .expect("array iterator yields exactly N TX buffers");
+            Arc::new(TcpSocketSlot::new(TcpSocket::new(stack, rx, tx)))
+        });
+        Self {
+            local_endpoint: local_endpoint.into(),
+            slots,
+        }
+    }
+
+    fn into_server_futures(
+        self,
+        codec: Arc<AimxCodec>,
+        dispatch: Arc<dyn Dispatch>,
+        config: SessionConfig,
+        max_workers: usize,
+    ) -> Vec<BoxFuture> {
+        let worker_count = max_workers.min(N);
+        let mut futures = Vec::with_capacity(worker_count);
+        for slot in self.slots.into_iter().take(worker_count) {
+            futures.push(Box::pin(SendFutureWrapper(serve_socket_slot(
+                slot,
+                self.local_endpoint,
+                codec.clone(),
+                dispatch.clone(),
+                config.clone(),
+            ))) as BoxFuture);
+        }
+        futures
+    }
+}
+
+impl Listener for TcpListener<1> {
+    fn accept(&mut self) -> BoxFut<'_, TransportResult<Box<dyn Connection>>> {
+        Box::pin(SendFutureWrapper(async move {
+            let slot = &self.slots[0];
+            let mut socket = poll_fn(|cx| slot.poll_take(cx)).await;
+            socket.abort();
+            match socket.accept(self.local_endpoint).await {
+                Ok(()) => {
+                    Ok(Box::new(TcpConnection::reusable(socket, slot.clone()))
+                        as Box<dyn Connection>)
+                }
+                Err(_) => {
+                    socket.abort();
+                    slot.put(socket);
+                    Err(TransportError::Io)
+                }
+            }
+        }))
+    }
+}
+
+async fn serve_socket_slot(
+    slot: Arc<TcpSocketSlot>,
+    local_endpoint: IpListenEndpoint,
+    codec: Arc<AimxCodec>,
+    dispatch: Arc<dyn Dispatch>,
+    config: SessionConfig,
+) {
+    loop {
+        let mut socket = poll_fn(|cx| slot.poll_take(cx)).await;
+        socket.abort();
+        match socket.accept(local_endpoint).await {
+            Ok(()) => {
+                let conn =
+                    Box::new(TcpConnection::reusable(socket, slot.clone())) as Box<dyn Connection>;
+                run_session(conn, codec.as_ref(), dispatch.as_ref(), &config).await;
+            }
+            Err(_) => {
+                socket.abort();
+                slot.put(socket);
+            }
+        }
     }
 }
 
@@ -161,5 +372,130 @@ impl TcpClient {
             AimxCodec,
         )
         .scheme(DEFAULT_SCHEME)
+        .with_config(ClientConfig::default())
+    }
+}
+
+/// Accepts AimX connections over an explicit Embassy TCP socket pool.
+///
+/// `TcpServer::new(...)` is the one-socket convenience constructor. Use
+/// `TcpServer::<N>::with_buffers(...)` to keep `N` sockets concurrently
+/// listening, each backed by caller-owned static RX/TX buffers.
+pub struct TcpServer<const N: usize = 1> {
+    listener: OneShotCell<TcpListener<N>>,
+    config: AimxConfig,
+    scheme: String,
+}
+
+impl TcpServer<1> {
+    /// Serve AimX on one Embassy TCP socket.
+    pub fn new(
+        stack: Stack<'static>,
+        local_endpoint: impl Into<IpListenEndpoint>,
+        rx_buffer: &'static mut [u8],
+        tx_buffer: &'static mut [u8],
+    ) -> Self {
+        Self {
+            listener: OneShotCell::new(TcpListener::new(
+                stack,
+                local_endpoint,
+                rx_buffer,
+                tx_buffer,
+            )),
+            config: AimxConfig::uds_default(),
+            scheme: DEFAULT_SCHEME.to_string(),
+        }
+    }
+}
+
+impl<const N: usize> TcpServer<N> {
+    /// Serve AimX over an N-socket Embassy TCP listener pool.
+    ///
+    /// The server starts up to `min(N, max_connections)` workers. Each worker
+    /// keeps one `TcpSocket` in `accept()` while idle, so the network stack has
+    /// multiple pending listeners instead of rejecting inbound SYNs after a
+    /// single socket is consumed.
+    pub fn with_buffers(
+        stack: Stack<'static>,
+        local_endpoint: impl Into<IpListenEndpoint>,
+        rx_buffers: [&'static mut [u8]; N],
+        tx_buffers: [&'static mut [u8]; N],
+    ) -> Self {
+        Self {
+            listener: OneShotCell::new(TcpListener::with_buffers(
+                stack,
+                local_endpoint,
+                rx_buffers,
+                tx_buffers,
+            )),
+            config: AimxConfig::uds_default(),
+            scheme: DEFAULT_SCHEME.to_string(),
+        }
+    }
+
+    /// Use a prepared [`AimxConfig`] for limits and security policy.
+    pub fn with_config(mut self, config: AimxConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Set the security policy.
+    pub fn security_policy(mut self, policy: SecurityPolicy) -> Self {
+        self.config = self.config.security_policy(policy);
+        self
+    }
+
+    /// Maximum concurrently served connections.
+    ///
+    /// Effective concurrency is `min(N, max)`, because every active worker owns
+    /// exactly one listening or connected socket.
+    pub fn max_connections(mut self, max: usize) -> Self {
+        self.config = self.config.max_connections(max);
+        self
+    }
+
+    /// Maximum live subscriptions per connection.
+    pub fn max_subs_per_connection(mut self, max: usize) -> Self {
+        self.config = self.config.max_subs_per_connection(max);
+        self
+    }
+
+    /// Override the scheme this connector registers.
+    pub fn scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.scheme = scheme.into();
+        self
+    }
+}
+
+impl<const N: usize> ConnectorBuilder for TcpServer<N> {
+    fn build<'a>(&'a self, db: &'a AimDb) -> BuildFuture<'a> {
+        let listener = self.listener.take_required();
+        let config = self.config.clone();
+        Box::pin(SendFutureWrapper(async move {
+            let listener = listener?;
+            crate::apply_writable(db, &config);
+            let session_config = SessionConfig {
+                limits: SessionLimits {
+                    max_connections: config.max_connections,
+                    max_subs_per_connection: config.max_subs_per_connection,
+                },
+                reads_hello: false,
+                acks_subscribe: false,
+            };
+            let dispatch: Arc<dyn Dispatch> = Arc::new(
+                aimdb_core::session::aimx::AimxDispatch::new(Arc::new(db.clone()), config),
+            );
+            let max_workers = session_config.limits.max_connections;
+            Ok(listener.into_server_futures(
+                Arc::new(AimxCodec),
+                dispatch,
+                session_config,
+                max_workers,
+            ))
+        }))
+    }
+
+    fn scheme(&self) -> &str {
+        &self.scheme
     }
 }

--- a/aimdb-tcp-connector/src/lib.rs
+++ b/aimdb-tcp-connector/src/lib.rs
@@ -28,7 +28,7 @@ pub const DEFAULT_SCHEME: &str = "tcp";
 
 /// Mark each record named in the policy's writable set as writable, so
 /// `record.list` advertises the writable flag. The dispatch also enforces it.
-#[cfg(feature = "tokio-runtime")]
+#[cfg(any(feature = "tokio-runtime", feature = "embassy-runtime"))]
 pub(crate) fn apply_writable(db: &aimdb_core::AimDb, config: &aimdb_core::remote::AimxConfig) {
     for key in config.security_policy.writable_records() {
         if let Some(id) = db.inner().resolve_str(&key) {
@@ -43,7 +43,11 @@ pub(crate) fn apply_writable(db: &aimdb_core::AimDb, config: &aimdb_core::remote
 pub use tokio_transport::{TcpClient, TcpConnection, TcpDialer, TcpListener, TcpServer};
 
 #[cfg(all(feature = "tokio-runtime", feature = "embassy-runtime"))]
-pub use embassy_transport::{TcpClient as EmbassyTcpClient, TcpConnection as EmbassyTcpConnection};
+pub use embassy_transport::{
+    TcpClient as EmbassyTcpClient, TcpConnection as EmbassyTcpConnection,
+    TcpDialer as EmbassyTcpDialer, TcpListener as EmbassyTcpListener,
+    TcpServer as EmbassyTcpServer,
+};
 #[cfg(all(feature = "tokio-runtime", feature = "embassy-runtime"))]
 pub use tokio_transport::{
     TcpClient as TokioTcpClient, TcpConnection as TokioTcpConnection, TcpDialer, TcpListener,
@@ -51,4 +55,4 @@ pub use tokio_transport::{
 };
 
 #[cfg(all(feature = "embassy-runtime", not(feature = "tokio-runtime")))]
-pub use embassy_transport::{TcpClient, TcpConnection};
+pub use embassy_transport::{TcpClient, TcpConnection, TcpDialer, TcpListener, TcpServer};


### PR DESCRIPTION
## Description
- Add `TcpServer::<N>::with_buffers(...)` for Embassy TCP servers, using an explicit N-socket RX/TX buffer pool.
- Keep one Embassy accept worker per active socket slot so `N >= 2` can accept concurrent inbound TCP clients.
- Rework Embassy TCP connection recycling so sockets return to the pool after disconnect/session exit.
- Make the Embassy TCP client/dialer reusable across failed connects and dropped links.
- Tighten `tcp://` endpoint validation, including bracketed IPv6 support and rejection of naked IPv6 targets.
- Clean up `aimdb-tcp-connector` feature dependencies and include `tokio-knx-connector-demo` in `fmt-check`.


## Related Issue
- Closes #168 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (`make check`).
- [x] I have updated the documentation accordingly.