### PR TITLE
feat(sync): classify SyncError by what the caller can do

### DIFF
--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -9,10 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`SyncError::kind()`.** Returns `aimdb_core::DbErrorKind` rather than a kind
+  of its own, so a caller — an FFI layer above all — has one set of actions for
+  the whole stack instead of one per crate. The `Db` arm delegates, so a buffer
+  that is merely empty classifies identically whether it is reached through this
+  facade or through `aimdb-core` directly.
 - **`SyncProducer<T: Settable>::set_value`/`try_set_value`/`set_value_at`** (design 041 §3.4, feature `data-contracts`). `set()` took a fully constructed `T`, so every outside-the-thread caller hand-assembled the struct; `set_value(value)` constructs via `T::set(value, timestamp)` and sends in one call — blocking (`set_value`), non-blocking (`try_set_value`), or with an explicit timestamp for replay/testing (`set_value_at`). `set_value`/`try_set_value` stamp the caller's `SystemTime` (crate is std-only). New optional dependency: `aimdb-data-contracts` (feature `settable`), behind the new `data-contracts` feature — the contracts crate gains no `sync` feature (dependency direction unchanged).
 
 ### Changed (breaking)
 
+- **`SyncError` is `#[non_exhaustive]`.** Downstream exhaustive matches now need
+  a wildcard arm; match on `kind()` instead where you only need to know what to
+  do. This is what makes every future `SyncError` variant additive rather than
+  breaking.
 - **Issue #131:** `AimDbSyncExt` extends the non-generic `aimdb_core::AimDb`; internal handles drop the `TokioAdapter` type parameter.
 - **Issue #200:** the internal channel bridge to the `tokio` thread is gone — blocking calls now call the runtime directly using the `block_on` seam. API implications:
   - `SyncProducer::set_with_timeout` removed

--- a/aimdb-sync/src/error.rs
+++ b/aimdb-sync/src/error.rs
@@ -1,14 +1,18 @@
 //! Errors of the blocking facade.
 use alloc::string::String;
 
-use aimdb_core::DbError;
+use aimdb_core::{DbError, DbErrorKind};
 
 /// Errors from the synchronous (blocking) API.
 ///
 /// Facade-specific failures (attach/detach, runtime-thread shutdown) are their
 /// own variants; anything from the underlying database wraps a [`DbError`]
 /// via [`SyncError::Db`].
+///
+/// `#[non_exhaustive]`: match on [`SyncError::kind`] where you only need to
+/// know what to do about the failure.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SyncError {
     /// Failed to attach the database to the runtime thread.
     #[error("Failed to attach database: {message}")]
@@ -41,5 +45,65 @@ pub enum SyncError {
     Db(#[from] DbError),
 }
 
+impl SyncError {
+    /// Classify the failure by what the caller can do about it.
+    ///
+    /// Returns [`DbErrorKind`] rather than a kind of its own, so a caller — an
+    /// FFI layer above all — has one set of actions for the whole stack instead
+    /// of one per crate. [`Db`](SyncError::Db) delegates, so a buffer that is
+    /// merely empty classifies the same whether it is reached through this
+    /// facade or through `aimdb-core` directly.
+    pub fn kind(&self) -> DbErrorKind {
+        match self {
+            // The cause may well have been a configuration mistake — the
+            // message says so — but these carry a `String`, so its kind does
+            // not survive the trip.
+            Self::AttachFailed { .. } | Self::DetachFailed { .. } => DbErrorKind::Internal,
+
+            Self::SetTimeout | Self::GetTimeout => DbErrorKind::Retry,
+
+            Self::RuntimeShutdown => DbErrorKind::Closed,
+
+            Self::Db(err) => err.kind(),
+        }
+    }
+}
+
 /// Result alias for blocking-facade operations.
 pub type SyncResult<T> = Result<T, SyncError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn facade_failures_classify_by_action() {
+        assert_eq!(
+            SyncError::AttachFailed {
+                message: "m".to_string()
+            }
+            .kind(),
+            DbErrorKind::Internal
+        );
+        assert_eq!(SyncError::GetTimeout.kind(), DbErrorKind::Retry);
+        assert_eq!(SyncError::SetTimeout.kind(), DbErrorKind::Retry);
+        assert_eq!(SyncError::RuntimeShutdown.kind(), DbErrorKind::Closed);
+    }
+
+    /// The point of returning `DbErrorKind` rather than a kind of this crate's
+    /// own: one switch covers the whole stack.
+    #[test]
+    fn a_wrapped_db_error_keeps_its_kind() {
+        for err in [
+            DbError::BufferEmpty,
+            DbError::BufferClosed {
+                buffer_name: "b".to_string(),
+            },
+            DbError::missing_configuration("p"),
+        ] {
+            let expected = err.kind();
+            assert_eq!(SyncError::Db(err).kind(), expected);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Follow-up to #225, which added `DbError::kind()` and `DbErrorKind` in `aimdb-core`. This does the `aimdb-sync` half.

`SyncError::kind()` returns **`DbErrorKind`** rather than a kind of its own. That's the point: an FFI layer built on this facade gets *one* switch for the whole stack instead of one per crate. The `Db` arm delegates, so a buffer that is merely empty classifies identically whether it's reached through the facade or through `aimdb-core` directly.

| Variant | Kind | Why |
|---|---|---|
| `AttachFailed`, `DetachFailed` | `Internal` | the facade's own machinery failed to start or stop |
| `SetTimeout`, `GetTimeout` | `Retry` | a bounded wait expired; the same call may succeed a moment later |
| `RuntimeShutdown` | `Closed` | terminal — the runtime thread is gone and will not come back |
| `Db(e)` | delegates to `e.kind()` | one classification, not two |

`SyncError` also becomes `#[non_exhaustive]`. This crate is 0.6.0 and unreleased, so the attribute is free today and makes every future variant additive — which matters immediately: the fork-safety work I'd like to raise next needs to add a variant, and without this that would be a breaking change rather than a patch.

## A known gap, recorded rather than hidden

`AttachFailed { message: String }` classifies as `Internal` even when the underlying cause was a configuration mistake — and after #226 that message often *is* a configuration mistake, spelled out:

```
Failed to attach database: Failed to build database: invalid configuration (1 error(s)): runtime not set (use .runtime())
```

The kind is thrown away one layer below where it would be useful. The fix is to make the startup channel carry a `DbError` instead of a `String`, so `AttachFailed` can keep the cause's kind. That changes a variant's shape, which is a decision rather than a cleanup, so it's left for a separate PR — and `#[non_exhaustive]` landing here is what makes it cheap when it's taken.

## Verification

`cargo test -p aimdb-sync --lib`, `cargo fmt --check` and the `--no-default-features` (no_std) build are green locally; CI covers the matrix.

## Related Issue
- Follows #225.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed (`make check`) — relying on CI for the full matrix.
- [x] I have updated the documentation accordingly.