### PR TITLE
add spmc ring sync example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,6 +2235,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hello-spmc-ring"
+version = "1.1.0"
+dependencies = [
+ "aimdb-core",
+ "aimdb-sync",
+ "aimdb-tokio-adapter",
+]
+
+[[package]]
 name = "hello-spmc-ring-async"
 version = "1.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "examples/hello-mailbox-async",
     "examples/hello-single-latest",
     "examples/hello-single-latest-async",
+    "examples/hello-spmc-ring",
     "examples/hello-spmc-ring-async",
     "examples/readme-quickstart",
     # Benchmarking infrastructure — host-only, excluded from default-members

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,30 @@ test:
 
 fmt:
 	@printf "$(GREEN)Formatting code (workspace members only)...$(NC)\n"
+	@for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest hello-single-latest-async hello-spmc-ring aimdb-bench; do \
+		printf "$(YELLOW)  → Formatting $$pkg$(NC)\n"; \
+		cargo fmt -p $$pkg 2>/dev/null || true; \
+	done
+	@printf "$(GREEN)✓ Formatting complete!$(NC)\n"
+
+fmt-check:
+	@printf "$(GREEN)Checking code formatting (workspace members only)...$(NC)\n"
+	@FAILED=0; \
+	for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest hello-single-latest-async hello-spmc-ring aimdb-bench; do \
+		printf "$(YELLOW)  → Checking $$pkg$(NC)\n"; \
+		if ! cargo fmt -p $$pkg -- --check 2>&1; then \
+			printf "$(RED)❌ Formatting check failed for $$pkg$(NC)\n"; \
+			FAILED=1; \
+		fi; \
+	done; \
+	if [ $$FAILED -eq 1 ]; then \
+		printf "$(RED)✗ Formatting check failed! Run 'make fmt' to fix.$(NC)\n"; \
+		exit 1; \
+	fi
+	@printf "$(GREEN)✓ All packages properly formatted!$(NC)\n"
+
+fmt:
+	@printf "$(GREEN)Formatting code (workspace members only)...$(NC)\n"
 	@for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest hello-single-latest-async hello-spmc-ring-async aimdb-bench; do \
 		printf "$(YELLOW)  → Formatting $$pkg$(NC)\n"; \
 		cargo fmt -p $$pkg 2>/dev/null || true; \
@@ -424,6 +448,8 @@ examples:
 	cargo build --package hello-single-latest
 	@printf "$(YELLOW)  → Building hello-single-latest-async$(NC)\n"
 	cargo build --package hello-single-latest-async
+	@printf "$(YELLOW)  → Building hello-spmc-ring$(NC)\n"
+	cargo build --package hello-spmc-ring
 	@printf "$(YELLOW)  → Building hello-spmc-ring-async$(NC)\n"
 	cargo build --package hello-spmc-ring-async
 	@printf "$(YELLOW)  → Building readme-quickstart (compiled README example)$(NC)\n"

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ test:
 
 fmt:
 	@printf "$(GREEN)Formatting code (workspace members only)...$(NC)\n"
-	@for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest hello-single-latest-async hello-spmc-ring aimdb-bench; do \
+	@for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest hello-single-latest-async hello-spmc-ring hello-spmc-ring-async aimdb-bench; do \
 		printf "$(YELLOW)  → Formatting $$pkg$(NC)\n"; \
 		cargo fmt -p $$pkg 2>/dev/null || true; \
 	done
@@ -193,7 +193,7 @@ fmt:
 fmt-check:
 	@printf "$(GREEN)Checking code formatting (workspace members only)...$(NC)\n"
 	@FAILED=0; \
-	for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest hello-single-latest-async hello-spmc-ring aimdb-bench; do \
+	for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest hello-single-latest-async hello-spmc-ring hello-spmc-ring-async aimdb-bench; do \
 		printf "$(YELLOW)  → Checking $$pkg$(NC)\n"; \
 		if ! cargo fmt -p $$pkg -- --check 2>&1; then \
 			printf "$(RED)❌ Formatting check failed for $$pkg$(NC)\n"; \

--- a/Makefile
+++ b/Makefile
@@ -206,30 +206,6 @@ fmt-check:
 	fi
 	@printf "$(GREEN)✓ All packages properly formatted!$(NC)\n"
 
-fmt:
-	@printf "$(GREEN)Formatting code (workspace members only)...$(NC)\n"
-	@for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest hello-single-latest-async hello-spmc-ring-async aimdb-bench; do \
-		printf "$(YELLOW)  → Formatting $$pkg$(NC)\n"; \
-		cargo fmt -p $$pkg 2>/dev/null || true; \
-	done
-	@printf "$(GREEN)✓ Formatting complete!$(NC)\n"
-
-fmt-check:
-	@printf "$(GREEN)Checking code formatting (workspace members only)...$(NC)\n"
-	@FAILED=0; \
-	for pkg in aimdb-derive aimdb-data-contracts aimdb-core aimdb-client aimdb-embassy-adapter aimdb-tokio-adapter aimdb-wasm-adapter aimdb-sync aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector aimdb-knx-connector aimdb-ws-protocol aimdb-websocket-connector aimdb-uds-connector aimdb-serial-connector aimdb-tcp-connector aimdb-codegen aimdb-cli aimdb-mcp sync-api-demo tokio-mqtt-connector-demo embassy-mqtt-connector-demo tokio-knx-connector-demo embassy-knx-connector-demo embassy-serial-connector-demo embassy-bench-stm32h5 weather-mesh-common weather-hub weather-station-alpha weather-station-beta hello-mailbox hello-mailbox-async hello-single-latest hello-single-latest-async hello-spmc-ring-async aimdb-bench; do \
-		printf "$(YELLOW)  → Checking $$pkg$(NC)\n"; \
-		if ! cargo fmt -p $$pkg -- --check 2>&1; then \
-			printf "$(RED)❌ Formatting check failed for $$pkg$(NC)\n"; \
-			FAILED=1; \
-		fi; \
-	done; \
-	if [ $$FAILED -eq 1 ]; then \
-		printf "$(RED)✗ Formatting check failed! Run 'make fmt' to fix.$(NC)\n"; \
-		exit 1; \
-	fi
-	@printf "$(GREEN)✓ All packages properly formatted!$(NC)\n"
-
 clippy:
 	@printf "$(GREEN)Running clippy (all valid combinations)...$(NC)\n"
 	@printf "$(YELLOW)  → Clippy on aimdb-derive$(NC)\n"

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ docker compose up
 
 | Buffer | Semantics | Use cases |
 | --- | --- | --- |
-| [**SPMC Ring**](examples/hello-spmc-ring-async) | Bounded stream with independent consumers | Sensor telemetry, event logs |
+| [**SPMC Ring**](examples/hello-spmc-ring/) / [**SPMC Ring async**](examples/hello-spmc-ring-async) | Bounded stream with independent consumers | Sensor telemetry, event logs |
 | [**SingleLatest**](examples/hello-single-latest) / [**SingleLatest async**](examples/hello-single-latest-async) | Only the current value matters | Feature flags, config, UI state |
 | [**Mailbox**](examples/hello-mailbox) / [**async Mailbox**](examples/hello-mailbox-async)| Latest instruction wins | Device commands, actuation, RPC |
 

--- a/examples/hello-spmc-ring/Cargo.toml
+++ b/examples/hello-spmc-ring/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hello-spmc-ring"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "AimDB minimal sync example demonstrating SPMC ring buffer semantics"
+publish = false
+
+[dependencies]
+aimdb-core = { path = "../../aimdb-core", features = ["std"] }
+aimdb-tokio-adapter = { path = "../../aimdb-tokio-adapter", features = [
+    "tokio-runtime",
+] }
+aimdb-sync = { path = "../../aimdb-sync" }

--- a/examples/hello-spmc-ring/README.md
+++ b/examples/hello-spmc-ring/README.md
@@ -22,9 +22,9 @@ cargo run -p hello-spmc-ring
 === hello-spmc-ring: SPMC ring buffer sync demo ===
 
 Ring size:          10
-Producer at rate    20.0 messages/sec
-Slow Observer at rate 10.0 messages/sec
-Fast Observer at rate 20.0 messages/sec
+Producer interval:   50 ms
+Fast tap delay:      none
+Slow tap delay:      100 ms
 
 
 1. Building database and attaching for sync API...

--- a/examples/hello-spmc-ring/README.md
+++ b/examples/hello-spmc-ring/README.md
@@ -1,0 +1,62 @@
+# hello-spmc-ring: sync Spmc Ring buffer demo
+The Spmc Ring buffer supports Single Producer - Multi Consumer pattern. It features a ring buffer with fixed capacity. Each consumer could read the full sequence at its own rate without waiting for consumption states of other consumers provided it doesn't fall behind by more values than the configured capacity. If a reader falls behind by more entries than the configured capacity, the oldest unread entries are dropped and the reader reports that it lagged.
+
+In contrast to [SingleLatest](../hello-single-latest), slow observer doesn't skip overwritten intermediate values and it receives every value because `SpmcRing` keeps one shared bounded sequence and every consumer tracks an independent read position.
+
+## When to use
+This Spmc Ring buffer demo is useful in a variety of scenarios where you need to broadcast messages to different types of consumers but you are not sure if one could lag behind others.
+
+## How it works
+The sync Spmc buffer demo works by simulating:
+- A sync producer generating a message at fixed interval (struct `Temperature`);
+- A fast consumer/observer consuming at the same rate of the producer's;
+- A slow consumer/observer consuming at a rate slower than producer's;
+
+## How to run
+From the workspace root, run:
+```
+cargo run -p hello-spmc-ring
+```
+**Expected output**
+```
+=== hello-spmc-ring: SPMC ring buffer sync demo ===
+
+Ring size:          10
+Producer at rate    20.0 messages/sec
+Slow Observer at rate 10.0 messages/sec
+Fast Observer at rate 20.0 messages/sec
+
+
+1. Building database and attaching for sync API...
+   Main: Setting Temperature At 1784318569: 30°C
+[info] [fast] observed temperature At 1784318569: 30°C
+[info] [slow] observed temperature At 1784318569: 30°C
+   Main: Setting Temperature At 1784318569: 30.5°C
+[info] [fast] observed temperature At 1784318569: 30.5°C
+[info] [slow] observed temperature At 1784318569: 30.5°C
+   Main: Setting Temperature At 1784318569: 31°C
+[info] [fast] observed temperature At 1784318569: 31°C
+   Main: Setting Temperature At 1784318570: 31.5°C
+[info] [fast] observed temperature At 1784318570: 31.5°C
+[info] [slow] observed temperature At 1784318569: 31°C
+   Main: Setting Temperature At 1784318570: 32°C
+[info] [fast] observed temperature At 1784318570: 32°C
+   Main: Setting Temperature At 1784318570: 32.5°C
+[info] [fast] observed temperature At 1784318570: 32.5°C
+[info] [slow] observed temperature At 1784318570: 31.5°C
+   Main: Setting Temperature At 1784318570: 33°C
+[info] [fast] observed temperature At 1784318570: 33°C
+   Main: Setting Temperature At 1784318570: 33.5°C
+[info] [fast] observed temperature At 1784318570: 33.5°C
+[info] [slow] observed temperature At 1784318570: 32°C
+   Main: Setting Temperature At 1784318570: 34°C
+[info] [fast] observed temperature At 1784318570: 34°C
+   Main: Setting Temperature At 1784318570: 34.5°C
+[info] [fast] observed temperature At 1784318570: 34.5°C
+[info] [slow] observed temperature At 1784318570: 32.5°C
+[info] [slow] observed temperature At 1784318570: 33°C
+[info] [slow] observed temperature At 1784318570: 33.5°C
+[info] [slow] observed temperature At 1784318570: 34°C
+[info] [slow] observed temperature At 1784318570: 34.5°C
+
+```

--- a/examples/hello-spmc-ring/src/main.rs
+++ b/examples/hello-spmc-ring/src/main.rs
@@ -1,0 +1,111 @@
+//! AimDB SPMC Ring Sync Demo
+//! This example demonstrates the `SpmcRing` buffer using AimDB's synchronous API.
+//!
+//! ## What This Demo Shows
+//!
+//! 1. Building an AimDB instance with a typed record and 2 tap observers (slow and fast)
+//! 2. Attaching the database to get a sync handle
+//! 3. Creating a producer in sync context
+//! 4. Setting values using blocking operations
+//! 5. Demonstrating how SPMC ring keeps a bounded backlog per consumer
+//! 6. Clean shutdown with detach()
+
+use std::{
+    fmt::Display,
+    sync::Arc,
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use aimdb_core::{buffer::BufferCfg, AimDbBuilder, Consumer, RuntimeContext};
+use aimdb_sync::AimDbBuilderSyncExt;
+use aimdb_tokio_adapter::{TokioAdapter, TokioRecordRegistrarExt};
+
+#[derive(Debug, Clone)]
+struct Temperature {
+    /// Temperature in degrees Celsius
+    celsius: f32,
+
+    /// Unix timestamp (secs)
+    timestamp_secs: u64,
+}
+
+impl Display for Temperature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "At {}: {}°C", self.timestamp_secs, self.celsius)
+    }
+}
+
+const KEY: &str = "sensor.temperature";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== hello-spmc-ring: SPMC ring buffer sync demo ===\n");
+    println!("Ring size:          10");
+    println!("Producer interval:   50 ms");
+    println!("Fast tap delay:      none");
+    println!("Slow tap delay:      100 ms");
+    println!("\n");
+    // Step 1: Build the database and attach it for sync API usage
+    println!("1. Building database and attaching for sync API...");
+
+    let adapter = Arc::new(TokioAdapter);
+    let mut builder = AimDbBuilder::new().runtime(adapter);
+
+    builder.configure::<Temperature>(KEY, |reg| {
+        reg.buffer(BufferCfg::SpmcRing { capacity: 10 })
+            // Register 2 taps that observe temperature values
+            .tap(sensor_observer_fast)
+            .tap(sensor_observer_slow);
+    });
+
+    // Build happens inside the runtime thread where Tokio context exists
+    let handle = builder.attach()?;
+
+    let producer = handle.producer::<Temperature>(KEY)?;
+
+    for i in 0..10 {
+        let now = SystemTime::now();
+        let since_the_epoch = now.duration_since(UNIX_EPOCH).expect("Time went backwards");
+
+        // Get timestamp in seconds (u64)
+        let timestamp_secs = since_the_epoch.as_secs();
+        let temperature = Temperature {
+            celsius: 30.0 + i as f32 * 0.5,
+            timestamp_secs,
+        };
+
+        println!("   Main: Setting Temperature {}", temperature);
+
+        producer.set(temperature)?;
+
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    // Give time to slow tap to be able to observe the rest of the values
+    thread::sleep(Duration::from_millis(1000));
+
+    handle.detach()?;
+
+    Ok(())
+}
+
+async fn sensor_observer_fast(ctx: RuntimeContext, consumer: Consumer<Temperature>) {
+    let mut reader = consumer.subscribe();
+
+    while let Ok(temp) = reader.recv().await {
+        ctx.log()
+            .info(&format!("[fast] observed temperature {}", temp));
+    }
+}
+
+async fn sensor_observer_slow(ctx: RuntimeContext, consumer: Consumer<Temperature>) {
+    let mut reader = consumer.subscribe();
+    let time = ctx.time();
+
+    while let Ok(temp) = reader.recv().await {
+        ctx.log()
+            .info(&format!("[slow] observed temperature {}", temp));
+
+        time.sleep_millis(100).await;
+    }
+}


### PR DESCRIPTION
## Description

Adds the `hello-spmc-ring` example demonstrating the `SpmcRing` buffer through AimDB's synchronous API.

The example:

- registers a `Temperature` record backed by `BufferCfg::SpmcRing { capacity: 10 }`
- publishes sensor readings using a synchronous `SyncProducer`
- observes readings through configured fast and slow taps
- demonstrates how each subscriber maintains an independent read position in the shared bounded sequence
- shows the slow tap falling behind and later receiving every retained intermediate value in order
- documents the contrast with `hello-single-latest`, where intermediate updates may be replaced
- adds the example to the workspace, Makefile, and main README

## Related Issue

Closes #184

## Testing

The following commands completed successfully:

* `cargo fmt --all -- --check`
* `cargo check -p hello-single-latest`
* `cargo clippy -p hello-single-latest --all-targets -- -D warnings`
* `cargo run -p hello-single-latest`
* `make examples`

`make check` completed all preceding checks but failed at the existing `codegen-drift` step on macOS because of a BSD `sed` regular-expression compatibility error:

```text
sed: RE error: invalid repetition count(s)
make: *** [codegen-drift] Error 1
```

## Checklist

* [x] I have read the [[CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md)](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
* [x] My code follows the project's coding standards.
* [ ] I have added tests to cover my changes. Not applicable: this PR adds a runnable documentation example rather than new library behavior.
* [ ] All new and existing tests passed (`make check`). The command is currently blocked by the macOS `sed` compatibility issue described above.
* [x] I have updated the documentation accordingly.