### PR TITLE
feat(sync)!: carry the cause's kind into AttachFailed

### DIFF
--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -82,6 +82,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
+- **`SyncError::AttachFailed` carries a `DbError` instead of a `String`.** The
+  field is now `source: DbError` rather than `message: String`. Flattening the
+  cause to a string threw away its classification one layer below where it is
+  useful: a startup that failed because the record graph was misconfigured still
+  reported `DbErrorKind::Internal`, even though the message said otherwise.
+  `SyncError::kind()` now delegates to the cause, so that case classifies as
+  `Configuration`. The `Display` output is unchanged in substance, and the cause
+  is exposed through `std::error::Error::source`.
 - **`SyncError` is `#[non_exhaustive]`.** Downstream exhaustive matches now need
   a wildcard arm; match on `kind()` instead where you only need to know what to
   do. This is what makes every future `SyncError` variant additive rather than

--- a/aimdb-sync/src/error.rs
+++ b/aimdb-sync/src/error.rs
@@ -15,10 +15,15 @@ use aimdb_core::{DbError, DbErrorKind};
 #[non_exhaustive]
 pub enum SyncError {
     /// Failed to attach the database to the runtime thread.
-    #[error("Failed to attach database: {message}")]
+    ///
+    /// Carries the underlying [`DbError`] rather than a flattened string, so
+    /// [`kind`](Self::kind) can report what actually went wrong — a bad record
+    /// graph classifies as `Configuration`, not as an internal fault.
+    #[error("Failed to attach database: {source}")]
     AttachFailed {
-        /// Human-readable description of the failure.
-        message: String,
+        /// What went wrong underneath.
+        #[source]
+        source: DbError,
     },
 
     /// Failed to detach the database from the runtime thread.
@@ -60,10 +65,13 @@ impl SyncError {
     /// facade or through `aimdb-core` directly.
     pub fn kind(&self) -> DbErrorKind {
         match self {
-            // The cause may well have been a configuration mistake — the
-            // message says so — but these carry a `String`, so its kind does
-            // not survive the trip.
-            Self::AttachFailed { .. } | Self::DetachFailed { .. } => DbErrorKind::Internal,
+            // The cause survives the trip, so a build that failed on a bad
+            // record graph classifies as `Configuration` here too.
+            Self::AttachFailed { source } => source.kind(),
+
+            // Detach failures are the facade's own machinery: a timeout, or a
+            // runtime thread that panicked. Neither has a `DbError` behind it.
+            Self::DetachFailed { .. } => DbErrorKind::Internal,
 
             Self::SetTimeout | Self::GetTimeout => DbErrorKind::Retry,
 
@@ -86,8 +94,24 @@ mod tests {
 
     #[test]
     fn facade_failures_classify_by_action() {
+        // AttachFailed delegates, so the cause's kind is what comes out.
         assert_eq!(
             SyncError::AttachFailed {
+                source: DbError::runtime_error("m")
+            }
+            .kind(),
+            DbErrorKind::Internal
+        );
+        assert_eq!(
+            SyncError::AttachFailed {
+                source: DbError::missing_configuration("broker.url")
+            }
+            .kind(),
+            DbErrorKind::Configuration,
+            "a startup that failed on configuration must not look internal"
+        );
+        assert_eq!(
+            SyncError::DetachFailed {
                 message: "m".to_string()
             }
             .kind(),

--- a/aimdb-sync/src/handle.rs
+++ b/aimdb-sync/src/handle.rs
@@ -2,7 +2,7 @@
 
 use crate::waiter::Waiter;
 use crate::{SyncError, SyncResult};
-use aimdb_core::{log_error, log_warn, AimDb, AimDbBuilder};
+use aimdb_core::{log_error, log_warn, AimDb, AimDbBuilder, DbError};
 use alloc::sync::Arc;
 use core::fmt::Debug;
 use core::time::Duration;
@@ -146,7 +146,10 @@ struct ShutdownSignal;
 
 /// What the runtime thread reports back while starting up: the thing itself,
 /// or why it could not be produced.
-type Startup<T> = Result<T, String>;
+///
+/// A `DbError` rather than a message, so the cause's classification survives
+/// the trip into [`SyncError::AttachFailed`] instead of being flattened.
+type Startup<T> = Result<T, DbError>;
 
 /// Wait for one startup report, turning every outcome into a `SyncResult`.
 ///
@@ -159,9 +162,12 @@ type Startup<T> = Result<T, String>;
 fn recv_startup<T>(rx: &mut mpsc::Receiver<Startup<T>>, what: &str) -> SyncResult<T> {
     match rx.blocking_recv() {
         Some(Ok(value)) => Ok(value),
-        Some(Err(cause)) => Err(SyncError::AttachFailed { message: cause }),
+        Some(Err(cause)) => Err(SyncError::AttachFailed { source: cause }),
         None => Err(SyncError::AttachFailed {
-            message: format!("runtime thread stopped before sending the {}", what),
+            source: DbError::runtime_error(format!(
+                "runtime thread stopped before sending the {}",
+                what
+            )),
         }),
     }
 }
@@ -187,7 +193,7 @@ impl AimDbHandle {
             .name("aimdb-sync-runtime".to_string())
             .spawn(|| Self::setup_background(builder, shutdown_rx, db_tx, handle_tx, alive_tx))
             .map_err(|e| SyncError::AttachFailed {
-                message: format!("Failed to spawn runtime thread: {}", e),
+                source: DbError::runtime_error(format!("Failed to spawn runtime thread: {}", e)),
             })?;
 
         // Both report the thread's own reason for failing rather than only the
@@ -236,9 +242,11 @@ impl AimDbHandle {
                         // Report the reason before dying. Dropping the sender
                         // would already unblock the caller; this is what gives
                         // it something to print.
-                        let cause = format!("Failed to create Tokio runtime: {}", e);
-                        log_error!("{}", cause);
-                        let _ = handle_tx.blocking_send(Err(cause));
+                        log_error!("Failed to create Tokio runtime: {}", e);
+                        let _ = handle_tx.blocking_send(Err(DbError::runtime_error(format!(
+                            "Failed to create Tokio runtime: {}",
+                            e
+                        ))));
                         return;
                     }
                 };
@@ -259,7 +267,7 @@ impl AimDbHandle {
                 });
             })
             .map_err(|e| SyncError::AttachFailed {
-                message: format!("Failed to spawn runtime thread: {}", e),
+                source: DbError::runtime_error(format!("Failed to spawn runtime thread: {}", e)),
             })?;
 
         let runtime_handle = recv_startup(&mut handle_rx, "runtime handle")?;
@@ -512,9 +520,11 @@ impl AimDbHandle {
         let runtime = match tokio::runtime::Runtime::new() {
             Ok(rt) => rt,
             Err(e) => {
-                let cause = format!("Failed to create Tokio runtime: {}", e);
-                log_error!("{}", cause);
-                let _ = handle_tx.blocking_send(Err(cause));
+                log_error!("Failed to create Tokio runtime: {}", e);
+                let _ = handle_tx.blocking_send(Err(DbError::runtime_error(format!(
+                    "Failed to create Tokio runtime: {}",
+                    e
+                ))));
                 return;
             }
         };
@@ -530,9 +540,9 @@ impl AimDbHandle {
             let (db, runner) = match builder.build().await {
                 Ok(d) => (Arc::new(d.0), d.1),
                 Err(e) => {
-                    let cause = format!("Failed to build database: {}", e);
-                    log_error!("{}", cause);
-                    let _ = db_tx.send(Err(cause)).await;
+                    // Sent as-is: this is the error whose kind is worth keeping.
+                    log_error!("Failed to build database: {}", e);
+                    let _ = db_tx.send(Err(e)).await;
                     return;
                 }
             };

--- a/aimdb-sync/src/lib.rs
+++ b/aimdb-sync/src/lib.rs
@@ -143,7 +143,9 @@
 //!   returned `Ok` into a buffer nobody drains is refused instead (std, Unix)
 //! - `SetTimeout`: Producer timeout expired
 //! - `GetTimeout`: Consumer timeout expired or no data (try_get)
-//! - `AttachFailed`: Failed to start runtime thread
+//! - `AttachFailed`: Failed to start runtime thread, carrying the `DbError`
+//!   that caused it — so `kind()` reports a bad record graph as
+//!   `Configuration` rather than as an internal fault
 //! - `DetachFailed`: Failed to stop runtime thread
 //! - `Db(DbError)`: Any error from the underlying database (e.g. record not
 //!   registered), wrapped unchanged

--- a/aimdb-sync/tests/attach_detach_test.rs
+++ b/aimdb-sync/tests/attach_detach_test.rs
@@ -72,13 +72,16 @@ fn a_failed_build_reports_why() {
     })
     .expect("attach should fail");
 
-    let SyncError::AttachFailed { message } = &err else {
+    let SyncError::AttachFailed { source } = &err else {
         panic!("expected AttachFailed, got {:?}", err);
     };
     assert!(
-        message.contains("runtime not set"),
-        "the cause should survive the trip, got: {message}"
+        source.to_string().contains("runtime not set"),
+        "the cause should survive the trip, got: {source}"
     );
+    // And its classification survives with it: this is a bad record graph, not
+    // an internal fault, and a caller switching on `kind()` must see that.
+    assert_eq!(err.kind(), aimdb_core::DbErrorKind::Configuration);
 }
 
 /// A runtime thread that stops before reporting must end the wait, not extend


### PR DESCRIPTION
> **Stacked on #232** (which is stacked on #230). Base is `fix/sync-detach-no-stranded-thread`, so the diff here is just this change.

## Description

The follow-up #228 flagged and deliberately left out, because it changes a variant's shape and that is a decision rather than a cleanup.

`AttachFailed` held a `String`, so the classification of whatever actually went wrong was thrown away one layer below where it is useful. After #226 that message often *is* a configuration mistake, spelled out in full — and `kind()` still said `Internal`:

```
Failed to attach database: Failed to build database: invalid configuration
(1 error(s)): runtime not set (use .runtime())
```

A caller switching on `kind()` to decide what to do would read that as **"report a bug"** rather than **"fix the graph before starting"** — the opposite of the action it needs, and exactly the failure mode the classification work in #225/#228 exists to prevent.

## The change

The startup channel carries `DbError` rather than `String`:

```rust
type Startup<T> = Result<T, DbError>;
```

so the error from `builder.build()` reaches the caller intact, and `AttachFailed` delegates:

```rust
Self::AttachFailed { source } => source.kind(),
```

The facade's own failures — a thread that would not spawn, a runtime that would not start, a thread that stopped before reporting — become `DbError::runtime_error`, which classifies as `Internal` exactly as before.

`DetachFailed` keeps its `String`. A timeout and a panicked thread have no `DbError` behind them, and inventing one would be worse than saying `Internal`.

## Breaking change

`SyncError::AttachFailed`'s field is now `source: DbError`, was `message: String`.

Cheap right now: `aimdb-sync` is 0.6.0 and unreleased, and `#[non_exhaustive]` landed in #228. `Display` output is unchanged in substance, and the cause is now also reachable through `std::error::Error::source`, which it was not before.

The only in-tree consumer was this crate's own test.

## Tests

- `SyncError::AttachFailed { source: DbError::missing_configuration(..) }.kind()` is `Configuration`, not `Internal` — the unit assertion for the whole point.
- The end-to-end test now asserts both halves: the message still names the cause, **and** `err.kind() == DbErrorKind::Configuration`.

## Related Issue
- Completes the gap recorded in #228.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed (`make check`) — relying on CI for the full matrix; `cargo test -p aimdb-sync`, clippy and the no_std build are green locally.
- [x] I have updated the documentation accordingly.