### PR TITLE
Avoid cloning Embassy mailbox values

### DIFF
--- a/aimdb-embassy-adapter/src/buffer.rs
+++ b/aimdb-embassy-adapter/src/buffer.rs
@@ -47,7 +47,7 @@ use core::task::{Context, Poll};
 use aimdb_core::buffer::{Buffer, BufferCfg, BufferReader};
 use aimdb_core::DbError;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
-use embassy_sync::channel::Channel;
+use embassy_sync::channel::{Channel, TrySendError};
 use embassy_sync::pubsub::{PubSubChannel, Subscriber, WaitResult};
 use embassy_sync::watch::{Receiver as WatchReceiver, Watch};
 
@@ -205,11 +205,10 @@ impl<
             EmbassyBufferInner::Mailbox(channel) => {
                 // Try to send, if full, clear and try again (overwrite semantic)
                 let sender = channel.sender();
-                if sender.try_send(value.clone()).is_err() {
-                    // Channel is full (has 1 old message), try to receive it to make space
+                if let Err(TrySendError::Full(rejected)) = sender.try_send(value) {
+                    // A receiver may drain the old message before this call; retry either way.
                     let _ = channel.try_receive();
-                    // Now try to send again
-                    let _ = sender.try_send(value);
+                    let _ = sender.try_send(rejected);
                 }
             }
         }
@@ -633,6 +632,7 @@ impl<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     // ── Host-test scaffolding ────────────────────────────────────────────
     // The crate links `defmt` (workspace dep) and embassy-time's
@@ -669,6 +669,59 @@ mod tests {
 
         let cfg3 = BufferCfg::Mailbox;
         let _buf3: TestBuffer = Buffer::new(&cfg3);
+    }
+
+    #[test]
+    fn test_mailbox_push_does_not_clone_payload() {
+        #[derive(Debug)]
+        struct CloneCounted {
+            value: u32,
+            clones: Arc<AtomicUsize>,
+        }
+
+        impl Clone for CloneCounted {
+            fn clone(&self) -> Self {
+                self.clones.fetch_add(1, Ordering::Relaxed);
+                Self {
+                    value: self.value,
+                    clones: Arc::clone(&self.clones),
+                }
+            }
+        }
+
+        type TestBuffer = EmbassyBuffer<CloneCounted, 1, 1, 1, 1>;
+
+        let clones = Arc::new(AtomicUsize::new(0));
+        let buffer: TestBuffer = TestBuffer::new_mailbox();
+        let mut reader = buffer.subscribe();
+
+        Buffer::push(
+            &buffer,
+            CloneCounted {
+                value: 1,
+                clones: Arc::clone(&clones),
+            },
+        );
+        assert_eq!(
+            clones.load(Ordering::Relaxed),
+            0,
+            "empty-slot push must not clone"
+        );
+
+        Buffer::push(
+            &buffer,
+            CloneCounted {
+                value: 2,
+                clones: Arc::clone(&clones),
+            },
+        );
+        assert_eq!(
+            clones.load(Ordering::Relaxed),
+            0,
+            "full-slot overwrite must recover ownership without cloning"
+        );
+        assert_eq!(reader.try_recv().unwrap().value, 2);
+        assert!(matches!(reader.try_recv(), Err(DbError::BufferEmpty)));
     }
 
     // ========================================================================


### PR DESCRIPTION
## Description

The Embassy mailbox push path cloned every value before its first `try_send`, even when the single slot was empty. Recover the rejected value from `TrySendError::Full` instead, drain the stale slot opportunistically, and retry with the same owned value.

The retry remains unconditional after a full result, preserving the race where a receiver drains the old item between the failed send and the overwrite attempt. Single-slot latest-value-wins behavior is unchanged.

A clone-counting regression verifies zero payload clones for both an empty-slot push and a full-slot overwrite.

## Related Issue

- Closes #186

## Verification

- Exact clone-counting regression: 1 passed
- Full `aimdb-embassy-adapter`: 16 unit, 3 connector, 1 session, and 4 doctests passed; 1 doctest ignored
- Strict adapter library clippy with `-D warnings`: passed
- `cargo fmt -p aimdb-embassy-adapter -- --check`: passed
- `git diff --check`: passed

The embedded `thumbv7em-none-eabihf` check could not run on this host because the installed Homebrew Rust toolchain has no `rustup` or embedded target (`E0463: can't find crate for core`). The repository-wide all-targets clippy also reaches an unrelated existing `default_constructed_unit_structs` lint in `tests/session_smoke.rs:115`; the changed library target is clean.

## Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed (`make check`).
- [x] Documentation changes are not required for this internal performance fix.
