### PR TITLE
Add entry-cleaning up behavior when stream got dropped

### DIFF
--- a/aimdb-websocket-connector/src/server/client_manager.rs
+++ b/aimdb-websocket-connector/src/server/client_manager.rs
@@ -36,6 +36,18 @@ struct SubEntry {
     dropped: AtomicU64,
 }
 
+/// Drop guard for SubEntry
+struct SubEntryGuard {
+    id: u64,
+    subs: Arc<DashMap<u64, SubEntry>>,
+}
+
+impl Drop for SubEntryGuard {
+    fn drop(&mut self) {
+        self.subs.remove(&self.id);
+    }
+}
+
 /// Shared per-topic broadcast bus. Cloning is cheap (all clones share state).
 #[derive(Clone)]
 pub struct ClientManager {
@@ -96,8 +108,13 @@ impl ClientManager {
                 dropped: AtomicU64::new(0),
             },
         );
-        let stream = futures_util::stream::unfold(rx, |mut rx| async move {
-            rx.recv().await.map(|item| (item, rx))
+        // A drop guard for RAII, thankfully self.subs is already Arc<_>
+        let guard = SubEntryGuard {
+            id,
+            subs: self.subs.clone(),
+        };
+        let stream = futures_util::stream::unfold((rx, guard), |(mut rx, guard)| async move {
+            rx.recv().await.map(|item| (item, (rx, guard)))
         });
         (id, Box::pin(stream))
     }
@@ -259,5 +276,20 @@ mod tests {
             updates.iter().all(|u| u.data.as_ptr() == first),
             "every subscriber shares the one payload Arc"
         );
+    }
+
+    // When a stream is dropped, its subscription in ClientManager
+    // together with its Sender must also be removed
+    #[tokio::test]
+    async fn subscription_dropped_when_stream_dropped() {
+        let mgr = ClientManager::new(256);
+        let (_id, stream) = mgr.subscribe("quiet.topic");
+
+        // Count before stream dropping
+        assert_eq!(mgr.subscription_count(), 1);
+        drop(stream);
+
+        // Associated entry must be unsubscribed
+        assert_eq!(mgr.subscription_count(), 0);
     }
 }

--- a/aimdb-websocket-connector/src/server/client_manager.rs
+++ b/aimdb-websocket-connector/src/server/client_manager.rs
@@ -42,6 +42,11 @@ struct SubEntryGuard {
     subs: Arc<DashMap<u64, SubEntry>>,
 }
 
+/// The Drop takes the write lock inside the sub DashMap.
+/// So must not drop this guard while the same thread is holding
+/// any ref into `subs` - `iter()`/`Ref` guard.
+/// This would lead to self-deadlock in the same thread
+/// Correct implementation: `ClientManager::broadcast` defers the `Drop` till the `iter` finished.
 impl Drop for SubEntryGuard {
     fn drop(&mut self) {
         self.subs.remove(&self.id);
@@ -93,10 +98,12 @@ impl ClientManager {
         }
     }
 
-    /// Register a subscription for `pattern`; returns its id and the stream of
-    /// topic-tagged record-value updates. Dropping the stream ends the
-    /// subscription; the next matching [`broadcast`](Self::broadcast) lazily
-    /// prunes the entry.
+    /// Register a subscription for `pattern`; returns its id and a pair of stream,
+    /// topic-tagged record-value updates, and its guard object. Dropping the stream 1) ends the
+    /// subscription; 2) drops associated subscription entry in the DashMap carried in the
+    /// guard.
+    /// The next matching [`broadcast`](Self::broadcast) keeps trying to lazily prunes the entry.
+    /// This could server as a safety net to make sure nothing leak.
     pub fn subscribe(&self, pattern: &str) -> (u64, BoxStream<'static, SubUpdate>) {
         let id = self.next_sub.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = mpsc::channel::<SubUpdate>(self.sub_capacity);
@@ -154,6 +161,9 @@ impl ClientManager {
                 Err(mpsc::error::TrySendError::Closed(_)) => dead.push(*entry.key()),
             }
         }
+
+        // Removals are deferred till here, avoiding holding read-lock
+        // why trying to acquire write-lock.
         for id in dead {
             self.subs.remove(&id);
         }
@@ -250,13 +260,29 @@ mod tests {
         }
     }
 
+    // A drop of Receiver (not Stream), does not lead to SubEntry dropped.
+    // Broadcast must handle the drop of matched pattern.
     #[tokio::test]
-    async fn dropped_stream_is_pruned() {
+    async fn broadcast_prunes_closed_channel_matched_pattern() {
         let mgr = ClientManager::new(256);
-        let (_id, stream) = mgr.subscribe("#");
+        let (tx, rx) = mpsc::channel::<SubUpdate>(256);
+        mgr.subs.insert(
+            1,
+            SubEntry {
+                pattern: "dropped_channel".to_string(),
+                tx,
+                dropped: AtomicU64::new(0),
+            },
+        );
+        drop(rx);
         assert_eq!(mgr.subscription_count(), 1);
-        drop(stream);
-        mgr.broadcast("t", b"v").await;
+
+        // Non-matching patterns survive the prune
+        mgr.broadcast("false_pattern", b"v").await;
+        assert_eq!(mgr.subscription_count(), 1);
+
+        // Matched pattern get pruned
+        mgr.broadcast("dropped_channel", b"v").await;
         assert_eq!(mgr.subscription_count(), 0);
     }
 

--- a/aimdb-websocket-connector/src/server/client_manager.rs
+++ b/aimdb-websocket-connector/src/server/client_manager.rs
@@ -42,11 +42,12 @@ struct SubEntryGuard {
     subs: Arc<DashMap<u64, SubEntry>>,
 }
 
-/// The Drop takes the write lock inside the sub DashMap.
+/// The Drop takes the write lock inside the subs DashMap.
 /// So must not drop this guard while the same thread is holding
 /// any ref into `subs` - `iter()`/`Ref` guard.
 /// This would lead to self-deadlock in the same thread
-/// Correct implementation: `ClientManager::broadcast` defers the `Drop` till the `iter` finished.
+/// Correct implementation: `ClientManager::broadcast` defers its removals
+/// until after the iteration.
 impl Drop for SubEntryGuard {
     fn drop(&mut self) {
         self.subs.remove(&self.id);
@@ -98,12 +99,12 @@ impl ClientManager {
         }
     }
 
-    /// Register a subscription for `pattern`; returns its id and a pair of stream,
-    /// topic-tagged record-value updates, and its guard object. Dropping the stream 1) ends the
-    /// subscription; 2) drops associated subscription entry in the DashMap carried in the
-    /// guard.
-    /// The next matching [`broadcast`](Self::broadcast) keeps trying to lazily prunes the entry.
-    /// This could server as a safety net to make sure nothing leak.
+    /// Register a subscription for `pattern`; returns its id and a Stream-bound object
+    /// of topic-tagged record-value updates.
+    /// The stream, when dropped, having its associated entry dropped
+    /// through a guard that the stream owns.
+    /// The next matching [`broadcast`](Self::broadcast) keeps trying to lazily prune the entry.
+    /// This could serve as a safety net to make sure nothing leaks.
     pub fn subscribe(&self, pattern: &str) -> (u64, BoxStream<'static, SubUpdate>) {
         let id = self.next_sub.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = mpsc::channel::<SubUpdate>(self.sub_capacity);
@@ -163,7 +164,7 @@ impl ClientManager {
         }
 
         // Removals are deferred till here, avoiding holding read-lock
-        // why trying to acquire write-lock.
+        // while trying to acquire write-lock.
         for id in dead {
             self.subs.remove(&id);
         }


### PR DESCRIPTION
## Description
What's new:
- Add a guard for `SubEntry` for RAII behavior. Also update `stream` in `ClientManager.subscribe()` to take in the guard and the Receiver;
- Add test for the entry-cleaned-up behavior when stream is dropped;

## Related Issue
- Closes #206 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (`make check`).
- [x] I have updated the documentation accordingly.
