### PR TITLE
docs(sync): say what a SyncConsumer is, and name the migration hazard

### DIFF
--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Capacity-related API removed: `AimDbBuilderSyncExt::producer_with_capacity`/`consumer_with_capacity` and the `DEFAULT_SYNC_CHANNEL_CAPACITY` constant are gone.
   - `SyncConsumer`: `get`, `try_get`, `get_with_timeout`, `get_latest`, and `get_latest_with_timeout` now take `&mut self` (was `&self`)
   - `SyncConsumer` no longer implements `Clone` or `Sync` (still `Send`).
+  - **Migration.** The replacement for a cloned consumer is a second
+    `handle.consumer()` — but note that it is not a like-for-like swap.
+    Cloning in 0.5.0 shared one stream, so each clone got *a share* of the
+    values (split). Calling `handle.consumer()` twice gives two independent
+    cursors, so each one sees *every* value (fan-out). Code that mechanically
+    replaces `clone()` with `consumer()` therefore changes behaviour with no
+    compile error. To keep split semantics, share one consumer as
+    `Arc<Mutex<SyncConsumer<T>>>`.
 
 ### Changed
 

--- a/aimdb-sync/src/consumer.rs
+++ b/aimdb-sync/src/consumer.rs
@@ -10,9 +10,20 @@ use std::time::Instant;
 
 /// Synchronous consumer for records of type `T`.
 ///
-/// Not thread-safe - can be moved to another thread, but not cloned.
-/// Each instance of SyncConsumer<T> reading from the same producer
-/// receives data independently according to buffer semantics (SPMC, etc.).
+/// A consumer is a **subscription with its own cursor**. Reading advances that
+/// cursor, which is why the methods take `&mut self`. `Send` but not `Sync`,
+/// and not `Clone`.
+///
+/// [`AimDbHandle::consumer`](crate::AimDbHandle::consumer) takes `&self` and
+/// hands out as many as you like, each with an independent cursor — so the
+/// default shape is **one per thread, and every consumer sees every value**.
+///
+/// To *split* a stream instead, so each value goes to exactly one of several
+/// workers, share one consumer as `Arc<Mutex<SyncConsumer<T>>>`.
+///
+/// Blocking reads drive the future on the *calling* thread, so they cost no
+/// runtime worker — but for the same reason they must not be called from
+/// inside a Tokio runtime.
 ///
 /// # Example
 ///

--- a/aimdb-sync/src/lib.rs
+++ b/aimdb-sync/src/lib.rs
@@ -171,8 +171,10 @@
 //! ## Safety
 //!
 //! `SyncProducer` is `Clone`, `Send + Sync` — share it freely across threads.
-//! `SyncConsumer` is `Send` only, not `Clone` — move it to a thread, don't share it;
-//! get independent readers via separate `handle.consumer()` calls instead.
+//! `SyncConsumer` is `Send` only, not `Clone` — it is a subscription with its own
+//! cursor, so move it to a thread and give each thread its own via a separate
+//! `handle.consumer()` call. Every consumer then sees every value. To *split* one
+//! stream across workers instead, share one as `Arc<Mutex<SyncConsumer<T>>>`.
 //! The API ensures proper resource cleanup through RAII and explicit `detach()`.
 
 #![warn(missing_docs)]


### PR DESCRIPTION
## Description

Three documentation gaps around `SyncConsumer`, found while building a C ABI layer on this crate and working out what the consumer half of it should look like.

### 1. The type doc said what a consumer *isn't*

> Not thread-safe - can be moved to another thread, but not cloned.

`&mut self` isn't an oversight, it's the honest signature — a reader is a **cursor**, `poll_recv(&mut self)` advances it, so reading mutates. Saying that turns the rest into a consequence rather than a list of restrictions: `AimDbHandle::consumer` takes `&self` and hands out as many as you like, each with its own cursor, so **one per thread** is the default shape and every consumer sees every value.

### 2. The split case had no answer anywhere

`Mutex<T>` is `Sync` whenever `T: Send`, so a caller who genuinely wants several workers to share one stream writes `Arc<Mutex<SyncConsumer<T>>>` — and it compiles today. Nothing said so.

### 3. One migration hazard that breaks a working program with no compile error

This is the part I'd most want a 0.5.0 user to see. Cloning a consumer in 0.5.0 shared one stream, so each clone got *a share* of the values (split). Calling `handle.consumer()` twice in 0.6.0 gives two independent cursors, so each sees *every* value (fan-out).

A user who mechanically replaces `clone()` with `consumer()` gets **different behaviour, silently** — each worker starts seeing every value instead of its share. The changelog entry for #200 is accurate about what was removed but doesn't name the replacement or this trap.

## Scope

Docs and a changelog note only — no API change.

I want to be explicit that I first thought this needed an API change (interior mutability so the methods could take `&self`) and that was wrong. Putting a `Mutex` *inside* `SyncConsumer` would impose split semantics on every caller including the majority who want fan-out, and it would break `try_get`'s contract — a non-blocking call would have to wait on a mutex held by a blocking `get()`, which is exactly the "never blocks" promise the method exists to make.

I'd also note the crate docs were already better than I initially credited: `lib.rs` does show the multiple-consumers pattern. What was missing is what a consumer *is*, the `Mutex` option, and the migration trap — so this PR is narrower than it might otherwise have been.

## Related Issue
- Follows #200, whose changelog entry this expands.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [ ] I have added tests to cover my changes — documentation only; doctests pass.
- [ ] All new and existing tests passed (`make check`) — relying on CI for the full matrix.
- [x] I have updated the documentation accordingly.