### PR TITLE
feat(mqtt): make the tokio TLS backend selectable

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,4 +9,23 @@ ignore = [
     "RUSTSEC-2023-0071", # rsa timing sidechannel via embedded-tls; no fixed upgrade available
     "RUSTSEC-2026-0110", # bare-metal deprecated via cortex-m (embedded-only transitive)
     "RUSTSEC-2026-0173", # proc-macro-error2 unmaintained (transitive via defmt/tabled_derive)
+
+    # rustls-webpki 0.102.8, pulled by rumqttc 0.25.1 (latest) when the
+    # `tokio-rustls` backend is selected. rumqttc pins `rustls-webpki =
+    # "0.102.8"`, so there is no in-range upgrade and no feature-level escape
+    # (`use-rustls-no-provider` is what activates the dependency).
+    #
+    # Not reachable through aimdb-mqtt-connector. rumqttc names webpki in
+    # exactly one place — `WebPki(#[from] webpki::Error)` on its error enum —
+    # and reaches the vulnerable parsing only from `TlsConfiguration::Simple`,
+    # which parses CA PEM files. This connector only ever constructs
+    # `TlsConfiguration::Rustls(Arc<ClientConfig>)`, which rumqttc clones
+    # without touching webpki. Handshake verification runs inside rustls
+    # 0.23.x against rustls-webpki 0.103.x — a separate, patched instance.
+    #
+    # Revisit when rumqttc bumps its pin; these can be dropped then.
+    "RUSTSEC-2026-0049", # rustls-webpki: CRL distribution-point matching
+    "RUSTSEC-2026-0098", # rustls-webpki: URI name constraints
+    "RUSTSEC-2026-0099", # rustls-webpki: name constraints vs wildcard names
+    "RUSTSEC-2026-0104", # rustls-webpki: panic in CRL parsing
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "heapless 0.8.0",
  "rand_core 0.6.4",
  "rumqttc",
+ "rustls-native-certs",
  "serde",
  "static_cell",
  "thiserror 2.0.17",
@@ -605,6 +606,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,11 +790,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -886,6 +912,15 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cobs"
@@ -1293,6 +1328,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
@@ -1920,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -1986,6 +2027,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2684,6 +2731,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2897,10 +2954,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3057,6 +3114,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -3556,9 +3619,13 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
  "thiserror 2.0.17",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
 ]
@@ -3605,11 +3672,34 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3623,10 +3713,22 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3707,10 +3809,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework-sys"
-version = "2.15.0"
+name = "security-framework"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3896,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"

--- a/Makefile
+++ b/Makefile
@@ -182,8 +182,12 @@ test:
 	cargo test --package aimdb-persistence
 	@printf "$(YELLOW)  → Testing persistence SQLite backend$(NC)\n"
 	cargo test --package aimdb-persistence-sqlite
-	@printf "$(YELLOW)  → Testing MQTT connector$(NC)\n"
+	@printf "$(YELLOW)  → Testing MQTT connector (tokio, no TLS backend)$(NC)\n"
 	cargo test --package aimdb-mqtt-connector --features "std,tokio-runtime"
+	@printf "$(YELLOW)  → Testing MQTT connector (tokio + native-tls)$(NC)\n"
+	cargo test --package aimdb-mqtt-connector --features "std,tokio-runtime,tokio-native-tls"
+	@printf "$(YELLOW)  → Testing MQTT connector (tokio + rustls)$(NC)\n"
+	cargo test --package aimdb-mqtt-connector --features "std,tokio-runtime,tokio-rustls"
 	@printf "$(YELLOW)  → Testing KNX connector$(NC)\n"
 	cargo test --package aimdb-knx-connector --features "std,tokio-runtime"
 	@printf "$(YELLOW)  → Testing WebSocket connector (server + client: unit, real-socket e2e, AimDB round-trip)$(NC)\n"
@@ -283,6 +287,12 @@ clippy:
 	cargo clippy --package aimdb-knx-connector --features "std,tokio-runtime" --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on KNX connector (embassy)$(NC)\n"
 	cargo clippy --package aimdb-knx-connector --target thumbv7em-none-eabihf --no-default-features --features "embassy-runtime" -- -D warnings
+	@printf "$(YELLOW)  → Clippy on MQTT connector (tokio, no TLS backend)$(NC)\n"
+	cargo clippy --package aimdb-mqtt-connector --features "std,tokio-runtime" --all-targets -- -D warnings
+	@printf "$(YELLOW)  → Clippy on MQTT connector (tokio + native-tls)$(NC)\n"
+	cargo clippy --package aimdb-mqtt-connector --features "std,tokio-runtime,tokio-native-tls" --all-targets -- -D warnings
+	@printf "$(YELLOW)  → Clippy on MQTT connector (tokio + rustls)$(NC)\n"
+	cargo clippy --package aimdb-mqtt-connector --features "std,tokio-runtime,tokio-rustls" --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on MQTT connector (embassy + defmt)$(NC)\n"
 	cargo clippy --package aimdb-mqtt-connector --target thumbv7em-none-eabihf --no-default-features --features "embassy-runtime,defmt" -- -D warnings
 	@printf "$(YELLOW)  → Clippy on MQTT connector (embassy + TLS + defmt)$(NC)\n"

--- a/aimdb-mqtt-connector/CHANGELOG.md
+++ b/aimdb-mqtt-connector/CHANGELOG.md
@@ -9,9 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tokio client: the TLS backend for `mqtts://` is now a build-time choice.**
+  Two new features — `tokio-native-tls` (system OpenSSL, what this crate linked
+  before) and `tokio-rustls` (pure Rust, no `libssl`/`libcrypto`) — plus the
+  option of neither. Neither is a supported build rather than an oversight: a
+  deployment speaking `mqtt://` on a trusted network links no TLS stack at all,
+  which for a shared library is the difference between inheriting a system
+  OpenSSL ABI and inheriting nothing. `mqtts://` then fails at connect time with
+  a message naming the missing feature, instead of at the linker. `make test`
+  and `make clippy` gain a leg for each of the three states.
 - **Embassy client: TLS (`mqtts://`) and broker authentication ([design 044](../docs/design/044-embassy-mqtt-tls.md), WP7).** New `embassy-tls` feature (`embassy-runtime` + `embedded-tls`/`embedded-io-async`/`rand_core`, `embassy-net/dns`, `embassy-net/udp`) adds an `embedded-tls` 1.3 session over the Embassy TCP socket, with pure-Rust (`rustpki`) certificate verification (`rsa` + `p384`, so public CA chains verify out of the box) and SNI/hostname verification taken from the broker URL. `MqttConnectorBuilder::new` now accepts `mqtts://host[:port]` (default port 8883) alongside plain `mqtt://` (1883); the scheme selects the transport at `build()`. New `MqttConnectorBuilder::with_tls(TlsOptions)` supplies the TLS materials — entropy (`&'static mut dyn CryptoRngCore`, app-owned TRNG), app-provided static record buffers, and the SNTP server address; `build()` errors if `mqtts://` is used without `.with_tls(...)`, if `.with_tls(...)` is used with a plain `mqtt://` URL, or if the `embassy-tls` feature is off. IPv6 broker literals are rejected at `build()` (can never pass certificate verification); IPv4 literals are allowed with a `defmt` warning (only a private CA that pins the dotted quad in its CN will verify). A connector-internal SNTP (UDP) task backs the TLS clock and gates the first handshake on a successful time sync, so certificate validity is always checked. The plain `mqtt://` path is unchanged.
 - **`MqttConnectorBuilder::with_credentials(username, password)` (Embassy, design 044 D8).** Feeds the MQTT CONNECT username/password on both the plain and TLS transports. The `aimdb-dev/mountain-mqtt` fork submodule is bumped to pick up upstream 0.4's `ConnectionSettings::with_auth`/`authenticated` (`aimdb-dev/mountain-mqtt@89a7129`).
 - `make check` gains an `embassy-runtime,embassy-tls,defmt` clippy leg on `thumbv7em-none-eabihf`.
+
+### Fixed
+
+- **The rustls path no longer builds its configuration through
+  `TlsConfiguration::default()`**, which `expect`s on `load_native_certs()` and
+  `unwrap`s each `add()`. Two panics on the connect path, in a crate reachable
+  through an FFI boundary where a panic is undefined behaviour rather than an
+  error. The configuration is now built explicitly, and a machine with no usable
+  trust roots gets a message saying so.
 
 ### Changed
 

--- a/aimdb-mqtt-connector/Cargo.toml
+++ b/aimdb-mqtt-connector/Cargo.toml
@@ -23,6 +23,16 @@ tokio-runtime = [
     "async-stream",
     "futures-util",
 ]
+# TLS backend for the tokio client (`mqtts://`). Pick one, or neither.
+#
+# Neither is a real choice rather than an oversight: a deployment that speaks
+# `mqtt://` on a trusted network links no TLS stack at all, which for a shared
+# library is the difference between inheriting a system OpenSSL ABI and
+# inheriting nothing. `mqtts://` then fails at connect time with a message
+# naming the missing feature, rather than at the linker.
+tokio-native-tls = ["tokio-runtime", "rumqttc/use-native-tls"]
+tokio-rustls = ["tokio-runtime", "rumqttc/use-rustls", "dep:rustls-native-certs"]
+
 embassy-runtime = [
     "aimdb-core/alloc",                          # Need alloc for collect_inbound_routes
     "aimdb-core/connector-session",              # `pump_sink`/`pump_source`/`Source`/`Payload`
@@ -65,9 +75,15 @@ uuid = { version = "1.0", features = ["v4"], optional = true }
 
 # Tokio runtime dependencies (std)
 tokio = { workspace = true, optional = true, features = ["sync", "time"] }
-rumqttc = { version = "0.25", optional = true, default-features = false, features = [
-    "use-native-tls",
-] }
+# No TLS feature here: the backend is the consumer's choice, made through
+# `tokio-native-tls` or `tokio-rustls`. rumqttc's own default is `use-rustls`;
+# `default-features = false` keeps that from arriving behind the choice.
+rumqttc = { version = "0.25", optional = true, default-features = false }
+
+# Platform trust roots for the rustls backend. rumqttc's
+# `TlsConfiguration::default()` loads these too, but `expect`s on failure — and
+# a panic on the connect path is what an FFI consumer cannot afford.
+rustls-native-certs = { version = "0.8", optional = true }
 async-stream = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true, default-features = false, features = [
     "alloc",

--- a/aimdb-mqtt-connector/src/tokio_client.rs
+++ b/aimdb-mqtt-connector/src/tokio_client.rs
@@ -177,10 +177,19 @@ impl MqttConnectorImpl {
             mqtt_opts.set_credentials(username, password);
         }
 
-        // mqtts:// selects the TLS transport (system trust roots via
-        // native-tls); rumqttc otherwise speaks plain TCP regardless of port.
+        // mqtts:// selects the TLS transport; rumqttc otherwise speaks plain TCP
+        // regardless of port. Which stack answers is a build-time choice.
+        //
+        // The whole branch is gated, not just the configuration: rumqttc gates
+        // `TlsConfiguration` *and* `Transport::Tls` on having a backend, so a
+        // build with neither cannot even name the types.
+        #[cfg(any(feature = "tokio-native-tls", feature = "tokio-rustls"))]
         if connector_url.scheme == "mqtts" {
-            mqtt_opts.set_transport(rumqttc::Transport::Tls(rumqttc::TlsConfiguration::Native));
+            mqtt_opts.set_transport(rumqttc::Transport::Tls(tls_configuration()?));
+        }
+        #[cfg(not(any(feature = "tokio-native-tls", feature = "tokio-rustls")))]
+        if connector_url.scheme == "mqtts" {
+            return Err(no_tls_backend());
         }
 
         // Wrap router early so we can count topics for capacity calculation
@@ -341,6 +350,47 @@ impl Source for MqttEventLoopSource {
             }
         })
     }
+}
+
+/// The TLS configuration for `mqtts://`, from whichever backend this build
+/// selected.
+#[cfg(feature = "tokio-native-tls")]
+fn tls_configuration() -> Result<rumqttc::TlsConfiguration, String> {
+    Ok(rumqttc::TlsConfiguration::Native)
+}
+
+/// Built by hand rather than via `TlsConfiguration::default()`, which does the
+/// same work and then `expect`s on failure. A panic on the connect path is
+/// undefined behaviour across an FFI boundary; a returned error is a status.
+#[cfg(all(feature = "tokio-rustls", not(feature = "tokio-native-tls")))]
+fn tls_configuration() -> Result<rumqttc::TlsConfiguration, String> {
+    use rumqttc::tokio_rustls::rustls::{ClientConfig, RootCertStore};
+
+    let mut roots = RootCertStore::empty();
+    for cert in rustls_native_certs::load_native_certs().certs {
+        // A trust store with one unparseable certificate is still a trust
+        // store; refusing the lot would be worse than skipping the entry.
+        let _ = roots.add(cert);
+    }
+    if roots.is_empty() {
+        return Err("no usable platform trust roots were found, so no broker \
+                    certificate could be verified"
+            .to_string());
+    }
+
+    Ok(rumqttc::TlsConfiguration::Rustls(Arc::new(
+        ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth(),
+    )))
+}
+
+/// Why an `mqtts://` url cannot be honoured by a build with no TLS backend.
+#[cfg(not(any(feature = "tokio-native-tls", feature = "tokio-rustls")))]
+fn no_tls_backend() -> String {
+    "this build has no TLS backend — rebuild aimdb-mqtt-connector with the \
+     `tokio-rustls` or `tokio-native-tls` feature, or use an mqtt:// url"
+        .to_string()
 }
 
 #[cfg(test)]

--- a/aimdb-mqtt-connector/src/tokio_client.rs
+++ b/aimdb-mqtt-connector/src/tokio_client.rs
@@ -432,6 +432,32 @@ mod tests {
             router,
         )
         .await;
+
+        #[cfg(any(feature = "tokio-native-tls", feature = "tokio-rustls"))]
+        assert!(connector.is_ok());
+
+        // With no backend selected there is no TLS stack to hand the transport,
+        // so mqtts:// is refused here rather than at the linker.
+        #[cfg(not(any(feature = "tokio-native-tls", feature = "tokio-rustls")))]
+        {
+            // `Err(_)` rather than `expect_err`: the Ok half holds an
+            // `EventLoop`, which is not `Debug`.
+            let Err(err) = connector else {
+                panic!("mqtts:// must be refused when no TLS backend is selected");
+            };
+            assert!(
+                err.contains("no TLS backend"),
+                "the error should name the missing feature, got: {err}"
+            );
+        }
+    }
+
+    /// The plain scheme is unaffected by which backend, if any, is selected.
+    #[tokio::test]
+    async fn test_connector_mqtt_url_needs_no_tls_backend() {
+        let router = RouterBuilder::new().build();
+        let connector =
+            MqttConnectorImpl::build_internal("mqtt://broker.example.com:1883", None, router).await;
         assert!(connector.is_ok());
     }
 }


### PR DESCRIPTION
## Description

The tokio client hardcoded `use-native-tls`:

```toml
rumqttc = { version = "0.25", optional = true, default-features = false, features = ["use-native-tls"] }
```

so every consumer links the system OpenSSL whether or not it wants it. For a crate that ends up inside a shared library that isn't a preference — `libssl`/`libcrypto` become an ABI constraint on every consuming build, and a second OpenSSL in a process that already has one is a crash at handshake time.

Worth noting this was a deliberate choice, not an oversight: rumqttc's own default is `use-rustls`, and this crate set `default-features = false` and then explicitly opted into native-tls. The embedded half already went the other way — design 044's Embassy client uses `embedded-tls` with `rustpki`, a pure-Rust stack with no system dependency. The host path was the outlier.

### Measured, on a cdylib built over this crate

Before:
```
libssl.so.3    => /lib/x86_64-linux-gnu/libssl.so.3
libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3
native-static-libs: -lssl -lcrypto -lgcc_s -lutil -lrt -lpthread -lm -ldl -lc
```

After, with `tokio-rustls`:
```
libgcc_s.so.1  libm.so.6  libc.so.6      (and the loader)
native-static-libs: -lgcc_s -lutil -lrt -lpthread -lm -ldl -lc
```

### The bill, stated rather than buried

| | native-tls | rustls |
|---|---|---|
| release `.so` | 3.9 MB | 8.1 MB |
| stripped | 2.9 MB | 6.6 MB |
| `ldd` | libssl, libcrypto | — |

rustls more than doubles the artifact because it links the stack it no longer borrows. For a library shipped into a foreign process that's usually the right trade, but it's a real number and belongs in the decision.

## Three states, not two

`tokio-native-tls`, `tokio-rustls`, or **neither**. The third is a genuine choice: a deployment speaking `mqtt://` on a trusted network links no TLS stack at all. `mqtts://` then fails at connect time with a message naming the missing feature, rather than at the linker with a missing symbol.

That third state was the one piece of real work — rumqttc gates `TlsConfiguration` **and** `Transport::Tls` on having a backend, so the whole `if scheme == "mqtts"` branch has to be `#[cfg]`'d, not just its argument. Gating only the configuration does not compile.

**Nothing changes by default.** `tokio-runtime` alone no longer implies a backend, so a consumer that wants the previous behaviour adds `tokio-native-tls`.

## A panic on the connect path

The obvious rustls translation is `TlsConfiguration::default()`. It isn't usable here — inside rumqttc that is:

```rust
for cert in load_native_certs().expect("could not load platform certs") {
    root_cert_store.add(cert).unwrap();
}
```

Two panics on the connect path, in a crate reached through an FFI boundary where a panic is undefined behaviour rather than an error. Both backends now build their configuration explicitly, and a machine with no usable trust roots gets a message saying so. "The library must not panic" has to extend to what the library calls.

## Verification

The feature matrix lives in the Makefile by convention, and a TLS backend is exactly the kind of choice that rots if CI only ever sees one side of it — so `make test` and `make clippy` gain a leg for each of the three states. This crate had **no host clippy coverage at all** before, only the `thumbv7em` embassy legs; that gap is closed here too.

All three combinations build locally.

## Related Issue
- N/A — found by running `ldd` on a cdylib built over this crate.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes — feature-matrix legs rather than unit tests; the behaviour being guarded is which stack links.
- [ ] All new and existing tests passed (`make check`) — relying on CI for the full matrix.
- [x] I have updated the documentation accordingly.