### PR TITLE
feat(core): add direct JSON byte paths for remote access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   codec replaces both the owned and scratch serializers, so changing a route
   from bounded postcard to owned JSON cannot retain stale postcard output.
 
+### Added — direct JSON remote-access payloads
+
+- **Issue #196:** state `record.get` and AimX subscription events now serialize
+  typed records directly to JSON bytes and hand them to the existing opaque
+  `Payload`/`RawValue` envelope path, avoiding an intermediate
+  `serde_json::Value`. All public tree APIs and manual codec/reader
+  implementations remain compatible through defaulted byte methods; AimX v2,
+  write parsing/safety, ring drain fallback, WebSocket/client/CLI/MCP/WASM
+  behavior and `no_std + alloc` support are unchanged. The focused in-memory
+  production-boundary gate records 16 → 6 allocation calls per reply/event and
+  a 1.55x–1.61x Criterion slope-estimate speedup on the measured host.
+  ([aimdb-core](aimdb-core/CHANGELOG.md))
+
 ### Changed — Design 038 simplification pass (breaking)
 
 Implementation of the accepted items of [design 038](docs/design/038-technical-debt-and-simplification-review.md)

--- a/aimdb-bench/Cargo.toml
+++ b/aimdb-bench/Cargo.toml
@@ -44,6 +44,14 @@ harness = false
 name = "b0_alloc_linkable"
 harness = false
 
+[[bench]]
+name = "b0_alloc_remote_json"
+harness = false
+
+[[bench]]
+name = "b1_b2_remote_json"
+harness = false
+
 [features]
 default = ["std"]
 # Gates `profiles`/`reports`/`harness` and their criterion/serde_json/

--- a/aimdb-bench/README.md
+++ b/aimdb-bench/README.md
@@ -22,6 +22,10 @@ Plus two informational benches that exercise the full runner-driven pipeline.
 - **Tokio** — `b0_alloc_tokio`, `b1_b2_tokio` (host).
 - **postcard `Linkable` codec** — `b0_alloc_linkable` (host). This isolates the
   issue #177 `encode_into` seam; it is not a whole-connector allocation claim.
+- **type-erased remote JSON** — `b0_alloc_remote_json` and
+  `b1_b2_remote_json` (host). These compare issue #196's direct JSON bytes with
+  the compatibility `serde_json::Value` tree through the real typed record,
+  buffer, `Payload` and AimX envelope. Socket I/O and scheduling are excluded.
 - **Embassy** — `b0_alloc_embassy`, `b1_b2_embassy`
   (host). These drive the real [`EmbassyBuffer`] backend via
   `futures::executor::block_on` over embassy-sync's poll methods — no
@@ -58,8 +62,14 @@ cargo bench -p aimdb-bench --bench b0_alloc_tokio
 # B0 — allocation gate (Postcard Linkable::encode_into codec seam)
 cargo bench -p aimdb-bench --bench b0_alloc_linkable
 
+# B0 — direct-vs-tree JSON allocations through the AimX envelope boundary
+cargo bench -p aimdb-bench --bench b0_alloc_remote_json
+
 # B1 + B2 — latency (time/iter) and throughput (msgs/sec), one Criterion suite
 cargo bench -p aimdb-bench --bench b1_b2_tokio
+
+# B1 + B2 — direct-vs-tree JSON latency at the same in-memory boundary
+cargo bench -p aimdb-bench --bench b1_b2_remote_json
 
 # Embassy buffer backend (host) — same classes
 cargo bench -p aimdb-bench --bench b0_alloc_embassy
@@ -112,6 +122,8 @@ The committed baseline lives in `data/baselines/b0_alloc_tokio.json`. When a cha
 `b0_alloc_linkable` warms up for 1,000 iterations, then measures 10,000 generated-shape postcard `Linkable::encode_into` calls into one stack buffer.
 The required result is **0 allocation calls and 0 allocated bytes**. It isolates the codec seam: `SerializedReader` still returns a boxed future, dynamic topics may allocate and connector implementations may copy payload ownership after the core pump lends them the scratch slice.
 
+`b0_alloc_remote_json` warms the production in-memory `record.get` and subscription-event paths, then compares 5000 tree/direct operations. Its gate is relative: direct JSON must reduce both allocation calls and allocated bytes. It does not require zero allocations because the owned JSON `Vec`, `Arc<[u8]>` payload and AimX envelope serialization still own storage.
+
 > **Embassy eager registration (design 039 F8/F9).** An Embassy `SpmcRing` reader registers its embassy `Subscriber` eagerly, at `subscribe()` time — matching Tokio's `broadcast` — so no separate priming step is needed before the first `push`.
 
 **Noise reduction:** a `new_current_thread()` Tokio executor is used so there are no work-stealing threads and Tokio's scheduler does not allocate per-poll in the hot path.
@@ -134,5 +146,8 @@ Use them as a comparison point, not a regression gate. If they regress, `b0_allo
 - B0 is a counter, not a memory profiler. It reports allocation count and byte total; not per-call precision or heap fragmentation.
 - B0's `bytes_per_msg` measures AimDB-added per-message heap allocations, not the message payload. Pre-W8 this was the `Box::pin` boxed `recv()` future (a single ~144 B type shared across all three buffer arms, hence identical byte counts); since design 037 / W8 the consume path is poll-based and this is **0 B/msg** on the clean path. A nonzero value flags a regression — e.g. the broadcast error path still allocates its `buffer_name` string, so a B0 run that triggers `BufferLagged`/`BufferClosed` will report > 0.
 - Criterion p99 can vary ±5–10% on noisy CI runners. Use p50 medians for trend comparisons.
+- The remote JSON benches stop at an encoded in-memory AimX frame. They do not
+  include connector queues, wakeups, syscalls, DMA/interrupt work or physical
+  wire time, so their speedup is not a whole-system latency claim.
 - Always specify `--release` or debug build consistently when comparing runs; optimizations differ by 5–50×.
 - `b_alloc_pipeline` uses a paced source: per-message pace tokens and notification channels. The coordination overhead is included in the measured window.

--- a/aimdb-bench/benches/b0_alloc_remote_json.rs
+++ b/aimdb-bench/benches/b0_alloc_remote_json.rs
@@ -1,0 +1,175 @@
+//! B0-Remote-JSON — allocation comparison for issue #196.
+//!
+//! Measures the real typed-record-to-AimX-envelope in-memory boundary for a
+//! canonical `record.get` and one subscription event. Socket I/O, scheduling,
+//! and physical transport are deliberately excluded.
+
+use std::hint::black_box;
+
+use aimdb_bench::alloc::{reset, snapshot};
+use aimdb_bench::remote_json::{verify_remote_json_paths, RemoteJsonHarness, RemoteJsonPath};
+
+const WARMUP_ITERS: usize = 500;
+const MEASURE_ITERS: usize = 5_000;
+const ALLOCATOR_PROBE_BYTES: usize = 64;
+
+#[global_allocator]
+static GLOBAL: aimdb_bench::alloc::CountingAllocator<std::alloc::System> =
+    aimdb_bench::alloc::CountingAllocator(std::alloc::System);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Operation {
+    RecordGet,
+    SubscriptionEvent,
+}
+
+impl Operation {
+    const ALL: [Self; 2] = [Self::RecordGet, Self::SubscriptionEvent];
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::RecordGet => "record_get",
+            Self::SubscriptionEvent => "subscription_event",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct AllocationRow {
+    operation: Operation,
+    path: RemoteJsonPath,
+    frame_bytes: usize,
+    allocations: u64,
+    allocated_bytes: u64,
+}
+
+fn exercise(
+    harness: &mut RemoteJsonHarness,
+    path: RemoteJsonPath,
+    operation: Operation,
+    iterations: usize,
+) -> usize {
+    let mut frame_bytes = 0;
+    for _ in 0..iterations {
+        let frame = match operation {
+            Operation::RecordGet => harness.record_get_frame(path),
+            Operation::SubscriptionEvent => harness.subscription_event_frame(path),
+        };
+        frame_bytes = black_box(frame.len());
+        black_box(frame);
+    }
+    frame_bytes
+}
+
+fn measure(
+    harness: &mut RemoteJsonHarness,
+    path: RemoteJsonPath,
+    operation: Operation,
+) -> AllocationRow {
+    exercise(harness, path, operation, WARMUP_ITERS);
+
+    reset();
+    let frame_bytes = exercise(harness, path, operation, MEASURE_ITERS);
+    let (allocations, allocated_bytes) = snapshot();
+
+    AllocationRow {
+        operation,
+        path,
+        frame_bytes,
+        allocations,
+        allocated_bytes,
+    }
+}
+
+/// Prove this bench binary's global allocator reaches the shared counters.
+fn allocation_counter_positive_control() -> (u64, u64) {
+    reset();
+
+    let mut probe = Vec::<u8>::with_capacity(black_box(ALLOCATOR_PROBE_BYTES));
+    probe.push(black_box(0xA5));
+    black_box(probe.as_slice());
+
+    let measured = snapshot();
+    assert!(
+        measured.0 >= 1,
+        "allocation counter missed the deliberate Vec allocation"
+    );
+    assert!(
+        measured.1 >= ALLOCATOR_PROBE_BYTES as u64,
+        "byte counter missed the deliberate Vec capacity"
+    );
+
+    drop(probe);
+    measured
+}
+
+fn main() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("remote JSON bench runtime");
+    runtime.block_on(verify_remote_json_paths());
+
+    let mut rows = Vec::with_capacity(Operation::ALL.len() * 2);
+    for operation in Operation::ALL {
+        let mut tree = runtime.block_on(RemoteJsonHarness::new());
+        rows.push(measure(&mut tree, RemoteJsonPath::Tree, operation));
+
+        let mut direct = runtime.block_on(RemoteJsonHarness::new());
+        rows.push(measure(&mut direct, RemoteJsonPath::Direct, operation));
+    }
+
+    for operation in Operation::ALL {
+        let tree = rows
+            .iter()
+            .find(|row| row.operation == operation && row.path == RemoteJsonPath::Tree)
+            .unwrap();
+        let direct = rows
+            .iter()
+            .find(|row| row.operation == operation && row.path == RemoteJsonPath::Direct)
+            .unwrap();
+
+        assert!(
+            direct.allocations < tree.allocations,
+            "{} direct path did not reduce allocation calls: tree={} direct={}",
+            operation.name(),
+            tree.allocations,
+            direct.allocations
+        );
+        assert!(
+            direct.allocated_bytes < tree.allocated_bytes,
+            "{} direct path did not reduce allocated bytes: tree={} direct={}",
+            operation.name(),
+            tree.allocated_bytes,
+            direct.allocated_bytes
+        );
+    }
+
+    let (probe_allocations, probe_bytes) = allocation_counter_positive_control();
+
+    println!("=== B0 direct JSON production-boundary comparison ===");
+    println!("Measured iterations per row: {MEASURE_ITERS}");
+    println!("Allocator probe: {probe_allocations} calls / {probe_bytes} bytes");
+    println!(
+        "{:<20} {:<8} {:>11} {:>12} {:>15} {:>12} {:>14}",
+        "operation",
+        "path",
+        "frame_bytes",
+        "allocations",
+        "allocated_bytes",
+        "allocs/op",
+        "bytes/op"
+    );
+
+    for row in rows {
+        println!(
+            "{:<20} {:<8} {:>11} {:>12} {:>15} {:>12.3} {:>14.1}",
+            row.operation.name(),
+            row.path.name(),
+            row.frame_bytes,
+            row.allocations,
+            row.allocated_bytes,
+            row.allocations as f64 / MEASURE_ITERS as f64,
+            row.allocated_bytes as f64 / MEASURE_ITERS as f64,
+        );
+    }
+}

--- a/aimdb-bench/benches/b1_b2_remote_json.rs
+++ b/aimdb-bench/benches/b1_b2_remote_json.rs
@@ -1,0 +1,81 @@
+//! B1/B2-Remote-JSON — latency and throughput for issue #196.
+//!
+//! Compares the compatibility JSON-tree route with direct JSON bytes through
+//! the real typed record, runtime buffer, opaque payload, and AimX envelope.
+//! Transport I/O and scheduler wakeups are outside the measured window.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use aimdb_bench::remote_json::{verify_remote_json_paths, RemoteJsonHarness, RemoteJsonPath};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+fn remote_json(criterion: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("remote JSON bench runtime");
+    runtime.block_on(verify_remote_json_paths());
+
+    let mut group = criterion.benchmark_group("remote_json");
+    group.throughput(Throughput::Elements(1));
+
+    let mut tree_get = runtime.block_on(RemoteJsonHarness::new());
+    group.bench_function(
+        BenchmarkId::new("record_get", RemoteJsonPath::Tree.name()),
+        |bencher| {
+            bencher.iter(|| {
+                let frame = tree_get.record_get_frame(RemoteJsonPath::Tree);
+                black_box(frame);
+            });
+        },
+    );
+
+    let mut direct_get = runtime.block_on(RemoteJsonHarness::new());
+    group.bench_function(
+        BenchmarkId::new("record_get", RemoteJsonPath::Direct.name()),
+        |bencher| {
+            bencher.iter(|| {
+                let frame = direct_get.record_get_frame(RemoteJsonPath::Direct);
+                black_box(frame);
+            });
+        },
+    );
+
+    let mut tree_event = runtime.block_on(RemoteJsonHarness::new());
+    group.bench_function(
+        BenchmarkId::new("subscription_event", RemoteJsonPath::Tree.name()),
+        |bencher| {
+            bencher.iter(|| {
+                let frame = tree_event.subscription_event_frame(RemoteJsonPath::Tree);
+                black_box(frame);
+            });
+        },
+    );
+
+    let mut direct_event = runtime.block_on(RemoteJsonHarness::new());
+    group.bench_function(
+        BenchmarkId::new("subscription_event", RemoteJsonPath::Direct.name()),
+        |bencher| {
+            bencher.iter(|| {
+                let frame = direct_event.subscription_event_frame(RemoteJsonPath::Direct);
+                black_box(frame);
+            });
+        },
+    );
+
+    group.finish();
+}
+
+fn configure() -> Criterion {
+    Criterion::default()
+        .sample_size(40)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(2))
+}
+
+criterion_group! {
+    name = benches;
+    config = configure();
+    targets = remote_json
+}
+criterion_main!(benches);

--- a/aimdb-bench/src/lib.rs
+++ b/aimdb-bench/src/lib.rs
@@ -22,6 +22,8 @@
 //! | `benches/b1_b2_tokio.rs`          | B1+B2 | Latency (time/iter) + throughput (Tokio) |
 //! | `benches/b0_alloc_embassy.rs`     | B0    | Per-message allocation (Embassy buffer)  |
 //! | `benches/b0_alloc_linkable.rs`    | B0    | Postcard `Linkable::encode_into` allocs  |
+//! | `benches/b0_alloc_remote_json.rs` | B0    | Direct-vs-tree AimX JSON allocations     |
+//! | `benches/b1_b2_remote_json.rs`     | B1+B2 | Direct-vs-tree AimX JSON latency         |
 //! | `benches/b1_b2_embassy.rs`        | B1+B2 | Latency (time/iter) + throughput (Embassy)|
 //! | `benches/b_alloc_pipeline.rs`     | info  | Per-message allocation (runner pipeline) |
 //! | `benches/b_runner_pipeline.rs`    | info  | Runner pipeline throughput (Criterion)   |
@@ -40,5 +42,7 @@ pub mod payloads;
 #[cfg(feature = "std")]
 pub mod profiles;
 pub mod profiles_embassy;
+#[cfg(feature = "std")]
+pub mod remote_json;
 #[cfg(feature = "std")]
 pub mod reports;

--- a/aimdb-bench/src/remote_json.rs
+++ b/aimdb-bench/src/remote_json.rs
@@ -1,0 +1,221 @@
+//! Production-path harness for issue #196's direct JSON-byte optimization.
+//!
+//! This intentionally stops at the in-memory AimX envelope boundary. It runs
+//! the real `TypedRecord` codec, runtime buffer, type-erased reader, `Payload`,
+//! and `AimxCodec`; it does not include a socket, scheduler wakeup, or physical
+//! transport.
+
+use std::sync::Arc;
+
+use aimdb_core::buffer::{BufferCfg, JsonBufferReader};
+use aimdb_core::session::aimx::AimxCodec;
+use aimdb_core::{
+    AimDb, AimDbBuilder, EnvelopeCodec, Outbound, Payload, Producer, RecordRegistrar,
+};
+use aimdb_tokio_adapter::{TokioAdapter, TokioRecordRegistrarExt};
+use serde::{Deserialize, Serialize};
+
+const RECORD_KEY: &str = "bench.remote-json";
+
+/// The two record serialization paths compared by the focused benchmarks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RemoteJsonPath {
+    /// Compatibility path: `T -> serde_json::Value -> JSON bytes`.
+    Tree,
+    /// Issue #196 path: `T -> JSON bytes`.
+    Direct,
+}
+
+impl RemoteJsonPath {
+    /// Stable label used by benchmark output.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Tree => "tree",
+            Self::Direct => "direct",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+struct Coordinates {
+    latitude_e6: i32,
+    longitude_e6: i32,
+}
+
+/// Heap-free typed fixture so measured allocations belong to JSON/session
+/// representation work rather than cloning the record itself.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+struct RemoteJsonSample {
+    sequence: u64,
+    temperature_c: f32,
+    quality: Option<u16>,
+    flags: [bool; 4],
+    coordinates: Coordinates,
+}
+
+fn sample(sequence: u64) -> RemoteJsonSample {
+    RemoteJsonSample {
+        sequence,
+        temperature_c: 23.75,
+        quality: Some(97),
+        flags: [true, false, true, true],
+        coordinates: Coordinates {
+            latitude_e6: 10_776_900,
+            longitude_e6: 106_700_900,
+        },
+    }
+}
+
+/// Reusable production-path state for allocation and latency measurements.
+pub struct RemoteJsonHarness {
+    db: AimDb,
+    producer: Producer<RemoteJsonSample>,
+    reader: Box<dyn JsonBufferReader + Send>,
+    sequence: u64,
+    frame: Vec<u8>,
+}
+
+impl RemoteJsonHarness {
+    /// Build one database with a remote-accessible `SingleLatest` record.
+    ///
+    /// The returned runner is intentionally not started: all measured
+    /// operations are synchronous buffer/codec/session work and no services
+    /// are registered.
+    pub async fn new() -> Self {
+        let mut builder = AimDbBuilder::new().runtime(Arc::new(TokioAdapter));
+        builder.configure::<RemoteJsonSample>(RECORD_KEY, |record: &mut RecordRegistrar<_>| {
+            record.buffer(BufferCfg::SingleLatest).with_remote_access();
+        });
+
+        let (db, _runner) = builder.build().await.expect("remote JSON bench db");
+        let producer = db
+            .producer::<RemoteJsonSample>(RECORD_KEY)
+            .expect("remote JSON bench producer");
+        producer.produce(sample(0));
+
+        let reader = {
+            let id = db
+                .inner()
+                .resolve_str(RECORD_KEY)
+                .expect("remote JSON bench record id");
+            db.inner()
+                .storage(id)
+                .expect("remote JSON bench record")
+                .json_access()
+                .expect("remote JSON access")
+                .subscribe_json()
+                .expect("remote JSON reader")
+        };
+
+        Self {
+            db,
+            producer,
+            reader,
+            sequence: 0,
+            frame: Vec::with_capacity(512),
+        }
+    }
+
+    /// Encode canonical latest state into a production AimX reply frame.
+    pub fn record_get_frame(&mut self, path: RemoteJsonPath) -> &[u8] {
+        let payload = match path {
+            RemoteJsonPath::Tree => {
+                let value = self
+                    .db
+                    .try_latest_as_json(RECORD_KEY)
+                    .expect("bench latest JSON tree");
+                Payload::from(serde_json::to_vec(&value).expect("bench tree serialization"))
+            }
+            RemoteJsonPath::Direct => Payload::from(
+                self.db
+                    .try_latest_as_json_bytes(RECORD_KEY)
+                    .expect("bench latest JSON bytes"),
+            ),
+        };
+
+        self.frame.clear();
+        AimxCodec
+            .encode(
+                Outbound::Reply {
+                    id: 1,
+                    result: Ok(payload),
+                },
+                &mut self.frame,
+            )
+            .expect("bench AimX reply");
+        &self.frame
+    }
+
+    /// Push one typed value, consume it through the type-erased subscription,
+    /// and encode a production AimX event frame.
+    pub fn subscription_event_frame(&mut self, path: RemoteJsonPath) -> &[u8] {
+        self.sequence = self.sequence.wrapping_add(1);
+        self.producer.produce(sample(self.sequence));
+
+        let payload = match path {
+            RemoteJsonPath::Tree => {
+                let value = self
+                    .reader
+                    .try_recv_json()
+                    .expect("bench subscription JSON tree");
+                Payload::from(serde_json::to_vec(&value).expect("bench tree serialization"))
+            }
+            RemoteJsonPath::Direct => Payload::from(
+                self.reader
+                    .try_recv_json_bytes()
+                    .expect("bench subscription JSON bytes"),
+            ),
+        };
+
+        self.frame.clear();
+        AimxCodec
+            .encode(
+                Outbound::Event {
+                    sub: "1",
+                    seq: self.sequence,
+                    data: payload,
+                },
+                &mut self.frame,
+            )
+            .expect("bench AimX event");
+        &self.frame
+    }
+}
+
+/// Assert that both paths produce equivalent JSON/AimX semantics.
+pub async fn verify_remote_json_paths() {
+    let mut tree = RemoteJsonHarness::new().await;
+    let mut direct = RemoteJsonHarness::new().await;
+
+    let tree_get: serde_json::Value =
+        serde_json::from_slice(tree.record_get_frame(RemoteJsonPath::Tree))
+            .expect("tree get frame");
+    let direct_get: serde_json::Value =
+        serde_json::from_slice(direct.record_get_frame(RemoteJsonPath::Direct))
+            .expect("direct get frame");
+    assert_eq!(tree_get, direct_get);
+
+    let tree_event: serde_json::Value =
+        serde_json::from_slice(tree.subscription_event_frame(RemoteJsonPath::Tree))
+            .expect("tree event frame");
+    let direct_event: serde_json::Value =
+        serde_json::from_slice(direct.subscription_event_frame(RemoteJsonPath::Direct))
+            .expect("direct event frame");
+    assert_eq!(tree_event, direct_event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn direct_and_tree_paths_have_equivalent_aimx_json() {
+        verify_remote_json_paths().await;
+    }
+
+    #[test]
+    fn path_names_are_stable() {
+        assert_eq!(RemoteJsonPath::Tree.name(), "tree");
+        assert_eq!(RemoteJsonPath::Direct.name(), "direct");
+    }
+}

--- a/aimdb-core/CHANGELOG.md
+++ b/aimdb-core/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Issue #196 — direct JSON bytes for type-erased remote reads.** The public
+  `RemoteSerialize`, `JsonCodec<T>`, `JsonRecordAccess` and
+  `JsonBufferReader` traits gain defaulted byte methods, preserving existing
+  manual implementations; the blanket Serde codec overrides them with direct
+  `to_vec`/`from_slice`. State `record.get` and subscription events now pass
+  owned JSON bytes into the existing opaque `Payload`/`RawValue` AimX path
+  without materializing an intermediate record `serde_json::Value`.
+  `RecordValue::as_json`, value-based APIs, custom codecs, AimX v2, ring-drain
+  fallback, write safety, lag/cancellation/backpressure behavior and
+  `no_std + alloc` remain unchanged. Focused production-boundary benchmarks
+  reduce allocation calls from 16 to 6 per reply/event; Criterion slope point
+  estimates show a 1.55x–1.61x in-memory record-to-envelope speedup on the
+  measured host.
 - **Issue #177 — bounded into-slice serialization for outbound links.** New
   `OutboundConnectorBuilder::with_serializer_into` and the additive
   `SerializedReader::recv_into`/`SerializedPayload` SPI let a fused typed reader

--- a/aimdb-core/Cargo.toml
+++ b/aimdb-core/Cargo.toml
@@ -35,10 +35,10 @@ alloc = ["serde"] # Enable heap in no_std
 # `RecordValue::as_json()`) plus the AimX remote-access data model
 # (`crate::remote`): record metadata + introspection (`RecordMetadata`,
 # `AimDb::list_records`), the JSON read/write/subscribe API
-# (`try_latest_as_json` / `set_record_from_json` / `JsonBufferReader`), and
-# the wire protocol/config/security/error types. The AimX *server* dispatch
-# (`session::aimx`) additionally needs `connector-session`. All compiles on
-# `no_std + alloc`.
+# (`try_latest_as_json[_bytes]` / `set_record_from_json` /
+# `JsonBufferReader`), and the wire protocol/config/security/error types. The
+# AimX *server* dispatch (`session::aimx`) additionally needs
+# `connector-session`. All compiles on `no_std + alloc`.
 remote = ["alloc", "serde_json"]
 
 # The connector-session substrate (`crate::session`): the dyn-safe trait set

--- a/aimdb-core/src/buffer/reader.rs
+++ b/aimdb-core/src/buffer/reader.rs
@@ -10,6 +10,8 @@
 //! The wrapped future is `Send` because the boxed reader is `Send`.
 
 use alloc::boxed::Box;
+#[cfg(feature = "remote")]
+use alloc::vec::Vec;
 use core::future::poll_fn;
 
 use crate::buffer::BufferReader;
@@ -56,9 +58,9 @@ impl<T: Clone + Send> Reader<T> {
 
 /// Owned, ergonomic handle over an erased [`JsonBufferReader`].
 ///
-/// Returned by `subscribe_json`. Awaiting `recv_json` is allocation-free: it
-/// wraps [`poll_recv_json`](JsonBufferReader::poll_recv_json) via
-/// `core::future::poll_fn` — no extra per-message box.
+/// Returned by `subscribe_json`. Awaiting `recv_json` or
+/// `recv_json_bytes` wraps the corresponding poll method via
+/// `core::future::poll_fn` — no extra per-message future box.
 #[cfg(feature = "remote")]
 pub struct JsonReader {
     inner: Box<dyn JsonBufferReader + Send>,
@@ -76,10 +78,22 @@ impl JsonReader {
         poll_fn(|cx| self.inner.poll_recv_json(cx)).await
     }
 
+    /// Receive the next value as owned JSON bytes.
+    pub async fn recv_json_bytes(&mut self) -> Result<Vec<u8>, DbError> {
+        poll_fn(|cx| self.inner.poll_recv_json_bytes(cx)).await
+    }
+
     /// Non-blocking receive as JSON — returns immediately.
     ///
     /// Returns `Err(DbError::BufferEmpty)` if no pending values.
     pub fn try_recv_json(&mut self) -> Result<serde_json::Value, DbError> {
         self.inner.try_recv_json()
+    }
+
+    /// Non-blocking receive as owned JSON bytes — returns immediately.
+    ///
+    /// Returns `Err(DbError::BufferEmpty)` if no pending values.
+    pub fn try_recv_json_bytes(&mut self) -> Result<Vec<u8>, DbError> {
+        self.inner.try_recv_json_bytes()
     }
 }

--- a/aimdb-core/src/buffer/traits.rs
+++ b/aimdb-core/src/buffer/traits.rs
@@ -8,6 +8,8 @@
 use core::task::{Context, Poll};
 
 use alloc::boxed::Box;
+#[cfg(feature = "remote")]
+use alloc::vec::Vec;
 
 use super::BufferCfg;
 use crate::DbError;
@@ -232,18 +234,19 @@ pub trait BufferReader<T: Clone + Send>: Send {
     fn try_recv(&mut self) -> Result<T, DbError>;
 }
 
-/// Reader trait for consuming JSON-serialized values from a buffer
+/// Reader trait for consuming JSON-serialized values from a buffer.
 ///
-/// Type-erased reader that subscribes to a typed buffer and emits values as
-/// `serde_json::Value`. Used by remote access protocol for subscriptions.
+/// Type-erased reader that subscribes to a typed buffer and emits either
+/// `serde_json::Value` or already-serialized JSON bytes. Used by the remote
+/// access protocol for subscriptions.
 ///
 /// This trait enables subscribing to a buffer without knowing the concrete type `T`
 /// at compile time, by serializing values to JSON on each poll.
 ///
 /// Object-safe and poll-based for the same reason as [`BufferReader`].
 /// Consumers use the [`JsonReader`](super::JsonReader) handle, whose
-/// `recv_json()` is `async` and wraps [`poll_recv_json`](JsonBufferReader::poll_recv_json)
-/// with no allocation.
+/// receive methods are `async` wrappers over the corresponding poll methods
+/// and do not box a per-message future.
 ///
 /// # Requirements
 /// - Record must be configured with `.with_remote_access()`
@@ -267,6 +270,32 @@ pub trait JsonBufferReader: Send {
     ///
     /// Returns `Err(DbError::BufferEmpty)` if no pending values.
     fn try_recv_json(&mut self) -> Result<serde_json::Value, DbError>;
+
+    /// Poll for the next value as owned JSON bytes.
+    ///
+    /// Existing implementations inherit a compatibility path that calls
+    /// [`poll_recv_json`](Self::poll_recv_json) and serializes the returned
+    /// tree. Typed record readers override this to encode `T` directly.
+    fn poll_recv_json_bytes(&mut self, cx: &mut Context<'_>) -> Poll<Result<Vec<u8>, DbError>> {
+        match self.poll_recv_json(cx) {
+            Poll::Ready(Ok(value)) => Poll::Ready(
+                serde_json::to_vec(&value)
+                    .map_err(|_| DbError::runtime_error("Failed to serialize value to JSON")),
+            ),
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    /// Non-blocking receive as owned JSON bytes.
+    ///
+    /// Existing implementations inherit a compatibility path through
+    /// [`try_recv_json`](Self::try_recv_json).
+    fn try_recv_json_bytes(&mut self) -> Result<Vec<u8>, DbError> {
+        let value = self.try_recv_json()?;
+        serde_json::to_vec(&value)
+            .map_err(|_| DbError::runtime_error("Failed to serialize value to JSON"))
+    }
 }
 
 /// Snapshot of buffer metrics at a point in time

--- a/aimdb-core/src/builder.rs
+++ b/aimdb-core/src/builder.rs
@@ -218,6 +218,22 @@ impl AimDbInner {
             .latest_json()
     }
 
+    /// Try to get a record's latest value as owned JSON bytes.
+    ///
+    /// This is the byte-oriented sibling of
+    /// [`try_latest_as_json`](Self::try_latest_as_json). The built-in Serde
+    /// codec serializes the typed record directly; compatibility codecs may
+    /// inherit a `Value`-based fallback.
+    #[cfg(feature = "remote")]
+    pub fn try_latest_as_json_bytes(&self, record_key: &str) -> Option<Vec<u8>> {
+        let id = self.resolve_str(record_key)?;
+        self.storages
+            .get(id.index())?
+            .record
+            .json_access()?
+            .latest_json_bytes()
+    }
+
     /// Sets a record value from JSON (remote access API)
     ///
     /// Deserializes the JSON value and writes it to the record's buffer.
@@ -1060,6 +1076,17 @@ impl AimDb {
     #[cfg(feature = "remote")]
     pub fn try_latest_as_json(&self, record_name: &str) -> Option<serde_json::Value> {
         self.inner.try_latest_as_json(record_name)
+    }
+
+    /// Try to get a record's latest value as owned JSON bytes.
+    ///
+    /// Semantics match [`try_latest_as_json`](Self::try_latest_as_json):
+    /// buffers without a canonical latest value (notably `SpmcRing`) return
+    /// `None`. AimX `record.get` retains its per-connection drain fallback for
+    /// those records.
+    #[cfg(feature = "remote")]
+    pub fn try_latest_as_json_bytes(&self, record_name: &str) -> Option<Vec<u8>> {
+        self.inner.try_latest_as_json_bytes(record_name)
     }
 
     /// Sets a record value from JSON (remote access API)

--- a/aimdb-core/src/codec.rs
+++ b/aimdb-core/src/codec.rs
@@ -1,9 +1,10 @@
 //! JSON codec for records (feature `remote`, no_std + alloc compatible).
 //!
 //! A record's value `T` often has to cross a type-erasure boundary into a wire
-//! format. AimX (std) crosses into `serde_json::Value`; so can a no_std
-//! connector or a local `record.latest()?.as_json()` call. This module
-//! provides that bridge without requiring `std` — `serde_json` runs on `alloc`
+//! format. AimX uses owned JSON bytes on its outbound record hot paths and
+//! `serde_json::Value` where a tree is still required; no_std connectors and
+//! local `record.latest()?.as_json()` calls use the same bridge. This module
+//! provides both forms without requiring `std` — `serde_json` runs on `alloc`
 //! alone, so embedded targets can opt in via the `remote` feature.
 //!
 //! Two layers:
@@ -22,6 +23,7 @@
 //!   `RecordValue::as_json` route through it. This mirrors the connector
 //!   layer's fused `SerializedSource` / `IngestFn` callbacks.
 
+use alloc::vec::Vec;
 use serde::{de::DeserializeOwned, Serialize};
 
 /// A record type that can be encoded to / decoded from the JSON wire format.
@@ -36,6 +38,27 @@ pub trait RemoteSerialize: Sized {
 
     /// Deserialize a JSON value into `Self`, or `None` on schema mismatch.
     fn from_json(value: &serde_json::Value) -> Option<Self>;
+
+    /// Serialize this value to owned JSON bytes.
+    ///
+    /// The default preserves compatibility with manual implementations by
+    /// routing through [`to_json`](Self::to_json). The blanket Serde
+    /// implementation overrides it with direct `T -> Vec<u8>` serialization,
+    /// avoiding an intermediate [`serde_json::Value`] tree.
+    fn to_json_vec(&self) -> Option<Vec<u8>> {
+        serde_json::to_vec(&self.to_json()?).ok()
+    }
+
+    /// Deserialize one complete JSON value from `bytes`.
+    ///
+    /// The default preserves compatibility with manual implementations by
+    /// parsing a [`serde_json::Value`] and calling
+    /// [`from_json`](Self::from_json). The blanket Serde implementation
+    /// overrides it with direct slice deserialization.
+    fn from_json_slice(bytes: &[u8]) -> Option<Self> {
+        let value = serde_json::from_slice(bytes).ok()?;
+        Self::from_json(&value)
+    }
 }
 
 impl<T> RemoteSerialize for T
@@ -48,6 +71,14 @@ where
 
     fn from_json(value: &serde_json::Value) -> Option<Self> {
         serde_json::from_value(value.clone()).ok()
+    }
+
+    fn to_json_vec(&self) -> Option<Vec<u8>> {
+        serde_json::to_vec(self).ok()
+    }
+
+    fn from_json_slice(bytes: &[u8]) -> Option<Self> {
+        serde_json::from_slice(bytes).ok()
     }
 }
 
@@ -63,6 +94,23 @@ pub trait JsonCodec<T>: Send + Sync {
 
     /// Decode a JSON value into `T`, or `None` on schema mismatch.
     fn decode(&self, value: &serde_json::Value) -> Option<T>;
+
+    /// Encode a typed value into owned JSON bytes.
+    ///
+    /// Defaulted through [`encode`](Self::encode) so existing custom codecs
+    /// remain source-compatible and retain their exact JSON-tree semantics.
+    fn encode_to_vec(&self, value: &T) -> Option<Vec<u8>> {
+        serde_json::to_vec(&self.encode(value)?).ok()
+    }
+
+    /// Decode one complete JSON value from a byte slice.
+    ///
+    /// Defaulted through [`decode`](Self::decode) so existing custom codecs
+    /// remain source-compatible.
+    fn decode_slice(&self, bytes: &[u8]) -> Option<T> {
+        let value = serde_json::from_slice(bytes).ok()?;
+        self.decode(&value)
+    }
 }
 
 /// Zero-sized serde-backed [`JsonCodec`].
@@ -79,5 +127,120 @@ impl<T: RemoteSerialize> JsonCodec<T> for SerdeJsonCodec {
 
     fn decode(&self, value: &serde_json::Value) -> Option<T> {
         T::from_json(value)
+    }
+
+    fn encode_to_vec(&self, value: &T) -> Option<Vec<u8>> {
+        value.to_json_vec()
+    }
+
+    fn decode_slice(&self, bytes: &[u8]) -> Option<T> {
+        T::from_json_slice(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::String;
+    use alloc::vec;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Fixture {
+        name: String,
+        optional: Option<u32>,
+        bytes: Vec<u8>,
+    }
+
+    struct TreeOnlyCodec;
+
+    impl JsonCodec<Fixture> for TreeOnlyCodec {
+        fn encode(&self, value: &Fixture) -> Option<serde_json::Value> {
+            serde_json::to_value(value).ok()
+        }
+
+        fn decode(&self, value: &serde_json::Value) -> Option<Fixture> {
+            serde_json::from_value(value.clone()).ok()
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ManualRemote(u64);
+
+    // Deliberately implements only the original required methods. This type
+    // does not implement Serde, proving the new byte methods are additive.
+    impl RemoteSerialize for ManualRemote {
+        fn to_json(&self) -> Option<serde_json::Value> {
+            Some(json!({ "value": self.0 }))
+        }
+
+        fn from_json(value: &serde_json::Value) -> Option<Self> {
+            Some(Self(value.get("value")?.as_u64()?))
+        }
+    }
+
+    fn fixture() -> Fixture {
+        Fixture {
+            name: "cảm biến \"ngoài trời\"".into(),
+            optional: None,
+            bytes: vec![0, 1, 127, 255],
+        }
+    }
+
+    #[test]
+    fn tree_only_codec_gets_default_byte_compatibility() {
+        let value = fixture();
+        let bytes = TreeOnlyCodec.encode_to_vec(&value).unwrap();
+
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&bytes).unwrap(),
+            TreeOnlyCodec.encode(&value).unwrap()
+        );
+        assert_eq!(TreeOnlyCodec.decode_slice(&bytes), Some(value));
+    }
+
+    #[test]
+    fn manual_remote_serialize_gets_default_byte_compatibility() {
+        let value = ManualRemote(42);
+        let bytes =
+            <SerdeJsonCodec as JsonCodec<ManualRemote>>::encode_to_vec(&SerdeJsonCodec, &value)
+                .unwrap();
+
+        assert_eq!(bytes, br#"{"value":42}"#);
+        assert_eq!(
+            <SerdeJsonCodec as JsonCodec<ManualRemote>>::decode_slice(&SerdeJsonCodec, &bytes),
+            Some(value)
+        );
+    }
+
+    #[test]
+    fn serde_codec_byte_path_matches_json_value_semantics() {
+        let value = fixture();
+        let bytes =
+            <SerdeJsonCodec as JsonCodec<Fixture>>::encode_to_vec(&SerdeJsonCodec, &value).unwrap();
+
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&bytes).unwrap(),
+            <SerdeJsonCodec as JsonCodec<Fixture>>::encode(&SerdeJsonCodec, &value).unwrap()
+        );
+        assert_eq!(
+            <SerdeJsonCodec as JsonCodec<Fixture>>::decode_slice(&SerdeJsonCodec, &bytes),
+            Some(value)
+        );
+    }
+
+    #[test]
+    fn serde_codec_rejects_malformed_trailing_and_mismatched_bytes() {
+        for invalid in [
+            br#"{"name":"truncated""#.as_slice(),
+            br#"{"name":"ok","optional":null,"bytes":[]} trailing"#.as_slice(),
+            br#"{"name":7,"optional":null,"bytes":[]}"#.as_slice(),
+        ] {
+            assert!(
+                <SerdeJsonCodec as JsonCodec<Fixture>>::decode_slice(&SerdeJsonCodec, invalid)
+                    .is_none()
+            );
+        }
     }
 }

--- a/aimdb-core/src/remote/stream.rs
+++ b/aimdb-core/src/remote/stream.rs
@@ -1,11 +1,11 @@
 //! Record-update streaming helper for AimX remote access.
 //!
 //! [`stream_record_updates`] adapts a record's [`JsonBufferReader`] into a
-//! plain [`Stream`] of JSON values. Cancellation is by `drop`; backpressure
-//! is the underlying buffer's responsibility. The handler holds the
-//! returned stream inside its per-subscription future so that the
-//! connection's `FuturesUnordered` is the sole owner of the subscription's
-//! lifecycle.
+//! plain [`Stream`] of owned JSON [`Payload`](crate::session::Payload)s.
+//! Cancellation is by `drop`; backpressure is the underlying buffer's
+//! responsibility. The handler holds the returned stream inside its
+//! per-subscription future so that the connection's `FuturesUnordered` is the
+//! sole owner of the subscription's lifecycle.
 
 use alloc::string::ToString;
 
@@ -14,7 +14,7 @@ use crate::{AimDb, DbError, DbResult};
 use futures_core::Stream;
 use futures_util::stream::unfold;
 
-/// Subscribe to a record and yield each update as a JSON value.
+/// Subscribe to a record and yield each update as an opaque JSON payload.
 ///
 /// The returned stream owns the underlying [`JsonBufferReader`]; dropping
 /// it cancels the subscription. Lag (`BufferLagged`) is logged via
@@ -29,7 +29,7 @@ use futures_util::stream::unfold;
 pub(crate) fn stream_record_updates(
     db: &AimDb,
     record_key: &str,
-) -> DbResult<impl Stream<Item = serde_json::Value> + Send + 'static> {
+) -> DbResult<impl Stream<Item = crate::session::Payload> + Send + 'static> {
     let inner = db.inner();
     let id = inner
         .resolve_str(record_key)
@@ -56,8 +56,10 @@ pub(crate) fn stream_record_updates(
 
     Ok(unfold(state, |(mut reader, key)| async move {
         loop {
-            match reader.recv_json().await {
-                Ok(value) => return Some((value, (reader, key))),
+            match reader.recv_json_bytes().await {
+                Ok(bytes) => {
+                    return Some((crate::session::Payload::from(bytes), (reader, key)));
+                }
                 Err(DbError::BufferLagged { lag_count, .. }) => {
                     log_warn!(
                         "stream_record_updates: record '{}' subscription lagged by {} messages",
@@ -128,8 +130,8 @@ mod tests {
 
         let stream = unfold(reader, |mut reader| async move {
             loop {
-                match reader.recv_json().await {
-                    Ok(v) => return Some((v, reader)),
+                match reader.recv_json_bytes().await {
+                    Ok(bytes) => return Some((bytes, reader)),
                     Err(DbError::BufferLagged { .. }) => continue,
                     Err(DbError::BufferClosed { .. }) => return None,
                     Err(_) => return None,
@@ -139,7 +141,13 @@ mod tests {
 
         let values: Vec<_> = stream.collect().await;
         assert_eq!(values.len(), 2);
-        assert_eq!(values[0], serde_json::json!({"v": 1}));
-        assert_eq!(values[1], serde_json::json!({"v": 2}));
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&values[0]).unwrap(),
+            serde_json::json!({"v": 1})
+        );
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&values[1]).unwrap(),
+            serde_json::json!({"v": 2})
+        );
     }
 }

--- a/aimdb-core/src/session/aimx/dispatch.rs
+++ b/aimdb-core/src/session/aimx/dispatch.rs
@@ -25,7 +25,6 @@ use alloc::vec;
 use alloc::vec::Vec;
 use hashbrown::HashMap;
 
-use futures_util::StreamExt;
 use serde_json::{json, Value};
 
 use crate::buffer::JsonBufferReader;
@@ -83,6 +82,22 @@ struct AimxSession {
     drain_readers: HashMap<String, Box<dyn JsonBufferReader + Send>>,
 }
 
+/// Internal dispatch result. Most methods still build a JSON tree; hot record
+/// paths can hand already-serialized JSON to the session engine.
+enum DispatchReply {
+    Value(Value),
+    RawJson(Payload),
+}
+
+impl DispatchReply {
+    fn into_payload(self) -> Payload {
+        match self {
+            Self::Value(value) => to_payload(&value),
+            Self::RawJson(payload) => payload,
+        }
+    }
+}
+
 impl Session for AimxSession {
     fn call<'a>(
         &'a mut self,
@@ -93,7 +108,7 @@ impl Session for AimxSession {
             let params: Value = serde_json::from_slice(&params).unwrap_or(Value::Null);
             self.dispatch_call(method, params)
                 .await
-                .map(|v| to_payload(&v))
+                .map(DispatchReply::into_payload)
         })
     }
 
@@ -106,7 +121,7 @@ impl Session for AimxSession {
         Box::pin(async move {
             let stream = crate::remote::stream::stream_record_updates(&self.db, topic)
                 .map_err(map_db_err)?;
-            Ok(Box::pin(stream.map(|v| to_payload(&v))) as BoxStream<'static, Payload>)
+            Ok(Box::pin(stream) as BoxStream<'static, Payload>)
         })
     }
 
@@ -131,15 +146,20 @@ impl Session for AimxSession {
 }
 
 impl AimxSession {
-    /// Match the method and produce its JSON result (or an [`RpcError`]).
-    async fn dispatch_call(&mut self, method: &str, params: Value) -> Result<Value, RpcError> {
-        match method {
+    /// Match the method and produce a tree or already-serialized JSON reply.
+    async fn dispatch_call(
+        &mut self,
+        method: &str,
+        params: Value,
+    ) -> Result<DispatchReply, RpcError> {
+        if method == "record.get" {
+            let name = str_field(&params, "name").ok_or(RpcError::NotFound)?;
+            return self.record_get(&name).map(DispatchReply::RawJson);
+        }
+
+        let value = match method {
             "hello" => Ok(self.welcome()),
             "record.list" => Ok(json!(self.db.list_records())),
-            "record.get" => {
-                let name = str_field(&params, "name").ok_or(RpcError::NotFound)?;
-                self.record_get(&name)
-            }
             "record.set" => self.record_set(params),
             "record.drain" => self.record_drain(params),
             "record.query" => self
@@ -162,7 +182,9 @@ impl AimxSession {
                 Ok(json!({ "reset": true }))
             }
             _ => Err(RpcError::NotFound),
-        }
+        }?;
+
+        Ok(DispatchReply::Value(value))
     }
 
     /// `record.set` (RPC): permission-checked write that echoes the new value.
@@ -183,7 +205,8 @@ impl AimxSession {
     /// `record.get`: the record's current value.
     ///
     /// A `SingleLatest`/state record exposes a non-destructive canonical latest
-    /// ([`try_latest_as_json`](crate::AimDb::try_latest_as_json)). A ring
+    /// ([`try_latest_as_json_bytes`](crate::AimDb::try_latest_as_json_bytes)).
+    /// A ring
     /// ([`SpmcRing`](crate::buffer::BufferCfg::SpmcRing)) has none, so we fall back
     /// to the connection's drain cursor and return the **most recent** available
     /// value. Two consequences of that fallback: it *advances the shared drain
@@ -191,13 +214,14 @@ impl AimxSession {
     /// and it yields `NotFound` until the ring produces a value *after* the cursor
     /// is first opened (a fresh broadcast reader starts at the tail). Use
     /// `record.drain` for a ring's full backlog.
-    fn record_get(&mut self, name: &str) -> Result<Value, RpcError> {
-        if let Some(v) = self.db.try_latest_as_json(name) {
-            return Ok(v);
+    fn record_get(&mut self, name: &str) -> Result<Payload, RpcError> {
+        if let Some(bytes) = self.db.try_latest_as_json_bytes(name) {
+            return Ok(Payload::from(bytes));
         }
         // Ring fallback: drain to the newest currently-available value (or NotFound).
         self.drain_values(name, usize::MAX)?
             .pop()
+            .map(|value| to_payload(&value))
             .ok_or(RpcError::NotFound)
     }
 

--- a/aimdb-core/src/typed_api.rs
+++ b/aimdb-core/src/typed_api.rs
@@ -659,8 +659,8 @@ where
 
     /// Installs the JSON codec for this record (feature `remote`)
     ///
-    /// Enables `record.latest()?.as_json()`, and on `std` the AimX `record.get`
-    /// / `set` / `subscribe` protocol. Requires `T: RemoteSerialize`
+    /// Enables `record.latest()?.as_json()` and the AimX `record.get` / `set` /
+    /// `subscribe` protocol. Requires `T: RemoteSerialize`
     /// (blanket-impl'd for every `Serialize + DeserializeOwned` type). Works on
     /// no_std + alloc.
     #[cfg(feature = "remote")]

--- a/aimdb-core/src/typed_record.rs
+++ b/aimdb-core/src/typed_record.rs
@@ -12,7 +12,8 @@
 //!   and `record.latest()?.as_json()` reads it.
 //! - **`remote`**: record metadata (`collect_metadata` → `RecordMetadata`,
 //!   the `writable` flag) plus the type-erased JSON read/write/subscribe methods
-//!   (`latest_json` / `set_from_json` / `subscribe_json`) used by the AimX server.
+//!   (`latest_json[_bytes]` / `set_from_json[_bytes]` / `subscribe_json`) used
+//!   by the AimX server.
 //!
 //! Without `remote`, use `record.latest()` + `Deref` for value access and
 //! implement custom serialization for embedded protocols (CBOR, MessagePack, etc.).
@@ -57,10 +58,11 @@ use crate::buffer::DynBuffer;
 #[cfg(feature = "remote")]
 type RecordCodec<T> = Arc<dyn crate::codec::JsonCodec<T>>;
 
-/// Wrapper for a record's latest value with optional serialization
+/// Wrapper for a record's latest value with optional serialization.
 ///
 /// Created by `TypedRecord::latest()`. Core methods (`get()`, `into_inner()`, `Deref`) work in
-/// both std and no_std. JSON serialization (`.as_json()`) requires std feature.
+/// both std and no_std. JSON serialization (`.as_json()`) requires the
+/// `remote` feature.
 pub struct RecordValue<T> {
     value: T,
     #[cfg(feature = "remote")]
@@ -110,13 +112,13 @@ impl<T> core::ops::Deref for RecordValue<T> {
     }
 }
 
-/// Adapter that wraps a typed BufferReader and serializes values to JSON (std only)
+/// Adapter that wraps a typed `BufferReader` and serializes values to JSON.
 ///
 /// Bridges the gap between typed buffers and type-erased JSON streaming for
-/// remote access subscriptions. Each `recv_json()` call:
+/// remote access subscriptions. Each receive:
 /// 1. Receives a typed value `T` from the buffer
-/// 2. Serializes it to JSON using the configured serializer
-/// 3. Returns the JSON value
+/// 2. Serializes it through the configured codec
+/// 3. Returns either a JSON tree (compatibility API) or owned JSON bytes
 ///
 /// Used internally by `TypedRecord::subscribe_json()`.
 #[cfg(feature = "remote")]
@@ -153,6 +155,28 @@ impl<T: Clone + Send + 'static> crate::buffer::JsonBufferReader for JsonReaderAd
         // Serialize to JSON using the configured codec
         self.codec
             .encode(&value)
+            .ok_or_else(|| crate::DbError::runtime_error("Failed to serialize value to JSON"))
+    }
+
+    fn poll_recv_json_bytes(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Vec<u8>, crate::DbError>> {
+        match self.inner.poll_recv(cx) {
+            Poll::Ready(Ok(value)) => {
+                Poll::Ready(self.codec.encode_to_vec(&value).ok_or_else(|| {
+                    crate::DbError::runtime_error("Failed to serialize value to JSON")
+                }))
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn try_recv_json_bytes(&mut self) -> Result<Vec<u8>, crate::DbError> {
+        let value = self.inner.try_recv()?;
+        self.codec
+            .encode_to_vec(&value)
             .ok_or_else(|| crate::DbError::runtime_error("Failed to serialize value to JSON"))
     }
 }
@@ -318,6 +342,15 @@ pub trait JsonRecordAccess {
     /// Used internally by remote access protocol. **Users should use `record.latest()?.as_json()`.**
     fn latest_json(&self) -> Option<serde_json::Value>;
 
+    /// Returns owned JSON bytes for type-erased remote access.
+    ///
+    /// Existing implementations inherit a compatibility path through
+    /// [`latest_json`](Self::latest_json). `TypedRecord<T>` overrides this and
+    /// asks its codec to encode `T` directly.
+    fn latest_json_bytes(&self) -> Option<Vec<u8>> {
+        serde_json::to_vec(&self.latest_json()?).ok()
+    }
+
     /// Subscribe to record updates as JSON stream
     ///
     /// Creates a type-erased subscription that emits `serde_json::Value` instead of
@@ -360,6 +393,18 @@ pub trait JsonRecordAccess {
     /// - Record not configured with buffer
     /// - Record not configured with `.with_remote_access()`
     fn set_from_json(&self, json_value: serde_json::Value) -> crate::DbResult<()>;
+
+    /// Sets a record from one complete JSON value encoded as bytes.
+    ///
+    /// Existing implementations inherit a parser-backed compatibility path
+    /// through [`set_from_json`](Self::set_from_json). This accepts the exact
+    /// record value, not an AimX request/write wrapper; the wire dispatch keeps
+    /// wrapper extraction on its existing tree path.
+    fn set_from_json_bytes(&self, bytes: &[u8]) -> crate::DbResult<()> {
+        let value = serde_json::from_slice(bytes)
+            .map_err(|_| crate::DbError::runtime_error("Failed to parse JSON value"))?;
+        self.set_from_json(value)
+    }
 }
 
 // Helper extension trait for type-safe downcasting
@@ -498,12 +543,11 @@ pub struct TypedRecord<T: Send + 'static + Debug + Clone> {
     #[cfg(feature = "remote")]
     writable: portable_atomic::AtomicBool,
 
-    /// Type-erased JSON value codec (feature `remote`).
+    /// Type-erased JSON tree/byte codec (feature `remote`).
     /// `Some` iff the record opted into JSON via `.with_remote_access()`.
-    /// `RecordValue::as_json` and — under `remote` — the AimX read
-    /// (`latest_json`), write (`set_from_json`), and subscribe (`subscribe_json`)
-    /// paths route through it. Built from a `SerdeJsonCodec` where the
-    /// `T: RemoteSerialize` bound is known at the call site.
+    /// `RecordValue::as_json` and — under `remote` — the AimX read, write, and
+    /// subscribe paths route through it. Built from a `SerdeJsonCodec` where
+    /// the `T: RemoteSerialize` bound is known at the call site.
     #[cfg(feature = "remote")]
     remote_codec: Option<RecordCodec<T>>,
 
@@ -517,7 +561,7 @@ pub struct TypedRecord<T: Send + 'static + Debug + Clone> {
 impl<T: Send + 'static + Debug + Clone> TypedRecord<T> {
     /// Creates a new empty typed record
     ///
-    /// Call `.with_remote_access()` to enable JSON (std only).
+    /// Call `.with_remote_access()` to enable JSON (feature `remote`).
     pub fn new() -> Self {
         Self {
             producer: Mutex::new(None),
@@ -863,6 +907,65 @@ impl<T: Send + 'static + Debug + Clone> TypedRecord<T> {
         );
 
         self
+    }
+
+    /// Validate a type-erased remote write and return its configured codec.
+    ///
+    /// Both the JSON-tree and JSON-byte entrypoints use this helper so the
+    /// no-producer/no-transform rule and error ordering cannot drift apart.
+    #[cfg(feature = "remote")]
+    fn remote_write_codec(&self, operation: &str) -> crate::DbResult<RecordCodec<T>> {
+        use crate::DbError;
+
+        if self.has_producer() || self.has_transform() {
+            log_warn!(
+                "Rejected {} for '{}': has active producer or transform",
+                operation,
+                core::any::type_name::<T>()
+            );
+
+            return Err(DbError::permission_denied(alloc::format!(
+                "Cannot set record '{}' - has active producer or transform. \
+                 Use internal application logic instead. \
+                 Remote access can only set configuration records without producers.",
+                core::any::type_name::<T>()
+            )));
+        }
+
+        let codec = self.remote_codec.clone().ok_or_else(|| {
+            DbError::runtime_error(alloc::format!(
+                "Record '{}' not configured with .with_remote_access(). \
+                 Cannot deserialize from JSON.",
+                core::any::type_name::<T>()
+            ))
+        })?;
+
+        if self.buffer.is_none() {
+            return Err(DbError::runtime_error(alloc::format!(
+                "Record '{}' has no buffer configured. \
+                 Cannot produce value without buffer.",
+                core::any::type_name::<T>()
+            )));
+        }
+
+        Ok(codec)
+    }
+
+    #[cfg(feature = "remote")]
+    fn commit_remote_write(&self, value: T) {
+        log_debug!(
+            "Successfully deserialized JSON to type: {}",
+            core::any::type_name::<T>()
+        );
+
+        // Push through the unified write path. This also marks metadata as
+        // updated, matching the original `set_from_json` path.
+        self.writer_handle().push(value);
+
+        log_info!(
+            "Successfully set value from JSON for record: {}",
+            core::any::type_name::<T>()
+        );
     }
 
     /// Returns a reference to the registered outbound connectors
@@ -1221,6 +1324,20 @@ impl<T: Send + Sync + 'static + Debug + Clone> JsonRecordAccess for TypedRecord<
         result
     }
 
+    fn latest_json_bytes(&self) -> Option<Vec<u8>> {
+        log_debug!(
+            "latest_json_bytes called for type: {}",
+            core::any::type_name::<T>()
+        );
+
+        let value = self.buffer.as_ref()?.peek()?;
+        let result = self.remote_codec.as_ref()?.encode_to_vec(&value);
+
+        log_debug!("Byte serialization result: {:?}", result.is_some());
+
+        result
+    }
+
     fn subscribe_json(&self) -> crate::DbResult<Box<dyn crate::buffer::JsonBufferReader + Send>> {
         use crate::DbError;
 
@@ -1268,40 +1385,8 @@ impl<T: Send + Sync + 'static + Debug + Clone> JsonRecordAccess for TypedRecord<
             core::any::type_name::<T>()
         );
 
-        // SAFETY CHECK 1: Enforce "No Producer Override" rule
-        if self.has_producer() || self.has_transform() {
-            log_warn!(
-                "Rejected set_from_json for '{}': has active producer or transform",
-                core::any::type_name::<T>()
-            );
+        let codec = self.remote_write_codec("set_from_json")?;
 
-            return Err(DbError::permission_denied(alloc::format!(
-                "Cannot set record '{}' - has active producer or transform. \
-                 Use internal application logic instead. \
-                 Remote access can only set configuration records without producers.",
-                core::any::type_name::<T>()
-            )));
-        }
-
-        // Check if the codec is configured (set by .with_remote_access())
-        let codec = self.remote_codec.clone().ok_or_else(|| {
-            DbError::runtime_error(alloc::format!(
-                "Record '{}' not configured with .with_remote_access(). \
-                 Cannot deserialize from JSON.",
-                core::any::type_name::<T>()
-            ))
-        })?;
-
-        // Check if buffer exists
-        if self.buffer.is_none() {
-            return Err(DbError::runtime_error(alloc::format!(
-                "Record '{}' has no buffer configured. \
-                 Cannot produce value without buffer.",
-                core::any::type_name::<T>()
-            )));
-        }
-
-        // Deserialize JSON -> T
         let value: T = codec.decode(&json_value).ok_or_else(|| {
             DbError::runtime_error(alloc::format!(
                 "Failed to deserialize JSON to type '{}'. \
@@ -1310,20 +1395,115 @@ impl<T: Send + Sync + 'static + Debug + Clone> JsonRecordAccess for TypedRecord<
             ))
         })?;
 
-        log_debug!(
-            "Successfully deserialized JSON to type: {}",
-            core::any::type_name::<T>()
-        );
-
-        // Push through the unified write path. This also marks
-        // metadata as updated — previously skipped on this path.
-        self.writer_handle().push(value);
-
-        log_info!(
-            "Successfully set value from JSON for record: {}",
-            core::any::type_name::<T>()
-        );
+        self.commit_remote_write(value);
 
         Ok(())
+    }
+
+    fn set_from_json_bytes(&self, bytes: &[u8]) -> crate::DbResult<()> {
+        use crate::DbError;
+
+        log_debug!(
+            "set_from_json_bytes called for type: {}",
+            core::any::type_name::<T>()
+        );
+
+        let codec = self.remote_write_codec("set_from_json_bytes")?;
+        let value: T = codec.decode_slice(bytes).ok_or_else(|| {
+            DbError::runtime_error(alloc::format!(
+                "Failed to deserialize JSON to type '{}'. \
+                 JSON structure does not match the expected schema.",
+                core::any::type_name::<T>()
+            ))
+        })?;
+
+        self.commit_remote_write(value);
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "remote"))]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::buffer::{BufferReader, DynBuffer};
+    use crate::codec::JsonCodec;
+
+    struct OneReader(Option<u32>);
+
+    impl BufferReader<u32> for OneReader {
+        fn poll_recv(&mut self, _cx: &mut Context<'_>) -> Poll<Result<u32, crate::DbError>> {
+            Poll::Ready(self.try_recv())
+        }
+
+        fn try_recv(&mut self) -> Result<u32, crate::DbError> {
+            self.0.take().ok_or(crate::DbError::BufferEmpty)
+        }
+    }
+
+    struct PeekBuffer(u32);
+
+    impl DynBuffer<u32> for PeekBuffer {
+        fn push(&self, _value: u32) {}
+
+        fn subscribe_boxed(&self) -> Box<dyn BufferReader<u32> + Send> {
+            Box::new(OneReader(Some(self.0)))
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn peek(&self) -> Option<u32> {
+            Some(self.0)
+        }
+    }
+
+    struct TrackingCodec {
+        tree_calls: Arc<AtomicUsize>,
+        byte_calls: Arc<AtomicUsize>,
+    }
+
+    impl JsonCodec<u32> for TrackingCodec {
+        fn encode(&self, value: &u32) -> Option<serde_json::Value> {
+            self.tree_calls.fetch_add(1, Ordering::Relaxed);
+            Some(serde_json::json!(value))
+        }
+
+        fn decode(&self, value: &serde_json::Value) -> Option<u32> {
+            value.as_u64()?.try_into().ok()
+        }
+
+        fn encode_to_vec(&self, value: &u32) -> Option<Vec<u8>> {
+            self.byte_calls.fetch_add(1, Ordering::Relaxed);
+            serde_json::to_vec(value).ok()
+        }
+    }
+
+    #[test]
+    fn typed_latest_and_subscription_select_the_codec_byte_path() {
+        let tree_calls = Arc::new(AtomicUsize::new(0));
+        let byte_calls = Arc::new(AtomicUsize::new(0));
+        let codec: RecordCodec<u32> = Arc::new(TrackingCodec {
+            tree_calls: tree_calls.clone(),
+            byte_calls: byte_calls.clone(),
+        });
+
+        let mut record = TypedRecord::<u32>::new();
+        record.remote_codec = Some(codec);
+        record.buffer = Some(Arc::new(PeekBuffer(17)));
+
+        assert_eq!(record.latest_json_bytes().unwrap(), b"17");
+
+        let mut reader = record.subscribe_json().unwrap();
+        assert_eq!(reader.try_recv_json_bytes().unwrap(), b"17");
+
+        assert_eq!(byte_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(tree_calls.load(Ordering::Relaxed), 0);
+
+        assert_eq!(record.latest_json(), Some(serde_json::json!(17)));
+        assert_eq!(tree_calls.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
## Description
Adds a compatibility-preserving direct JSON byte path to AimDB's type-erased remote-access stack.

- Adds defaulted byte methods to `RemoteSerialize`, `JsonCodec<T>`,  `JsonRecordAccess` and `JsonBufferReader`.
- Keeps existing custom codec and reader impls source-compatible through `serde_json::Value` fallbacks.
- Overrides the built-in serde path with direct `serde_json::to_vec` and `serde_json::from_slice`.
- Routes state-record record.get and subscription events through owned JSON Payloads without materializing an intermediate record `serde_json::Value`.
- Preserves the existing AimX v2 schema, authorization, lag handling, cancellation, backpressure, error behavior, ring drain cursor semantics and no-producer-override write safety.
- Keeps metadata, graph, query, admin, aggregate drain, `record.set` and write wrapper handling on the existing tree path. Inbound wire handling does not use hand-written JSON offset extraction.
- Adds semantic-equivalence, compatibility, allocation and `criterion` benchmark coverage.

### Performance
The focused benchmarks measure the in-memory typed-record-to-AimX-envelope boundary. They do not include connector queues, scheduler wakeups, syscalls or physical wire time.

### Validation
- `make check`
- `cargo test -p aimdb-bench`
- `cargo bench -p aimdb-bench --bench b0_alloc_remote_json`
- `cargo bench -p aimdb-bench --bench b1_b2_remote_json`

The full repository gate covers formatting, linting, host tests, valid feature combinations, `no_std` + alloc, Cortex-M, WASM, dependency policy, README drift, codegen drift and production simulation checks.

## Related Issue
- Closes #196 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (`make check`).
- [x] I have updated the documentation accordingly.