### PR TITLE
feat(sync): let a producer report whether a publish can still land

### DIFF
--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -86,10 +86,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   publish path is one relaxed atomic load, and a program that never attaches
   never installs a handler. A database the child attaches *itself* after
   forking is unaffected — the guard is a generation counter, not a poison flag.
-  The detection itself is internal: a facade built on this crate has the same
-  problem for the same reason, and asks `SyncProducer::check()` rather than the
-  generation counter, so the crate is committed in semver to the question and
-  not to the mechanism that answers it.
+  The detection itself stays internal: a facade asks `SyncProducer::check()`
+  rather than the generation counter, so the semver commitment is to the
+  question and not to the mechanism.
 - **A panic-freedom contract on the blocking surface.** The crate is compiled
   under `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)` outside
   its own tests, so "a panic here is a bug, not an error channel" is checked
@@ -104,14 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still reach the database?" without publishing — `Ok(())`, or
   `RuntimeShutdown` / `ForkedChild`. It is the check `set()` already performs,
   exposed rather than duplicated, so the answer cannot drift from what a publish
-  would find. A facade built on this crate needs it to report its own closed
-  state: asking its `AimDbHandle` is usually not open to it, because an FFI door
-  keeps the handle behind a lock and answering while a shutdown holds that lock
-  is how a caller's interpreter lock deadlocks against its own teardown. A
-  producer is reachable without that lock — which is why a publish never queues
-  behind a shutdown either. This is the shape the fork detection is exposed
-  through: the question a caller has, not the stamp-and-compare mechanism that
-  happens to answer it today.
+  would find. It takes no lock, which is what makes it usable from a facade
+  whose own teardown holds the lock its `AimDbHandle` sits behind.
 - **`SyncError::kind()`.** Returns `aimdb_core::DbErrorKind` rather than a kind
   of its own, so a caller — an FFI layer above all — has one set of actions for
   the whole stack instead of one per crate. The `Db` arm delegates, so a buffer

--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -86,10 +86,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   publish path is one relaxed atomic load, and a program that never attaches
   never installs a handler. A database the child attaches *itself* after
   forking is unaffected — the guard is a generation counter, not a poison flag.
-  The detection is entirely internal: a facade built on this crate will have the
-  same problem for the same reason, but none exists yet, so exposing the
-  stamp-and-compare pair would commit the crate in semver to a model chosen
-  against no real caller.
+  The detection itself is internal: a facade built on this crate has the same
+  problem for the same reason, and asks `SyncProducer::check()` rather than the
+  generation counter, so the crate is committed in semver to the question and
+  not to the mechanism that answers it.
 - **A panic-freedom contract on the blocking surface.** The crate is compiled
   under `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)` outside
   its own tests, so "a panic here is a bug, not an error channel" is checked
@@ -100,6 +100,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   process dying. Documented with its two limits: `block_on` still panics if
   called from inside a Tokio runtime, and the guarantee stops at this crate's
   edge.
+- **`SyncProducer::check()`.** Answers "can a publish through this producer
+  still reach the database?" without publishing — `Ok(())`, or
+  `RuntimeShutdown` / `ForkedChild`. It is the check `set()` already performs,
+  exposed rather than duplicated, so the answer cannot drift from what a publish
+  would find. A facade built on this crate needs it to report its own closed
+  state: asking its `AimDbHandle` is usually not open to it, because an FFI door
+  keeps the handle behind a lock and answering while a shutdown holds that lock
+  is how a caller's interpreter lock deadlocks against its own teardown. A
+  producer is reachable without that lock — which is why a publish never queues
+  behind a shutdown either. This is the shape the fork detection is exposed
+  through: the question a caller has, not the stamp-and-compare mechanism that
+  happens to answer it today.
 - **`SyncError::kind()`.** Returns `aimdb_core::DbErrorKind` rather than a kind
   of its own, so a caller — an FFI layer above all — has one set of actions for
   the whole stack instead of one per crate. The `Db` arm delegates, so a buffer

--- a/aimdb-sync/src/fork.rs
+++ b/aimdb-sync/src/fork.rs
@@ -76,14 +76,11 @@ fn load() -> Generation {
 
 /// The generation to stamp on something being created now.
 ///
-/// Crate-private, and staying that way. A layer built *on* this crate does have
-/// the same problem — an FFI door holds state of its own that a `fork`
-/// invalidates — but it is served by
-/// [`SyncProducer::check`](crate::SyncProducer::check), which answers the
-/// question that layer actually has ("can I still publish?") rather than
-/// exporting the mechanism that answers it today. Publishing this pair instead
-/// would commit the crate in semver to stamp-and-compare, and a producer is
-/// what such a facade can reach without taking the lock its own shutdown holds.
+/// Crate-private, and staying that way. A layer built *on* this crate has the
+/// same problem, and is served by
+/// [`SyncProducer::check`](crate::SyncProducer::check) — the question it
+/// actually has ("can I still publish?"), rather than the stamp-and-compare
+/// mechanism, which publishing this pair would pin us to in semver.
 ///
 /// **Arms the handler**, because otherwise it hands out a number that cannot
 /// change. A caller above this crate stamps its own state before any database

--- a/aimdb-sync/src/fork.rs
+++ b/aimdb-sync/src/fork.rs
@@ -76,11 +76,14 @@ fn load() -> Generation {
 
 /// The generation to stamp on something being created now.
 ///
-/// Crate-private for now. A layer built *on* this crate has the same problem —
-/// an FFI door holds state of its own that a `fork` invalidates — but no such
-/// layer exists yet, and exposing this would commit us in semver to the
-/// stamp-and-compare model. Widen it when something real needs it, so the
-/// shape can be chosen against that caller rather than guessed at.
+/// Crate-private, and staying that way. A layer built *on* this crate does have
+/// the same problem — an FFI door holds state of its own that a `fork`
+/// invalidates — but it is served by
+/// [`SyncProducer::check`](crate::SyncProducer::check), which answers the
+/// question that layer actually has ("can I still publish?") rather than
+/// exporting the mechanism that answers it today. Publishing this pair instead
+/// would commit the crate in semver to stamp-and-compare, and a producer is
+/// what such a facade can reach without taking the lock its own shutdown holds.
 ///
 /// **Arms the handler**, because otherwise it hands out a number that cannot
 /// change. A caller above this crate stamps its own state before any database

--- a/aimdb-sync/src/producer.rs
+++ b/aimdb-sync/src/producer.rs
@@ -97,27 +97,13 @@ where
     /// Whether a publish through this producer can still reach the database.
     ///
     /// `Ok(())` means [`set`](Self::set) reaches the record graph — not that it
-    /// succeeds. An unregistered key still fails there, as it always has; this
-    /// answers the question before that one.
-    ///
-    /// Two ways it cannot: the runtime thread is gone
-    /// ([`SyncError::RuntimeShutdown`]), or this process `fork`ed since the
-    /// producer was made and the thread did not come across
-    /// ([`SyncError::ForkedChild`]).
-    ///
-    /// # Why this is on the producer and not the handle
-    ///
-    /// A facade built on this crate has to answer "can I still publish?" for
-    /// its own callers, and asking its [`AimDbHandle`](crate::AimDbHandle) is
-    /// usually not open to it: an FFI door keeps the handle behind a lock, and
-    /// answering while a shutdown holds that lock is how a caller's interpreter
-    /// lock deadlocks against its own teardown. A producer is reachable without
-    /// that lock — which is why a publish never queues behind a shutdown either
-    /// — so it is the one place the question can be asked from.
+    /// succeeds; an unregistered key still fails there. Otherwise
+    /// [`SyncError::RuntimeShutdown`] or [`SyncError::ForkedChild`].
     ///
     /// This is the check [`set`](Self::set) performs, not a second one beside
-    /// it, so the answer cannot drift from what a publish would actually do.
-    /// Lock-free and cheap: a [`Weak`] upgrade and one relaxed atomic load.
+    /// it, so the answer cannot drift from what a publish would find. It takes
+    /// no lock — a [`Weak`] upgrade and one relaxed atomic load — so a facade
+    /// can ask it while its own teardown holds the handle's lock.
     #[inline]
     pub fn check(&self) -> SyncResult<()> {
         self.runtime()?.check()

--- a/aimdb-sync/src/producer.rs
+++ b/aimdb-sync/src/producer.rs
@@ -94,6 +94,35 @@ where
         self.rt.upgrade().ok_or(SyncError::RuntimeShutdown)
     }
 
+    /// Whether a publish through this producer can still reach the database.
+    ///
+    /// `Ok(())` means [`set`](Self::set) reaches the record graph — not that it
+    /// succeeds. An unregistered key still fails there, as it always has; this
+    /// answers the question before that one.
+    ///
+    /// Two ways it cannot: the runtime thread is gone
+    /// ([`SyncError::RuntimeShutdown`]), or this process `fork`ed since the
+    /// producer was made and the thread did not come across
+    /// ([`SyncError::ForkedChild`]).
+    ///
+    /// # Why this is on the producer and not the handle
+    ///
+    /// A facade built on this crate has to answer "can I still publish?" for
+    /// its own callers, and asking its [`AimDbHandle`](crate::AimDbHandle) is
+    /// usually not open to it: an FFI door keeps the handle behind a lock, and
+    /// answering while a shutdown holds that lock is how a caller's interpreter
+    /// lock deadlocks against its own teardown. A producer is reachable without
+    /// that lock — which is why a publish never queues behind a shutdown either
+    /// — so it is the one place the question can be asked from.
+    ///
+    /// This is the check [`set`](Self::set) performs, not a second one beside
+    /// it, so the answer cannot drift from what a publish would actually do.
+    /// Lock-free and cheap: a [`Weak`] upgrade and one relaxed atomic load.
+    #[inline]
+    pub fn check(&self) -> SyncResult<()> {
+        self.runtime()?.check()
+    }
+
     /// Set the value, blocking until it can be sent.
     ///
     /// This call will block the current thread until the value can be sent to the runtime thread.

--- a/aimdb-sync/tests/fork_safety_test.rs
+++ b/aimdb-sync/tests/fork_safety_test.rs
@@ -56,6 +56,11 @@ fn a_forked_child_is_refused_rather_than_silently_dropped() {
             inherited.try_set(Reading { value: 2 }),
             Err(SyncError::ForkedChild)
         );
+        // The same refusal, asked rather than provoked. This is what a facade
+        // above this crate calls to answer "am I still open?" in a child, so it
+        // has to agree with the two publishes above — and it does by
+        // construction, being the check they both go through.
+        let check_agrees = matches!(inherited.check(), Err(SyncError::ForkedChild));
         // Leak rather than free. The child is about to `_exit`, which reclaims
         // everything anyway, and `free` is the unsafe act here: it takes the
         // allocator lock, which a thread that did not survive the fork may have
@@ -64,7 +69,7 @@ fn a_forked_child_is_refused_rather_than_silently_dropped() {
         // the destructor, so there is nothing to lose by not running it.
         std::mem::forget(inherited);
 
-        refused && refused_try
+        refused && refused_try && check_agrees
     });
     assert_eq!(code, 0, "the child's publishes should have been refused");
 

--- a/aimdb-sync/tests/fork_safety_test.rs
+++ b/aimdb-sync/tests/fork_safety_test.rs
@@ -56,10 +56,8 @@ fn a_forked_child_is_refused_rather_than_silently_dropped() {
             inherited.try_set(Reading { value: 2 }),
             Err(SyncError::ForkedChild)
         );
-        // The same refusal, asked rather than provoked. This is what a facade
-        // above this crate calls to answer "am I still open?" in a child, so it
-        // has to agree with the two publishes above — and it does by
-        // construction, being the check they both go through.
+        // The same refusal, asked rather than provoked: `check()` has to agree
+        // with the two publishes above.
         let check_agrees = matches!(inherited.check(), Err(SyncError::ForkedChild));
         // Leak rather than free. The child is about to `_exit`, which reclaims
         // everything anyway, and `free` is the unsafe act here: it takes the

--- a/aimdb-sync/tests/integration_test.rs
+++ b/aimdb-sync/tests/integration_test.rs
@@ -247,11 +247,6 @@ fn test_runtime_shutdown_error() {
 }
 
 /// `check()` answers the same question `set()` does, without publishing.
-///
-/// A facade above this crate needs it to report its own "closed" state, and
-/// cannot get there through the handle: that lives behind its lock, and taking
-/// that lock is what its shutdown already holds. The producer is reachable
-/// without it.
 #[test]
 fn check_reports_what_a_publish_would_find() {
     let (handle, producer, _consumer) = setup(BufferCfg::SpmcRing { capacity: 10 });

--- a/aimdb-sync/tests/integration_test.rs
+++ b/aimdb-sync/tests/integration_test.rs
@@ -246,6 +246,28 @@ fn test_runtime_shutdown_error() {
     assert!(matches!(result, Err(SyncError::RuntimeShutdown)));
 }
 
+/// `check()` answers the same question `set()` does, without publishing.
+///
+/// A facade above this crate needs it to report its own "closed" state, and
+/// cannot get there through the handle: that lives behind its lock, and taking
+/// that lock is what its shutdown already holds. The producer is reachable
+/// without it.
+#[test]
+fn check_reports_what_a_publish_would_find() {
+    let (handle, producer, _consumer) = setup(BufferCfg::SpmcRing { capacity: 10 });
+
+    producer.check().expect("usable while attached");
+
+    handle.detach().expect("Failed to detach");
+
+    // The same verdict `set()` reaches, arrived at without sending anything.
+    assert!(matches!(producer.check(), Err(SyncError::RuntimeShutdown)));
+    assert!(matches!(
+        producer.set(test_value()),
+        Err(SyncError::RuntimeShutdown)
+    ));
+}
+
 /// Test error handling - runtime shutdown, non-blocking operations
 #[test]
 fn test_runtime_shutdown_error_non_blocking() {


### PR DESCRIPTION
## Why

A facade built on `aimdb-sync` has to answer *"can I still publish?"* for its own callers, and today it cannot.

`fork::generation` and `fork::forked_since` are crate-private, and asking the `AimDbHandle` is not open to an FFI door that keeps it behind a lock — answering while a shutdown holds that lock is exactly how a caller's interpreter lock deadlocks against its own teardown. That is the lock-ordering rule the Python door established.

So the question had no supported route. `aimdb-weather-mesh`'s `StationHandle::is_closed` reached for `aimdb_sync::fork::*` instead, and stopped compiling when #235 made the module private.

## What

One method on `SyncProducer`:

```rust
pub fn check(&self) -> SyncResult<()> {
    self.runtime()?.check()
}
```

Two lines, because #235 had already put every route in behind a single check. `Ok(())`, or `RuntimeShutdown` / `ForkedChild`.

It answers from the one component reachable **without** the handle's lock — which is also why a publish never queues behind a shutdown. And it is the check `set()` already performs, not a second one beside it, so it cannot report open while a publish would be refused.

## On exposing `fork` instead

Not done, deliberately. What this commits to in semver is the *question*, not the *mechanism*. Publishing the generation pair would pin stamp-and-compare — the objection `2bcc5a3` raised when it withdrew them mid-PR.

That commit deferred the decision for want of a real caller to design against. The caller exists now, and its requirement is specific: cheap, and never the mutex. `check()` is designed against it. The note on `fork::generation` claiming no such layer exists is corrected to point at the supported route.

## Tests

- `check_reports_what_a_publish_would_find` — usable while attached, `RuntimeShutdown` after detach, and the same verdict `set()` reaches.
- The forked-child test now also asserts `check()` agrees with the two publishes beside it. That agreement is the property a facade depends on.

## Verification

- `aimdb-sync`: 58 tests green (was 57), plus `--no-default-features` and `--features data-contracts`.
- `cargo fmt --check` and clippy clean on all three feature configurations.
- End-to-end through the C++ door in `aimdb-weather-mesh` (`make spike-cpp`), all four checks of the fork round green.

## Merge order

`aimdb-dev/aimdb-weather-mesh` has a companion PR that consumes this. **This one lands first** — that one does not compile without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)