### PR TITLE
fix(sync): make panic-freedom a checked property, not a convention

### DIFF
--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A panic-freedom contract on the blocking surface.** The crate is compiled
+  under `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)` outside
+  its own tests, so "a panic here is a bug, not an error channel" is checked
+  rather than remembered. There were no violations left to fix — the last two
+  went with the mutex removed in #226 — so this is a ratchet, not a cleanup.
+  It matters most across an FFI boundary, where unwinding is undefined
+  behaviour and a consumer's `panic = "abort"` turns any panic into the whole
+  process dying. Documented with its two limits: `block_on` still panics if
+  called from inside a Tokio runtime, and the guarantee stops at this crate's
+  edge.
 - **`SyncError::kind()`.** Returns `aimdb_core::DbErrorKind` rather than a kind
   of its own, so a caller — an FFI layer above all — has one set of actions for
   the whole stack instead of one per crate. The `Db` arm delegates, so a buffer

--- a/aimdb-sync/src/lib.rs
+++ b/aimdb-sync/src/lib.rs
@@ -176,9 +176,30 @@
 //! `handle.consumer()` call. Every consumer then sees every value. To *split* one
 //! stream across workers instead, share one as `Arc<Mutex<SyncConsumer<T>>>`.
 //! The API ensures proper resource cleanup through RAII and explicit `detach()`.
+//!
+//! **A panic from this crate is a bug, not an error channel.** Every failure is
+//! a [`SyncError`]. The blocking surface is compiled under
+//! `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)` so the
+//! property is checked rather than remembered. This matters most to callers
+//! reaching the crate from another language: a panic unwinding past an FFI
+//! boundary is undefined behaviour, and a consumer whose profile sets
+//! `panic = "abort"` turns any panic into the whole process dying.
+//!
+//! Two things this does not promise. `block_on` panics if called from inside a
+//! Tokio runtime — the blocking surface must be entered from a thread that is
+//! not already running one. And the guarantee stops at this crate's edge: a
+//! dependency reached through it can still panic on its own.
 
 #![warn(missing_docs)]
 #![warn(clippy::all)]
+// A panic on this surface is not an error channel, it is a bug. Callers reach
+// this crate from other languages, where unwinding past the boundary is
+// undefined behaviour and `panic = "abort"` in a consumer's profile turns any
+// panic into the whole process dying. Checked rather than remembered.
+#![cfg_attr(
+    not(test),
+    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
+)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
## Description

Callers reach this crate from other languages, and two things there put panic-freedom upstream of anything an FFI layer can do about it:

- **A panic writes to fd 2 regardless.** Rust's panic hook is process-global, so a shim that catches the unwind still can't stop the message and backtrace reaching the application's stderr — measured at 1,732 bytes for one panic, past whatever log sink the embedder installed.
- **`panic = "abort"` compiles the catch out.** A consumer's profile may set it without knowing this library is in the graph, turning every catch into an abort of the whole process.

Installing a panic hook in the FFI layer to fix this would be the same trespass as an extension deciding where an application's diagnostics go. So the fix belongs here, and it's a discipline rather than a feature: **the blocking surface must not panic.**

## This is a ratchet, not a cleanup

There is nothing to fix. The two reachable `Mutex::lock().unwrap()` sites went with the `Arc<Mutex<Option<Handle>>>` removed in #226, and `aimdb-sync/src` has no `unwrap`, `expect`, `panic!`, `unreachable!` or `todo!` left. This adds the lint that keeps it that way:

```rust
#![cfg_attr(
    not(test),
    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
)]
```

`not(test)` rather than a blanket deny, so the crate's own unit tests can still assert with the usual tools — CR-4's wording was "on the non-test surface", and integration tests in `tests/` are separate crates that the attribute never reached anyway.

## The two limits, stated rather than implied

I'd rather the contract be honest than sound stronger than it is, so the crate docs now say both:

- **`block_on` still panics if called from inside a Tokio runtime.** The blocking surface has to be entered from a thread that isn't already running one. That's a usage error rather than a failure the crate can return, but it *is* a panic and pretending otherwise would be worse than documenting it.
- **The guarantee stops at this crate's edge.** A dependency reached through it can still panic on its own — which is not hypothetical: #227 found exactly that in rumqttc's `TlsConfiguration::default()`, two `expect`/`unwrap` calls on the connect path.

## Verification

`cargo clippy -p aimdb-sync --all-targets -- -D warnings` and the `--no-default-features` leg are both clean.

## Follow-up not taken here

CR-4 also asked for the same rule stated for `aimdb-core`'s public API. That's a much larger surface and a separate judgement about how much of the core is reachable from a blocking caller, so I've left it out rather than half-do it.

## Related Issue
- Completes the second half of CR-4; the first half landed in #226.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [ ] I have added tests to cover my changes — the lint *is* the check; there is no behaviour to test.
- [ ] All new and existing tests passed (`make check`) — relying on CI for the full matrix.
- [x] I have updated the documentation accordingly.