### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2917,7 +2917,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
`cargo deny check` started failing on main after RUSTSEC-2026-0258 was
published against h2 <0.4.16: empty DATA frames were accepted and queued
without limit, so an undrained stream could grow memory without bound or
panic on length overflow. h2 reaches us transitively through hyper (axum,
reqwest) — no first-party code is involved.

Lockfile-only change via `cargo update -p h2`. The resolver also re-points
nu-ansi-term at windows-sys 0.61.2, which was already in the lockfile.

`cargo deny check` now reports: advisories ok, bans ok, licenses ok,
sources ok.