### PR TITLE
Remove std dependencies from aimdb-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,8 +330,9 @@ dependencies = [
  "aimdb-tokio-adapter",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4064,6 +4064,8 @@ dependencies = [
  "aimdb-tokio-adapter",
  "serde",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/aimdb-core/src/log.rs
+++ b/aimdb-core/src/log.rs
@@ -14,6 +14,7 @@
 //!   `Vec<String>`). The few sites that mirror events to defmt (router.rs)
 //!   keep explicit `#[cfg(feature = "defmt")]` gates next to these macros.
 
+#[macro_export]
 macro_rules! log_debug {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
@@ -23,6 +24,7 @@ macro_rules! log_debug {
     }};
 }
 
+#[macro_export]
 macro_rules! log_info {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
@@ -32,6 +34,7 @@ macro_rules! log_info {
     }};
 }
 
+#[macro_export]
 macro_rules! log_warn {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
@@ -41,6 +44,7 @@ macro_rules! log_warn {
     }};
 }
 
+#[macro_export]
 macro_rules! log_error {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]

--- a/aimdb-sync/Cargo.toml
+++ b/aimdb-sync/Cargo.toml
@@ -13,12 +13,13 @@ categories = ["database", "api-bindings"]
 # Core dependencies
 aimdb-core = { path = "../aimdb-core", version = "1.1.0" }
 aimdb-tokio-adapter = { path = "../aimdb-tokio-adapter", version = "0.6.0" }
+tracing = { workspace = true, optional = true }
 
 # Tokio for channels and runtime
 tokio = { version = "1.40", features = ["sync", "rt", "time", "macros"] }
 
 # Error handling
-thiserror = "1.0"
+thiserror = { version = "2.0.16", default-features = false }
 
 # Optional: Settable::set (feature `data-contracts`) for the `set_value` family.
 # aimdb-sync depends on the contracts crate, never the reverse — the contracts
@@ -35,10 +36,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [features]
-default = []
+default = ["std"]
+
+std = []
 
 # Enable tracing for debugging
-tracing = ["aimdb-core/tracing"]
+tracing = ["dep:tracing", "aimdb-core/tracing"]
 
 # SyncProducer::set_value / try_set_value / set_value_at for Settable types
 data-contracts = ["dep:aimdb-data-contracts"]

--- a/aimdb-sync/src/consumer.rs
+++ b/aimdb-sync/src/consumer.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 /// # use serde::{Serialize, Deserialize};
 /// # #[derive(Debug, Clone, Serialize, Deserialize)]
 /// # struct Temperature { celsius: f32 }
-/// # fn example(consumer: &SyncConsumer<Temperature>) -> Result<(), Box<dyn std::error::Error>> {
+/// # fn example(consumer: &SyncConsumer<Temperature>) -> SyncResult<()> {
 /// // Get value (blocks until available)
 /// let temp = consumer.get()?;
 /// println!("Temperature: {}°C", temp.celsius);
@@ -81,13 +81,14 @@ where
     ///
     /// ```no_run
     /// use aimdb_core::AimDbBuilder;
-    /// use aimdb_sync::AimDbBuilderSyncExt;
+    /// use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
     /// use aimdb_tokio_adapter::TokioAdapter;
     /// use std::sync::Arc;
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyData { value: i32 }
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// let handle = AimDbBuilder::new()
     ///     .runtime(Arc::new(TokioAdapter))
     ///     .attach()?;
@@ -119,14 +120,15 @@ where
     ///
     /// ```no_run
     /// use aimdb_core::AimDbBuilder;
-    /// use aimdb_sync::AimDbBuilderSyncExt;
+    /// use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
     /// use aimdb_tokio_adapter::TokioAdapter;
     /// use std::sync::Arc;
     /// use std::time::Duration;
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyData { value: i32 }
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// let handle = AimDbBuilder::new()
     ///     .runtime(Arc::new(TokioAdapter))
     ///     .attach()?;
@@ -160,13 +162,14 @@ where
     ///
     /// ```no_run
     /// use aimdb_core::AimDbBuilder;
-    /// use aimdb_sync::AimDbBuilderSyncExt;
+    /// use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
     /// use aimdb_tokio_adapter::TokioAdapter;
     /// use std::sync::Arc;
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyData { value: i32 }
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// let handle = AimDbBuilder::new()
     ///     .runtime(Arc::new(TokioAdapter))
     ///     .attach()?;
@@ -207,13 +210,14 @@ where
     ///
     /// ```no_run
     /// use aimdb_core::AimDbBuilder;
-    /// use aimdb_sync::AimDbBuilderSyncExt;
+    /// use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
     /// use aimdb_tokio_adapter::TokioAdapter;
     /// use std::sync::Arc;
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyData { value: i32 }
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// let handle = AimDbBuilder::new()
     ///     .runtime(Arc::new(TokioAdapter))
     ///     .attach()?;
@@ -258,14 +262,15 @@ where
     ///
     /// ```no_run
     /// use aimdb_core::AimDbBuilder;
-    /// use aimdb_sync::AimDbBuilderSyncExt;
+    /// use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
     /// use aimdb_tokio_adapter::TokioAdapter;
     /// use std::sync::Arc;
     /// use std::time::Duration;
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyData { value: i32 }
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// let handle = AimDbBuilder::new()
     ///     .runtime(Arc::new(TokioAdapter))
     ///     .attach()?;

--- a/aimdb-sync/src/error.rs
+++ b/aimdb-sync/src/error.rs
@@ -1,4 +1,5 @@
 //! Errors of the blocking facade.
+use alloc::string::String;
 
 use aimdb_core::DbError;
 

--- a/aimdb-sync/src/handle.rs
+++ b/aimdb-sync/src/handle.rs
@@ -1,7 +1,7 @@
 //! AimDB handle for managing the sync API runtime thread.
 
 use crate::{SyncError, SyncResult};
-use aimdb_core::{AimDb, AimDbBuilder, DbError, DbResult};
+use aimdb_core::{log_error, log_warn, AimDb, AimDbBuilder, DbError, DbResult};
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
@@ -46,11 +46,12 @@ pub trait AimDbBuilderSyncExt {
     /// ```no_run
     /// use aimdb_core::AimDbBuilder;
     /// use aimdb_tokio_adapter::TokioAdapter;
-    /// use aimdb_sync::AimDbBuilderSyncExt;
+    /// use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
     /// use std::sync::Arc;
     ///
     /// # #[derive(Debug, Clone)] struct MyData { value: f32 }
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// let mut builder = AimDbBuilder::new()
     ///     .runtime(Arc::new(TokioAdapter::new()?));
     /// builder.configure::<MyData>("my.data", |reg| {
@@ -87,10 +88,10 @@ pub trait AimDbSyncExt {
     ///
     /// ```no_run
     /// use aimdb_core::AimDb;
-    /// use aimdb_sync::AimDbSyncExt;
+    /// use aimdb_sync::{AimDbSyncExt, SyncResult};
     ///
     /// // `db` comes out of an async `AimDbBuilder::build()` elsewhere
-    /// # fn demo(db: AimDb) -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn demo(db: AimDb) -> SyncResult<()> {
     /// let handle = db.attach()?;
     /// # Ok(())
     /// # }
@@ -156,7 +157,7 @@ impl AimDbHandle {
                 let runtime = match tokio::runtime::Runtime::new() {
                     Ok(rt) => rt,
                     Err(e) => {
-                        eprintln!("Failed to create Tokio runtime: {}", e);
+                        log_error!("Failed to create Tokio runtime: {}", e);
                         return;
                     }
                 };
@@ -166,7 +167,7 @@ impl AimDbHandle {
 
                 // Send the runtime handle to the main thread
                 if handle_tx.blocking_send(rt_handle).is_err() {
-                    eprintln!("Failed to send runtime handle to main thread");
+                    log_error!("Failed to send runtime handle to main thread");
                     return;
                 }
 
@@ -175,14 +176,14 @@ impl AimDbHandle {
                     let (db, runner) = match builder.build().await {
                         Ok(d) => (Arc::new(d.0), d.1),
                         Err(e) => {
-                            eprintln!("Failed to build database: {}", e);
+                            log_error!("Failed to build database: {}", e);
                             return;
                         }
                     };
 
                     // Send the database to the main thread
                     if db_tx.send(db.clone()).await.is_err() {
-                        eprintln!("Failed to send database to main thread");
+                        log_error!("Failed to send database to main thread");
                         return;
                     }
 
@@ -242,7 +243,7 @@ impl AimDbHandle {
                 let runtime = match tokio::runtime::Runtime::new() {
                     Ok(rt) => rt,
                     Err(e) => {
-                        eprintln!("Failed to create Tokio runtime: {}", e);
+                        log_error!("Failed to create Tokio runtime: {}", e);
                         return;
                     }
                 };
@@ -302,7 +303,7 @@ impl AimDbHandle {
     /// # use serde::{Serialize, Deserialize};
     /// # #[derive(Debug, Clone, Serialize, Deserialize)]
     /// # struct Temperature { celsius: f32 }
-    /// # fn example(handle: &AimDbHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example(handle: &AimDbHandle) -> SyncResult<()> {
     /// let producer = handle.producer::<Temperature>("sensor::temp")?;
     /// producer.set(Temperature { celsius: 25.0 })?;
     /// # Ok(())
@@ -337,7 +338,7 @@ impl AimDbHandle {
     /// # use serde::{Serialize, Deserialize};
     /// # #[derive(Clone, Debug, Serialize, Deserialize)]
     /// # struct Temperature { celsius: f32 }
-    /// # fn example(handle: &AimDbHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example(handle: &AimDbHandle) -> SyncResult<()> {
     /// let consumer = handle.consumer::<Temperature>("sensor::temp")?;
     /// let temp = consumer.get()?;
     /// # Ok(())
@@ -376,7 +377,7 @@ impl AimDbHandle {
     /// # use serde::{Serialize, Deserialize};
     /// # #[derive(Debug, Clone, Serialize, Deserialize)]
     /// # struct HighFrequencySensor { value: f32 }
-    /// # fn example(handle: &AimDbHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example(handle: &AimDbHandle) -> SyncResult<()> {
     /// // High-frequency sensor needs larger buffer
     /// let producer = handle.producer_with_capacity::<HighFrequencySensor>("sensor::high_freq", 1000)?;
     /// producer.set(HighFrequencySensor { value: 42.0 })?;
@@ -438,7 +439,7 @@ impl AimDbHandle {
     /// # use serde::{Serialize, Deserialize};
     /// # #[derive(Clone, Debug, Serialize, Deserialize)]
     /// # struct RareEvent { id: u32 }
-    /// # fn example(handle: &AimDbHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example(handle: &AimDbHandle) -> SyncResult<()> {
     /// // Rare events need smaller buffer
     /// let consumer = handle.consumer_with_capacity::<RareEvent>("events::rare", 10)?;
     /// let event = consumer.get()?;
@@ -482,7 +483,7 @@ impl AimDbHandle {
                             Err(DbError::BufferLagged { lag_count, .. }) => {
                                 // Consumer fell behind - this is not fatal
                                 // Log warning but continue receiving
-                                eprintln!(
+                                log_warn!(
                                     "Warning: Consumer for {} lagged by {} messages",
                                     std::any::type_name::<T>(),
                                     lag_count
@@ -495,7 +496,7 @@ impl AimDbHandle {
                             }
                             Err(e) => {
                                 // Other unexpected errors - log and stop
-                                eprintln!(
+                                log_error!(
                                     "Error reading from buffer for {}: {}",
                                     std::any::type_name::<T>(),
                                     e
@@ -506,7 +507,7 @@ impl AimDbHandle {
                     }
                 }
                 Err(e) => {
-                    eprintln!(
+                    log_error!(
                         "Failed to subscribe to record type {}: {}",
                         std::any::type_name::<T>(),
                         e
@@ -541,7 +542,7 @@ impl AimDbHandle {
     ///
     /// ```rust,no_run
     /// # use aimdb_sync::*;
-    /// # fn example(handle: AimDbHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example(handle: AimDbHandle) -> SyncResult<()> {
     /// handle.detach()?;
     /// # Ok(())
     /// # }
@@ -568,7 +569,7 @@ impl AimDbHandle {
     /// ```rust,no_run
     /// # use aimdb_sync::*;
     /// # use std::time::Duration;
-    /// # fn example(handle: AimDbHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example(handle: AimDbHandle) -> SyncResult<()> {
     /// handle.detach_timeout(Duration::from_secs(5))?;
     /// # Ok(())
     /// # }
@@ -641,12 +642,12 @@ impl Drop for AimDbHandle {
     /// If shutdown fails, the runtime thread may be left running.
     fn drop(&mut self) {
         if self.thread_handle.is_some() {
-            eprintln!("Warning: AimDbHandle dropped without calling detach()");
-            eprintln!("Attempting emergency shutdown with 5 second timeout");
+            log_warn!("Warning: AimDbHandle dropped without calling detach()");
+            log_warn!("Attempting emergency shutdown with 5 second timeout");
 
             let timeout = Duration::from_secs(5);
             if let Err(e) = self.detach_internal(Some(timeout)) {
-                eprintln!("Error during emergency shutdown: {}", e);
+                log_error!("Error during emergency shutdown: {}", e);
             }
         }
     }

--- a/aimdb-sync/src/lib.rs
+++ b/aimdb-sync/src/lib.rs
@@ -46,15 +46,16 @@
 //! ```no_run
 //! use aimdb_core::{AimDbBuilder, buffer::BufferCfg};
 //! use aimdb_tokio_adapter::{TokioAdapter, TokioRecordRegistrarExt};
-//! use aimdb_sync::AimDbBuilderSyncExt;
+//! use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
 //! use std::sync::Arc;
 //!
 //! #[derive(Debug, Clone)]
 //! struct Temperature {
 //!     celsius: f32,
 //! }
-//!
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Guard againts the use of TokioAdapter in case of "std"
+//! # #[cfg(feature = "std")]
+//! # fn main() -> SyncResult<()> {
 //! // Build and attach database (NO #[tokio::main] NEEDED!)
 //! let adapter = Arc::new(TokioAdapter::new()?);
 //! let mut builder = AimDbBuilder::new().runtime(adapter);
@@ -114,9 +115,9 @@
 //! will receive each value. For independent subscriptions, create multiple consumers:
 //!
 //! ```no_run
-//! # use aimdb_sync::AimDbHandle;
+//! # use aimdb_sync::{AimDbHandle, SyncResult};
 //! # #[derive(Debug, Clone)] struct Temperature { celsius: f32 }
-//! # fn demo(handle: &AimDbHandle) -> Result<(), Box<dyn std::error::Error>> {
+//! # fn demo(handle: &AimDbHandle) -> SyncResult<()> {
 //! let consumer1 = handle.consumer::<Temperature>("sensor.temp")?;
 //! let consumer2 = handle.consumer::<Temperature>("sensor.temp")?;
 //!
@@ -131,11 +132,11 @@
 //! You can customize this per record type using the `_with_capacity` methods:
 //!
 //! ```no_run
-//! # use aimdb_sync::AimDbHandle;
+//! # use aimdb_sync::{AimDbHandle, SyncResult};
 //! # #[derive(Debug, Clone)] struct SensorData { value: f32 }
 //! # #[derive(Debug, Clone)] struct RareEvent { code: u8 }
 //! # #[derive(Debug, Clone)] struct LatestOnly { state: u8 }
-//! # fn demo(handle: &AimDbHandle) -> Result<(), Box<dyn std::error::Error>> {
+//! # fn demo(handle: &AimDbHandle) -> SyncResult<()> {
 //! // High-frequency sensor data needs larger buffer
 //! let producer = handle.producer_with_capacity::<SensorData>("sensor.fast", 1000)?;
 //!
@@ -167,8 +168,9 @@
 //!
 //! 1. **Use `get_latest()`** - Drains the channel to get the most recent value:
 //!    ```no_run
+//!    # use aimdb_sync::SyncResult;
 //!    # #[derive(Debug, Clone)] struct Temperature { celsius: f32 }
-//!    # fn demo(consumer: &aimdb_sync::SyncConsumer<Temperature>) -> aimdb_sync::SyncResult<()> {
+//!    # fn demo(consumer: &aimdb_sync::SyncConsumer<Temperature>) -> SyncResult<()> {
 //!    // Always get the latest value, skipping queued intermediates
 //!    let latest = consumer.get_latest()?;
 //!    # Ok(())
@@ -223,13 +225,14 @@
 //!
 //! ```no_run
 //! # use aimdb_sync::{DbError, SyncError, SyncProducer};
+//! # use aimdb_core::{log_error};
 //! # #[derive(Debug, Clone)] struct Temperature { celsius: f32 }
 //! # fn demo(producer: &SyncProducer<Temperature>, data: Temperature) {
 //! // Errors are properly propagated to the caller
 //! match producer.set(data) {
 //!     Ok(()) => println!("Successfully produced"),
-//!     Err(SyncError::Db(DbError::RecordKeyNotFound { .. })) => eprintln!("Record not registered"),
-//!     Err(e) => eprintln!("Production failed: {}", e),
+//!     Err(SyncError::Db(DbError::RecordKeyNotFound { .. })) => log_error!("Record not registered"),
+//!     Err(e) => log_error!("Production failed: {}", e),
 //! }
 //! # }
 //! ```
@@ -242,6 +245,8 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+extern crate alloc;
 
 mod consumer;
 mod error;

--- a/aimdb-sync/src/producer.rs
+++ b/aimdb-sync/src/producer.rs
@@ -24,7 +24,7 @@ use tokio::sync::{mpsc, oneshot};
 /// # use serde::{Serialize, Deserialize};
 /// # #[derive(Clone, Debug, Serialize, Deserialize)]
 /// # struct Temperature { celsius: f32 }
-/// # fn example(producer: &SyncProducer<Temperature>) -> Result<(), Box<dyn std::error::Error>> {
+/// # fn example(producer: &SyncProducer<Temperature>) -> SyncResult<()> {
 /// // Set value (blocks until sent)
 /// producer.set(Temperature { celsius: 25.0 })?;
 ///
@@ -118,13 +118,14 @@ where
     ///
     /// ```no_run
     /// use aimdb_core::AimDbBuilder;
-    /// use aimdb_sync::AimDbBuilderSyncExt;
+    /// use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
     /// use aimdb_tokio_adapter::TokioAdapter;
     /// use std::sync::Arc;
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyData { value: i32 }
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// let handle = AimDbBuilder::new()
     ///     .runtime(Arc::new(TokioAdapter))
     ///     .attach()?;
@@ -153,14 +154,15 @@ where
     ///
     /// ```no_run
     /// use aimdb_core::AimDbBuilder;
-    /// use aimdb_sync::AimDbBuilderSyncExt;
+    /// use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
     /// use aimdb_tokio_adapter::TokioAdapter;
     /// use std::sync::Arc;
     /// use std::time::Duration;
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyData { value: i32 }
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// let handle = AimDbBuilder::new()
     ///     .runtime(Arc::new(TokioAdapter))
     ///     .attach()?;
@@ -191,13 +193,14 @@ where
     ///
     /// ```no_run
     /// use aimdb_core::AimDbBuilder;
-    /// use aimdb_sync::AimDbBuilderSyncExt;
+    /// use aimdb_sync::{AimDbBuilderSyncExt, SyncResult};
     /// use aimdb_tokio_adapter::TokioAdapter;
     /// use std::sync::Arc;
     ///
     /// # #[derive(Debug, Clone)]
     /// # struct MyData { value: i32 }
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// let handle = AimDbBuilder::new()
     ///     .runtime(Arc::new(TokioAdapter))
     ///     .attach()?;
@@ -241,7 +244,8 @@ where
     ///
     /// ```no_run
     /// # #[cfg(feature = "data-contracts")]
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[cfg(feature = "std")]
+    /// # fn main() -> SyncResult<()> {
     /// use aimdb_core::AimDbBuilder;
     /// use aimdb_data_contracts::{SchemaType, Settable};
     /// use aimdb_sync::AimDbBuilderSyncExt;

--- a/aimdb-sync/src/producer.rs
+++ b/aimdb-sync/src/producer.rs
@@ -245,6 +245,7 @@ where
     /// ```no_run
     /// # #[cfg(feature = "data-contracts")]
     /// # #[cfg(feature = "std")]
+    /// # use aimdb_sync::SyncResult;
     /// # fn main() -> SyncResult<()> {
     /// use aimdb_core::AimDbBuilder;
     /// use aimdb_data_contracts::{SchemaType, Settable};

--- a/examples/sync-api-demo/Cargo.toml
+++ b/examples/sync-api-demo/Cargo.toml
@@ -6,16 +6,24 @@ license.workspace = true
 description = "AimDB example demonstrating synchronous API usage"
 publish = false
 
+[features]
+# Demo cases where AimDBHandle is properly detached
+graceful-shutdown = []
+
 [dependencies]
 # AimDB dependencies
 aimdb-core = { path = "../../aimdb-core", features = ["std"] }
 aimdb-tokio-adapter = { path = "../../aimdb-tokio-adapter", features = [
     "tokio-runtime",
 ] }
-aimdb-sync = { path = "../../aimdb-sync" }
+aimdb-sync = { path = "../../aimdb-sync", features = ["tracing"] }
 
 # Runtime for initialization
 tokio = { workspace = true, features = ["full"] }
+
+# For tracing
+tracing = { version = "0.1", default-features = false }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }

--- a/examples/sync-api-demo/src/main.rs
+++ b/examples/sync-api-demo/src/main.rs
@@ -33,6 +33,15 @@ struct Temperature {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Subscribe to tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr) // Log to stderr, stdout is for JSON-RPC
+        .init();
+
     println!("=== AimDB Sync API Demo ===\n");
 
     // Step 1: Build the database and attach it for sync API usage
@@ -153,7 +162,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_millis(200));
 
     // Detach the handle to gracefully shut down the runtime thread
+    #[cfg(feature = "graceful-shutdown")]
     handle.detach()?;
+    #[cfg(feature = "graceful-shutdown")]
     println!("   ✓ Database detached successfully\n");
 
     println!("=== Demo Complete ===");


### PR DESCRIPTION
## Description
What's new:
- `thiserror` to 2.x
- Use alloc::string::String instead of std::string::String
- Use `log_*` instead of `eprintln!`
- Use `SyncResult` in doctest

What's still not working:
- Warning not show up in `examples/sync-api-demo`, possibly due to missing `tracing` feature in packgage's `Cargo.toml` and `Drop` behavior not executed

## Related Issue
- #197 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (`make check`).
- [x] I have updated the documentation accordingly.
