### PR TITLE
fix(sync): remove both busy-waits, and report why startup failed

### DIFF
--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`AimDbSyncExt::attach` no longer spins, and can no longer hang.** The
+  constructor polled a `Mutex<Option<Handle>>` on a 1 ms sleep while the runtime
+  thread filled it — and that thread returns early if `Runtime::new()` fails, so
+  the wait never ended. It now takes the same channel-and-`blocking_recv` shape
+  `AimDbBuilderSyncExt::attach` has always used: a runtime thread that dies drops
+  its sender, which closes the channel, which ends the wait with
+  `SyncError::AttachFailed`.
+- **A startup failure now carries its cause.** Both constructors' channels carry
+  a `Result`, so a failed `Runtime::new()` or a failed `build()` reports *why*
+  instead of only that it happened — previously the reason reached the log sink
+  and nothing else, which for an FFI consumer meant a status code and an empty
+  explanation.
+- **`detach_timeout` parks instead of polling.** The wait used a 10 ms sleep
+  loop, so every shutdown paid up to 10 ms it did not need and the timeout was
+  rounded up to the next tick. It now blocks on `recv_timeout`.
+- **Both `Mutex::lock().unwrap()` sites are gone**, with the mutex they guarded.
+  A poisoned lock could panic out of the blocking surface, which across an FFI
+  boundary is undefined behaviour rather than an error.
+
 ### Added
 
 - **`SyncProducer<T: Settable>::set_value`/`try_set_value`/`set_value_at`** (design 041 §3.4, feature `data-contracts`). `set()` took a fully constructed `T`, so every outside-the-thread caller hand-assembled the struct; `set_value(value)` constructs via `T::set(value, timestamp)` and sends in one call — blocking (`set_value`), non-blocking (`try_set_value`), or with an explicit timestamp for replay/testing (`set_value_at`). `set_value`/`try_set_value` stamp the caller's `SystemTime` (crate is std-only). New optional dependency: `aimdb-data-contracts` (feature `settable`), behind the new `data-contracts` feature — the contracts crate gains no `sync` feature (dependency direction unchanged).

--- a/aimdb-sync/src/handle.rs
+++ b/aimdb-sync/src/handle.rs
@@ -127,6 +127,28 @@ pub struct AimDbHandle {
 #[derive(Debug, Clone, Copy)]
 struct ShutdownSignal;
 
+/// What the runtime thread reports back while starting up: the thing itself,
+/// or why it could not be produced.
+type Startup<T> = Result<T, String>;
+
+/// Wait for one startup report, turning every outcome into a `SyncResult`.
+///
+/// The `None` arm is what makes this a wait rather than a hang: a runtime
+/// thread that dies without reporting drops its sender, and a dropped sender
+/// closes the channel.
+///
+/// Blocks the calling thread, so it must not be called from inside a Tokio
+/// runtime.
+fn recv_startup<T>(rx: &mut mpsc::Receiver<Startup<T>>, what: &str) -> SyncResult<T> {
+    match rx.blocking_recv() {
+        Some(Ok(value)) => Ok(value),
+        Some(Err(cause)) => Err(SyncError::AttachFailed { message: cause }),
+        None => Err(SyncError::AttachFailed {
+            message: format!("runtime thread stopped before sending the {}", what),
+        }),
+    }
+}
+
 impl AimDbHandle {
     /// Create a new handle by spawning the runtime thread and building the database inside it.
     pub(crate) fn new_from_builder(builder: AimDbBuilder) -> SyncResult<Self> {
@@ -134,8 +156,8 @@ impl AimDbHandle {
         let (shutdown_tx, shutdown_rx) = mpsc::channel::<ShutdownSignal>(1);
 
         // Create channels for passing the built database and runtime handle back
-        let (db_tx, mut db_rx) = mpsc::channel::<Arc<AimDb>>(1);
-        let (handle_tx, mut handle_rx) = mpsc::channel::<tokio::runtime::Handle>(1);
+        let (db_tx, mut db_rx) = mpsc::channel::<Startup<Arc<AimDb>>>(1);
+        let (handle_tx, mut handle_rx) = mpsc::channel::<Startup<tokio::runtime::Handle>>(1);
 
         // Spawn the runtime thread
         let thread_handle = thread::Builder::new()
@@ -145,19 +167,10 @@ impl AimDbHandle {
                 message: format!("Failed to spawn runtime thread: {}", e),
             })?;
 
-        // Wait for runtime handle to be available
-        let runtime_handle = handle_rx
-            .blocking_recv()
-            .ok_or_else(|| SyncError::AttachFailed {
-                message: "Runtime thread failed to send handle".to_string(),
-            })?;
-
-        // Wait for database to be built
-        let db = db_rx
-            .blocking_recv()
-            .ok_or_else(|| SyncError::AttachFailed {
-                message: "Runtime thread failed to build database".to_string(),
-            })?;
+        // Both report the thread's own reason for failing rather than only the
+        // fact that it failed.
+        let runtime_handle = recv_startup(&mut handle_rx, "runtime handle")?;
+        let db = recv_startup(&mut db_rx, "database")?;
 
         Ok(Self {
             thread_handle: Some(thread_handle),
@@ -171,13 +184,14 @@ impl AimDbHandle {
         // Create shutdown channel
         let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<ShutdownSignal>(1);
 
+        // A channel rather than a mutex the caller polls — the same shape
+        // `new_from_builder` has always used. See `recv_startup`.
+        let (handle_tx, mut handle_rx) = mpsc::channel::<Startup<tokio::runtime::Handle>>(1);
+
         // Wrap database in Arc for sharing
         let db = Arc::new(db);
 
         // Spawn the runtime thread
-        let runtime_handle_result = Arc::new(std::sync::Mutex::new(None));
-        let runtime_handle_clone = runtime_handle_result.clone();
-
         let thread_handle = thread::Builder::new()
             .name("aimdb-sync-runtime".to_string())
             .spawn(move || {
@@ -185,15 +199,23 @@ impl AimDbHandle {
                 let runtime = match tokio::runtime::Runtime::new() {
                     Ok(rt) => rt,
                     Err(e) => {
-                        log_error!("Failed to create Tokio runtime: {}", e);
+                        // Report the reason before dying. Dropping the sender
+                        // would already unblock the caller; this is what gives
+                        // it something to print.
+                        let cause = format!("Failed to create Tokio runtime: {}", e);
+                        log_error!("{}", cause);
+                        let _ = handle_tx.blocking_send(Err(cause));
                         return;
                     }
                 };
 
-                // Store the runtime handle so the main thread can access it
+                // Hand the runtime handle to the caller.
+                if handle_tx
+                    .blocking_send(Ok(runtime.handle().clone()))
+                    .is_err()
                 {
-                    let mut handle = runtime_handle_clone.lock().unwrap();
-                    *handle = Some(runtime.handle().clone());
+                    log_error!("Failed to send runtime handle to main thread");
+                    return;
                 }
 
                 // Wait for shutdown signal
@@ -206,14 +228,7 @@ impl AimDbHandle {
                 message: format!("Failed to spawn runtime thread: {}", e),
             })?;
 
-        // Wait for runtime handle to be available
-        let runtime_handle = loop {
-            let handle_opt = runtime_handle_result.lock().unwrap().clone();
-            if let Some(handle) = handle_opt {
-                break handle;
-            }
-            thread::sleep(Duration::from_millis(1));
-        };
+        let runtime_handle = recv_startup(&mut handle_rx, "runtime handle")?;
 
         Ok(Self {
             thread_handle: Some(thread_handle),
@@ -355,36 +370,40 @@ impl AimDbHandle {
         if let Some(thread_handle) = self.thread_handle.take() {
             match timeout {
                 Some(duration) => {
-                    // Join with timeout using a different approach since JoinHandle
-                    // doesn't directly support timeouts
-                    let handle_thread = thread::spawn(move || thread_handle.join());
+                    // `JoinHandle` has no timed join, so a helper thread does the
+                    // blocking join and reports through a channel. `recv_timeout`
+                    // parks until the thread is actually down, so a shutdown that
+                    // takes 1 ms costs 1 ms instead of being rounded up to the
+                    // next tick of a sleep loop.
+                    let (done_tx, done_rx) = std::sync::mpsc::channel::<bool>();
+                    thread::spawn(move || {
+                        // Fails only if the caller already timed out and dropped
+                        // the receiver — that is how this thread learns nobody
+                        // is listening, not an error worth reporting.
+                        let _ = done_tx.send(thread_handle.join().is_ok());
+                    });
 
-                    // Wait for the thread to complete with timeout
-                    let start = std::time::Instant::now();
-                    loop {
-                        if handle_thread.is_finished() {
-                            break;
+                    match done_rx.recv_timeout(duration) {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            return Err(SyncError::DetachFailed {
+                                message: "Runtime thread panicked".to_string(),
+                            })
                         }
-                        if start.elapsed() > duration {
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                             return Err(SyncError::DetachFailed {
                                 message: format!(
                                     "Runtime thread did not shut down within {:?}",
                                     duration
                                 ),
-                            });
+                            })
                         }
-                        thread::sleep(Duration::from_millis(10));
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                            return Err(SyncError::DetachFailed {
+                                message: "Failed to join helper thread".to_string(),
+                            })
+                        }
                     }
-
-                    // Retrieve the result
-                    handle_thread
-                        .join()
-                        .map_err(|_| SyncError::DetachFailed {
-                            message: "Failed to join helper thread".to_string(),
-                        })?
-                        .map_err(|_| SyncError::DetachFailed {
-                            message: "Runtime thread panicked".to_string(),
-                        })?;
                 }
                 None => {
                     // Join without timeout
@@ -401,21 +420,23 @@ impl AimDbHandle {
     fn setup_background(
         builder: AimDbBuilder,
         mut shutdown_rx: mpsc::Receiver<ShutdownSignal>,
-        db_tx: mpsc::Sender<Arc<AimDb>>,
-        handle_tx: mpsc::Sender<tokio::runtime::Handle>,
+        db_tx: mpsc::Sender<Startup<Arc<AimDb>>>,
+        handle_tx: mpsc::Sender<Startup<tokio::runtime::Handle>>,
     ) {
         // Create a new Tokio runtime for this thread
         let runtime = match tokio::runtime::Runtime::new() {
             Ok(rt) => rt,
             Err(e) => {
-                log_error!("Failed to create Tokio runtime: {}", e);
+                let cause = format!("Failed to create Tokio runtime: {}", e);
+                log_error!("{}", cause);
+                let _ = handle_tx.blocking_send(Err(cause));
                 return;
             }
         };
         // Get the runtime handle before moving into block_on
         let rt_handle = runtime.handle().clone();
         // Send the runtime handle to the main thread
-        if handle_tx.blocking_send(rt_handle).is_err() {
+        if handle_tx.blocking_send(Ok(rt_handle)).is_err() {
             log_error!("Failed to send runtime handle to main thread");
             return;
         }
@@ -424,13 +445,15 @@ impl AimDbHandle {
             let (db, runner) = match builder.build().await {
                 Ok(d) => (Arc::new(d.0), d.1),
                 Err(e) => {
-                    log_error!("Failed to build database: {}", e);
+                    let cause = format!("Failed to build database: {}", e);
+                    log_error!("{}", cause);
+                    let _ = db_tx.send(Err(cause)).await;
                     return;
                 }
             };
 
             // Send the database to the main thread
-            if db_tx.send(db.clone()).await.is_err() {
+            if db_tx.send(Ok(db.clone())).await.is_err() {
                 log_error!("Failed to send database to main thread");
                 return;
             }

--- a/aimdb-sync/tests/attach_detach_test.rs
+++ b/aimdb-sync/tests/attach_detach_test.rs
@@ -1,0 +1,127 @@
+//! Attach and detach: the two paths that used to busy-wait.
+//!
+//! `AimDbSyncExt::attach` is covered here because it had no in-tree caller at
+//! all — which is how an unbounded spin survived in it. Every other test in
+//! this crate goes through `AimDbBuilderSyncExt::attach`.
+#![cfg(feature = "std")]
+use aimdb_core::{buffer::BufferCfg, AimDbBuilder};
+use aimdb_sync::{AimDbBuilderSyncExt, AimDbSyncExt, SyncError};
+use aimdb_tokio_adapter::{TokioAdapter, TokioRecordRegistrarExt};
+use serde::{Deserialize, Serialize};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Reading {
+    value: u32,
+}
+
+fn configured_builder() -> AimDbBuilder {
+    let mut builder = AimDbBuilder::new().runtime(Arc::new(TokioAdapter));
+    builder.configure::<Reading>("sensor.reading", |reg| {
+        reg.buffer(BufferCfg::SpmcRing { capacity: 8 })
+            .tap(|_ctx, _consumer| async move {});
+    });
+    builder
+}
+
+/// Run `f` on its own thread and fail if it has not finished in `limit`.
+///
+/// A watchdog rather than a plain call: the defect these tests cover is a
+/// wait that never ends, and a test that reproduces it should fail rather
+/// than hang the suite.
+fn within<T: Send + 'static>(limit: Duration, f: impl FnOnce() -> T + Send + 'static) -> T {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = tx.send(f());
+    });
+    rx.recv_timeout(limit)
+        .unwrap_or_else(|_| panic!("did not finish within {:?}", limit))
+}
+
+/// `AimDbSyncExt::attach` — the entry point that carried the spin.
+#[test]
+fn attach_on_a_built_db_returns_a_usable_handle() {
+    // `build()` is async, so it runs in a runtime that is dropped before
+    // `attach()`: attach blocks, and must not be called from inside one.
+    let db = {
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let (db, _runner) = rt.block_on(configured_builder().build()).expect("build");
+        db
+    };
+
+    let handle = within(Duration::from_secs(10), move || db.attach()).expect("attach");
+    handle
+        .producer::<Reading>("sensor.reading")
+        .expect("producer");
+    handle.detach().expect("detach");
+}
+
+/// The reason a startup failed has to reach the caller, not only the log sink.
+///
+/// Before the channel carried a `Result`, this arrived as "Runtime thread
+/// failed to build database" while the real cause went only to a log the
+/// caller may never have installed.
+#[test]
+fn a_failed_build_reports_why() {
+    // No `.runtime()`, so `build()` fails inside the runtime thread.
+    let err = within(Duration::from_secs(10), || {
+        AimDbBuilder::new().attach().err()
+    })
+    .expect("attach should fail");
+
+    let SyncError::AttachFailed { message } = &err else {
+        panic!("expected AttachFailed, got {:?}", err);
+    };
+    assert!(
+        message.contains("runtime not set"),
+        "the cause should survive the trip, got: {message}"
+    );
+}
+
+/// A runtime thread that stops before reporting must end the wait, not extend
+/// it — a closed channel is what turns the old spin into an error.
+#[test]
+fn attach_never_waits_forever() {
+    let outcome = within(Duration::from_secs(10), || {
+        AimDbBuilder::new().attach().map(|_| ())
+    });
+    assert!(outcome.is_err(), "a builder with no runtime cannot attach");
+}
+
+#[test]
+fn detach_timeout_shuts_down_cleanly() {
+    let handle = configured_builder().attach().expect("attach");
+    let started = Instant::now();
+    handle
+        .detach_timeout(Duration::from_secs(5))
+        .expect("detach within timeout");
+    // Guards against a regression to a coarse poll; the wait now parks on a
+    // channel rather than sleeping between checks.
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "shutdown took {:?}",
+        started.elapsed()
+    );
+}
+
+#[test]
+fn producer_and_consumer_work_through_the_attached_runtime() {
+    let handle = configured_builder().attach().expect("attach");
+    let producer = handle
+        .producer::<Reading>("sensor.reading")
+        .expect("producer");
+    let mut consumer = handle
+        .consumer::<Reading>("sensor.reading")
+        .expect("consumer");
+
+    producer.set(Reading { value: 42 }).expect("set");
+    let got = consumer
+        .get_with_timeout(Duration::from_secs(5))
+        .expect("get");
+    assert_eq!(got, Reading { value: 42 });
+
+    handle.detach().expect("detach");
+}


### PR DESCRIPTION
## Description

`aimdb-sync` had two busy-waits. One of them could hang forever.

### The unbounded spin — `AimDbSyncExt::attach`

```rust
let runtime_handle = loop {
    let handle_opt = runtime_handle_result.lock().unwrap().clone();
    if let Some(handle) = handle_opt { break handle; }
    thread::sleep(Duration::from_millis(1));
};
```

The runtime thread that fills that slot has an early return: if `Runtime::new()` fails it logs and exits, and nothing is ever stored. `attach` then spins forever. Nothing above can time out around it — the wait is upstream of every timeout a caller could arm.

**The correct implementation was already sixty lines up.** `new_from_builder` has used a channel and one `blocking_recv` since it was written. Nothing had to be designed; the older constructor simply never picked it up.

What matters isn't the removal of the sleep, it's what a closed channel means: the runtime thread's early return drops the sender, a dropped sender closes the channel, and `blocking_recv()` yields `None`. A runtime that fails to start becomes `AttachFailed` instead of a caller that never returns.

### A startup failure now says why

Both channels carry a `Result`, not a bare value:

```rust
type Startup<T> = Result<T, String>;
```

Three outcomes, three arms, no fourth state. `None` is the one that used to be a hang. `Err` is what a consumer actually needs — without it a startup failure arrives as "runtime thread failed to send handle" while the real cause goes only to a log sink the caller may never have installed:

```
before: Failed to attach database: Runtime thread failed to build database
after:  Failed to attach database: Failed to build database: invalid configuration (1 error(s)): runtime not set (use .runtime())
```

### The 10 ms poll — `detach_internal`

`JoinHandle` has no timed join, so the helper thread stays — but it now reports through a channel and the caller uses `recv_timeout`. The wait parks instead of polling, and the timeout is exact rather than rounded up to the next tick. That 10 ms was never the runtime thread taking 10 ms to stop; it was the poll interval, paid by every shutdown in every language binding.

### Two `lock().unwrap()` sites

Both are gone with the `Arc<Mutex<Option<Handle>>>` they guarded. A poisoned lock could panic out of the blocking surface, which across an FFI boundary is undefined behaviour rather than an error.

## Verification

A sweep of `aimdb-sync/src/` for `thread::sleep`, `is_finished`, `yield_now` and `spin` returns nothing.

New `tests/attach_detach_test.rs` covers **`AimDbSyncExt::attach` specifically** — it had no in-tree caller at all, which is how the spin survived in it. Every other test in the crate goes through `AimDbBuilderSyncExt::attach`. The tests use a watchdog rather than a plain call, so a regression to an unbounded wait fails the suite instead of hanging it.

`cargo test -p aimdb-sync` and `cargo clippy -p aimdb-sync --all-targets -- -D warnings` are green locally; CI covers the rest of the matrix.

## What this does *not* fix

The helper thread still can't be reclaimed on timeout — you can't cancel a `join()`. It exits when the runtime thread finally stops, and its send fails harmlessly into a dropped receiver. A timed-out detach still returns while the runtime thread is alive, and the contract for what a caller may then do with the handle is still unwritten. I'd like to file that separately; it needs a decision rather than a patch.

## Related Issue
- N/A — found while building a C ABI layer on this crate.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed (`make check`) — relying on CI for the full matrix.
- [x] I have updated the documentation accordingly.