### PR TITLE
feat(core): add a `log` destination an FFI layer can install (design 050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Design 050: a log destination an FFI layer can install
+
+`aimdb-core` gains an optional, non-default `log` feature: a second destination
+for the crate-private `log_*` facade, alongside `tracing`. It is for hosts that
+cannot be handed a process-global `tracing` subscriber — the `weather-station-py`
+and `weather-station-cpp` doors both had to add `tracing-subscriber`, write a
+`Layer`, and install the host's global subscriber on the application's behalf,
+and the C++ one then needed a static of its own to hold the caller's
+`user_data`, because a `tracing::Layer` has nowhere to put it. A `log::Log` impl
+*is* that context, so the pointer travels with the callback and the static (with
+its data race and its first-wins/last-wins mismatch) goes away.
+
+With the feature off — the default, and every MCU build — nothing changes.
+`tracing` remains the default and the recommendation for Rust consumers; both
+may be on at once. `aimdb-sync` mirrors the feature, which is required rather
+than cosmetic: the facade macros expand in the calling crate, so the arm is
+selected by *that* crate's features. See
+[docs/design/050-log-destination-for-ffi.md](docs/design/050-log-destination-for-ffi.md);
+the FFI doors themselves are steps 2 and 3 there and live outside this
+repository.
+
 ### Changed — Design 047: AimX protocol version handshake gate (breaking)
 
 `PROTOCOL_VERSION` is bumped **`"2.0"` → `"3.0"`** to mark the design-047

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "heapless 0.9.3",
+ "log",
  "portable-atomic",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,9 +90,8 @@ tokio-serial = "5.4.5"
 
 # Basic observability
 tracing = { version = "0.1", default-features = false }
-# Second facade destination (design 050): lets an FFI layer install a `Log`
-# impl of its own instead of a process-global `tracing` subscriber. no_std by
-# default; `std` only adds `set_boxed_logger`.
+# Second facade destination (design 050), for FFI hosts that cannot be handed a
+# global `tracing` subscriber. no_std by default.
 log = { version = "0.4", default-features = false }
 
 # Async utilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,10 @@ tokio-serial = "5.4.5"
 
 # Basic observability
 tracing = { version = "0.1", default-features = false }
+# Second facade destination (design 050): lets an FFI layer install a `Log`
+# impl of its own instead of a process-global `tracing` subscriber. no_std by
+# default; `std` only adds `set_boxed_logger`.
+log = { version = "0.4", default-features = false }
 
 # Async utilities
 futures = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,10 @@ test:
 	cargo test --package aimdb-core --features "std,tracing,observability"
 	@printf "$(YELLOW)  → Testing aimdb-core (no_std + alloc + observability)$(NC)\n"
 	cargo test --package aimdb-core --no-default-features --features "alloc,observability"
+	@printf "$(YELLOW)  → Testing aimdb-core (log destination: gate, first-wins, target)$(NC)\n"
+	cargo test --package aimdb-core --features "std,log"
+	@printf "$(YELLOW)  → Testing aimdb-core (both destinations: once each)$(NC)\n"
+	cargo test --package aimdb-core --features "std,log,tracing" --test log_facade_delivery
 	@printf "$(YELLOW)  → Testing aimdb-core (no_std + alloc + remote)$(NC)\n"
 	cargo test --package aimdb-core --no-default-features --features "alloc,remote"
 	@printf "$(YELLOW)  → Testing aimdb-core remote module$(NC)\n"
@@ -177,6 +181,8 @@ test:
 	cargo test --package aimdb-sync
 	@printf "$(YELLOW)  → Testing sync wrapper (no_std)$(NC)\n"
 	cargo test --package aimdb-sync --no-default-features
+	@printf "$(YELLOW)  → Testing sync wrapper (log destination; guards the mirrored feature)$(NC)\n"
+	cargo test --package aimdb-sync --features log --test log_facade
 	@printf "$(YELLOW)  → Testing sync wrapper (data-contracts: set_value family)$(NC)\n"
 	cargo test --package aimdb-sync --features data-contracts
 	@printf "$(YELLOW)  → Testing codegen library$(NC)\n"
@@ -256,6 +262,9 @@ clippy:
 	cargo clippy --package aimdb-core --no-default-features --features "alloc,remote" --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on aimdb-core (std)$(NC)\n"
 	cargo clippy --package aimdb-core --features "std,tracing,observability" --all-targets -- -D warnings
+	@printf "$(YELLOW)  → Clippy on aimdb-core (log destination, alone and beside tracing)$(NC)\n"
+	cargo clippy --package aimdb-core --features "std,log" --all-targets -- -D warnings
+	cargo clippy --package aimdb-core --features "std,log,tracing" --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on tokio adapter$(NC)\n"
 	cargo clippy --package aimdb-tokio-adapter --features "tokio-runtime,tracing,observability" --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on embassy adapter$(NC)\n"
@@ -268,6 +277,8 @@ clippy:
 	cargo clippy --package aimdb-sync --no-default-features --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on sync wrapper (data-contracts)$(NC)\n"
 	cargo clippy --package aimdb-sync --features data-contracts --all-targets -- -D warnings
+	@printf "$(YELLOW)  → Clippy on sync wrapper (log destination)$(NC)\n"
+	cargo clippy --package aimdb-sync --features log --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on client library$(NC)\n"
 	cargo clippy --package aimdb-client --all-targets -- -D warnings
 	@printf "$(YELLOW)  → Clippy on client library (serial transport arm)$(NC)\n"
@@ -399,6 +410,8 @@ test-embedded:
 	cargo check --package aimdb-core --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features "alloc,connector-session,remote"
 	@printf "$(YELLOW)  → Checking aimdb-core (no_std/embassy) on thumbv7em-none-eabihf target$(NC)\n"
 	cargo check --package aimdb-core --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features alloc
+	@printf "$(YELLOW)  → Checking aimdb-core (no_std + log destination) on thumbv7em-none-eabihf target$(NC)\n"
+	cargo check --package aimdb-core --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features "alloc,log"
 	@printf "$(YELLOW)  → Checking aimdb-embassy-adapter on thumbv7em-none-eabihf target$(NC)\n"
 	cargo check --package aimdb-embassy-adapter --target thumbv7em-none-eabihf --target-dir $(EMBEDDED_CHECK_TARGET_DIR) --no-default-features --features "embassy-runtime"
 	@printf "$(YELLOW)  → Checking aimdb-embassy-adapter with network support on thumbv7em-none-eabihf target$(NC)\n"

--- a/aimdb-core/CHANGELOG.md
+++ b/aimdb-core/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Design 050: an optional `log` feature, a second destination for the `log_*`
+  facade.** With it on, every facade call site also emits a `log` record; with it
+  off (the default, and every MCU build) the expansion is what it was. It exists
+  for a host that cannot be handed a process-global `tracing` subscriber —
+  chiefly an FFI layer loaded into a non-Rust process, which needs its
+  callback's context pointer to travel *with* the callback. A `log::Log` impl is
+  an ordinary value, so the context lives inside the destination instead of in a
+  static of the binding's own; `set_logger` also decides first-wins once, in
+  Rust, for every binding. `tracing` stays the default and the recommendation for
+  Rust consumers, and both may be enabled at once. Events arrive with
+  `Record::target()` set to the emitting module (`aimdb_core::builder`), the same
+  string a subscriber has always seen. See the crate docs for what a destination
+  must guarantee — the reentrancy rule is stricter than it was under `tracing`,
+  which has a guard `log` does not — and for the three bridges that can deliver
+  an event twice to a process that installed only one destination.
+- **`aimdb_core::__private`, hidden and unstable.** Re-exports the `log` crate so
+  a crate expanding the facade needs the `log` *feature* but not the
+  *dependency*. Not public API.
+
 - **`DbError::kind()` and `DbErrorKind`.** Eight action-shaped kinds — `Retry`,
   `Lagged`, `Closed`, `Transport`, `Data`, `Configuration`, `Usage`, `Internal` —
   so a caller can decide what to do without matching ~20 variants. The match in

--- a/aimdb-core/Cargo.toml
+++ b/aimdb-core/Cargo.toml
@@ -53,13 +53,9 @@ connector-session = ["alloc"]
 # Observability features (available on both std/no_std)
 tracing = ["dep:tracing"] # Works in both std and no_std environments
 defmt = ["dep:defmt"]     # Embedded logging via probe (no_std)
-# A second destination for the `log_*` facade, for hosts that cannot install a
-# `tracing` subscriber — chiefly FFI layers loaded into a non-Rust process,
-# which need the callback's context pointer to travel with the callback (a
-# `tracing::Layer` has nowhere to put it). Deliberately *not* in `default`: 66
-# call sites on an MCU should not each grow a level check because a host FFI
-# layer wanted one. May be combined with `tracing`; see the crate docs for what
-# that costs. See docs/design/050-log-destination-for-ffi.md.
+# A second facade destination, for hosts that cannot be handed a global
+# `tracing` subscriber (design 050). Not in `default`: 66 call sites on an MCU
+# should not each grow a level check because an FFI layer wanted one.
 log = ["dep:log"]
 # Observability: buffer introspection counters (produced/consumed/dropped/
 # occupancy) plus automatic stage profiling (.source()/.tap()/.link() timing).
@@ -115,8 +111,8 @@ portable-atomic = { version = "1.9", default-features = false }
 # Observability (optional)
 tracing = { workspace = true, optional = true }
 defmt = { workspace = true, optional = true }
-# Re-exported as `aimdb_core::__private::log` so facade users do not have to
-# declare the dependency themselves (`::tracing` still carries that tax).
+# Re-exported as `aimdb_core::__private::log`, so facade users need the feature
+# but not this dependency (`::tracing` still charges that tax).
 log = { workspace = true, optional = true }
 
 # Synchronization primitives for no_std

--- a/aimdb-core/Cargo.toml
+++ b/aimdb-core/Cargo.toml
@@ -53,6 +53,14 @@ connector-session = ["alloc"]
 # Observability features (available on both std/no_std)
 tracing = ["dep:tracing"] # Works in both std and no_std environments
 defmt = ["dep:defmt"]     # Embedded logging via probe (no_std)
+# A second destination for the `log_*` facade, for hosts that cannot install a
+# `tracing` subscriber — chiefly FFI layers loaded into a non-Rust process,
+# which need the callback's context pointer to travel with the callback (a
+# `tracing::Layer` has nowhere to put it). Deliberately *not* in `default`: 66
+# call sites on an MCU should not each grow a level check because a host FFI
+# layer wanted one. May be combined with `tracing`; see the crate docs for what
+# that costs. See docs/design/050-log-destination-for-ffi.md.
+log = ["dep:log"]
 # Observability: buffer introspection counters (produced/consumed/dropped/
 # occupancy) plus automatic stage profiling (.source()/.tap()/.link() timing).
 # Works in no_std (heap + atomics + a runtime clock).
@@ -107,6 +115,9 @@ portable-atomic = { version = "1.9", default-features = false }
 # Observability (optional)
 tracing = { workspace = true, optional = true }
 defmt = { workspace = true, optional = true }
+# Re-exported as `aimdb_core::__private::log` so facade users do not have to
+# declare the dependency themselves (`::tracing` still carries that tax).
+log = { workspace = true, optional = true }
 
 # Synchronization primitives for no_std
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }

--- a/aimdb-core/README.md
+++ b/aimdb-core/README.md
@@ -215,6 +215,8 @@ derive = ["aimdb-derive"]           # RecordKey derive macro
 std = ["alloc", "serde", ...]       # Standard library support
 alloc = ["serde"]                   # Heap allocation for no_std
 tracing = ["dep:tracing"]           # Structured logging (std + no_std)
+log = ["dep:log"]                   # Second destination, for FFI hosts that
+                                    # cannot install a global subscriber
 defmt = ["dep:defmt"]               # Embedded logging via probe
 metrics = ["dep:metrics", "std"]    # Performance metrics (requires std)
 test-utils = ["std"]                # Test helpers

--- a/aimdb-core/src/lib.rs
+++ b/aimdb-core/src/lib.rs
@@ -15,94 +15,28 @@
 //!
 //! # Where aimdb's own reporting goes
 //!
-//! `aimdb-core` reports through a crate-private facade with two optional
-//! destinations. Neither is on by default; with both off a call site still
-//! borrows its arguments (so it compiles warning-free) but emits nothing.
+//! Two optional destinations, neither on by default: **`tracing`**, the ordinary
+//! choice for a Rust binary, and **`log`**, for a host that cannot be handed a
+//! process-global subscriber — chiefly an FFI layer, which needs its callback's
+//! context pointer to live somewhere a `tracing::Layer` has no room for. Both
+//! may be on at once; both off emits nothing. Events carry the emitting module
+//! as their target (`aimdb_core::builder`) either way.
+//! See [docs/design/050](https://github.com/aimdb-dev/aimdb/blob/main/docs/design/050-log-destination-for-ffi.md)
+//! for filtering, duplicate delivery, and what the destination does not see.
 //!
-//! - **`tracing`** — the ordinary choice for a Rust binary, and the recommended
-//!   one. Install a subscriber and you get spans, `EnvFilter`'s per-target
-//!   directives, and everything else in that ecosystem.
-//! - **`log`** — for a host that *cannot* install a process-global `tracing`
-//!   subscriber, chiefly an FFI layer loaded into a non-Rust process. A
-//!   `log::Log` impl is an ordinary value, so a C or Python binding can keep its
-//!   callback's context pointer inside the destination itself rather than in a
-//!   static of its own.
+//! ## What a `log` destination must guarantee
 //!
-//! ## Using the `log` destination
+//! Getting one wrong costs a deadlock or memory unsafety, not a bad log line:
 //!
-//! Enable `aimdb-core/log` and install a logger before building the database:
-//!
-//! ```toml
-//! aimdb-core = { version = "1.3", features = ["log"] }
-//! ```
-//!
-//! ```ignore
-//! log::set_logger(&MY_LOGGER)?;      // or `set_boxed_logger` / `Box::leak`
-//! log::set_max_level(log::LevelFilter::Info);
-//! ```
-//!
-//! Events arrive with `Record::target()` set to the emitting module —
-//! `aimdb_core::builder`, `aimdb_core::session::pump`, `aimdb_sync::handle` —
-//! the same strings a `tracing` subscriber sees.
-//!
-//! ## What a destination must guarantee
-//!
-//! No signature can carry these, and an FFI layer that gets one wrong produces a
-//! deadlock or memory unsafety rather than a bad log line:
-//!
-//! 1. **It is called from any thread**, aimdb's runtime thread included — the
-//!    same thread every shutdown waits for. `log::Log` requires `Send + Sync`;
-//!    that requirement is load-bearing, not a formality.
-//! 2. **It must not unwind.** For a `cdylib` reached from C or C++ an unwind
-//!    across the boundary is undefined behaviour, not a crash. Catch on both
-//!    sides.
-//! 3. **It must not call back into aimdb on a path that itself logs.** A
-//!    destination that publishes a reading recurses without bound: unlike
-//!    `tracing`'s dispatcher, `log` has no reentrancy guard, so this is an
-//!    unbounded recursion on the runtime thread rather than a dropped event.
-//!    Calling the *getters* is fine.
-//! 4. **It must not block on anything a thread might hold while calling into
-//!    aimdb.** That is the whole lock ordering; it is what makes "the
-//!    destination must not free the database" a rule rather than a suggestion.
-//! 5. **It cannot be uninstalled.** `log::set_logger` is once per process by
-//!    construction, and reports that honestly: a second call returns `Err` and
-//!    the first destination keeps receiving. Whatever the logger points at must
-//!    outlive the process.
-//!
-//! ## Filtering
-//!
-//! `log::set_max_level` is one relaxed load, checked before the arguments are
-//! formatted, and covers the common case. There is no `EnvFilter` equivalent:
-//! per-target directives are the destination's business, and a `Log` impl that
-//! wants them matches a prefix list against `record.target()` itself.
-//!
-//! ## Both destinations at once
-//!
-//! `tracing` and `log` may both be enabled, and then both arms of the facade
-//! run. A process that installed two destinations sees each event once at each.
-//! A process that installed *one* can still see an event twice, and feature
-//! unification across a workspace can turn `log` on without anyone asking for
-//! it, so it is worth knowing the three bridges that cause it:
-//!
-//! - `tracing-subscriber`'s `tracing-log` feature (**on by default**) —
-//!   `SubscriberInitExt::init`/`try_init` installs a `LogTracer`, which converts
-//!   `log` records into `tracing` events. Turn the feature off, or build the
-//!   subscriber without `init()`.
-//! - `tracing`'s own optional `log` feature, which emits a `log` record for
-//!   every `tracing` event.
-//! - Any `log`-to-`tracing` bridge the process installs itself, such as
-//!   `tracing_log::LogTracer::init()` called directly.
-//!
-//! If duplicates are unacceptable and the host is an FFI layer, the clean answer
-//! is to build `aimdb-core` with `--no-default-features` plus `log` and leave
-//! `tracing` off entirely.
-//!
-//! ## What the `log` destination does not see
-//!
-//! Only events emitted through the facade. `aimdb-mqtt-connector`,
-//! `aimdb-knx-connector`, `aimdb-serial-connector` and `aimdb-uds-connector`
-//! still call `tracing::` directly (24 call sites between them); those reach a
-//! `tracing` subscriber only. Migrating them to the facade is follow-up work.
+//! 1. **Called from any thread**, aimdb's runtime thread included.
+//! 2. **Must not unwind** — across a C or C++ boundary that is UB.
+//! 3. **Must not re-enter aimdb on a path that itself logs.** `log` has no
+//!    reentrancy guard (`tracing` does), so this recurses without bound.
+//!    Getters are fine.
+//! 4. **Must not block on anything a thread might hold while calling into
+//!    aimdb** — that is the lock ordering.
+//! 5. **Cannot be uninstalled.** `set_logger` is once per process; a second
+//!    call returns `Err` and the first destination keeps receiving.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -112,17 +46,14 @@ extern crate alloc;
 #[macro_use]
 mod log;
 
-/// Implementation detail of the `log_*` macros. Not a public API: it carries no
-/// stability guarantee and may change in a patch release.
+/// Implementation detail of the `log_*` macros; no stability guarantee.
 ///
-/// The facade macros are `#[macro_export]`ed, so their bodies expand in the
-/// calling crate and can only name paths reachable from *there*. Re-exporting
-/// the `log` crate here is what lets a facade user enable the destination
-/// without also declaring `log` as a dependency of its own.
+/// The macros expand in the *calling* crate, so they can only name paths
+/// reachable from there — this re-export is what saves a facade user from
+/// declaring `log` itself.
 #[doc(hidden)]
 pub mod __private {
-    // `::log` and not `log`: this crate has a private `log` module at its root,
-    // and the leading `::` says unambiguously that this is the external crate.
+    // `::log`, not `log`: this crate has a private `log` module at its root.
     #[cfg(feature = "log")]
     pub use ::log;
 }

--- a/aimdb-core/src/lib.rs
+++ b/aimdb-core/src/lib.rs
@@ -12,6 +12,97 @@
 //! - **Producer-Consumer**: Built-in typed message passing
 //!
 //! See examples in the repository for usage patterns.
+//!
+//! # Where aimdb's own reporting goes
+//!
+//! `aimdb-core` reports through a crate-private facade with two optional
+//! destinations. Neither is on by default; with both off a call site still
+//! borrows its arguments (so it compiles warning-free) but emits nothing.
+//!
+//! - **`tracing`** — the ordinary choice for a Rust binary, and the recommended
+//!   one. Install a subscriber and you get spans, `EnvFilter`'s per-target
+//!   directives, and everything else in that ecosystem.
+//! - **`log`** — for a host that *cannot* install a process-global `tracing`
+//!   subscriber, chiefly an FFI layer loaded into a non-Rust process. A
+//!   `log::Log` impl is an ordinary value, so a C or Python binding can keep its
+//!   callback's context pointer inside the destination itself rather than in a
+//!   static of its own.
+//!
+//! ## Using the `log` destination
+//!
+//! Enable `aimdb-core/log` and install a logger before building the database:
+//!
+//! ```toml
+//! aimdb-core = { version = "1.3", features = ["log"] }
+//! ```
+//!
+//! ```ignore
+//! log::set_logger(&MY_LOGGER)?;      // or `set_boxed_logger` / `Box::leak`
+//! log::set_max_level(log::LevelFilter::Info);
+//! ```
+//!
+//! Events arrive with `Record::target()` set to the emitting module —
+//! `aimdb_core::builder`, `aimdb_core::session::pump`, `aimdb_sync::handle` —
+//! the same strings a `tracing` subscriber sees.
+//!
+//! ## What a destination must guarantee
+//!
+//! No signature can carry these, and an FFI layer that gets one wrong produces a
+//! deadlock or memory unsafety rather than a bad log line:
+//!
+//! 1. **It is called from any thread**, aimdb's runtime thread included — the
+//!    same thread every shutdown waits for. `log::Log` requires `Send + Sync`;
+//!    that requirement is load-bearing, not a formality.
+//! 2. **It must not unwind.** For a `cdylib` reached from C or C++ an unwind
+//!    across the boundary is undefined behaviour, not a crash. Catch on both
+//!    sides.
+//! 3. **It must not call back into aimdb on a path that itself logs.** A
+//!    destination that publishes a reading recurses without bound: unlike
+//!    `tracing`'s dispatcher, `log` has no reentrancy guard, so this is an
+//!    unbounded recursion on the runtime thread rather than a dropped event.
+//!    Calling the *getters* is fine.
+//! 4. **It must not block on anything a thread might hold while calling into
+//!    aimdb.** That is the whole lock ordering; it is what makes "the
+//!    destination must not free the database" a rule rather than a suggestion.
+//! 5. **It cannot be uninstalled.** `log::set_logger` is once per process by
+//!    construction, and reports that honestly: a second call returns `Err` and
+//!    the first destination keeps receiving. Whatever the logger points at must
+//!    outlive the process.
+//!
+//! ## Filtering
+//!
+//! `log::set_max_level` is one relaxed load, checked before the arguments are
+//! formatted, and covers the common case. There is no `EnvFilter` equivalent:
+//! per-target directives are the destination's business, and a `Log` impl that
+//! wants them matches a prefix list against `record.target()` itself.
+//!
+//! ## Both destinations at once
+//!
+//! `tracing` and `log` may both be enabled, and then both arms of the facade
+//! run. A process that installed two destinations sees each event once at each.
+//! A process that installed *one* can still see an event twice, and feature
+//! unification across a workspace can turn `log` on without anyone asking for
+//! it, so it is worth knowing the three bridges that cause it:
+//!
+//! - `tracing-subscriber`'s `tracing-log` feature (**on by default**) —
+//!   `SubscriberInitExt::init`/`try_init` installs a `LogTracer`, which converts
+//!   `log` records into `tracing` events. Turn the feature off, or build the
+//!   subscriber without `init()`.
+//! - `tracing`'s own optional `log` feature, which emits a `log` record for
+//!   every `tracing` event.
+//! - Any `log`-to-`tracing` bridge the process installs itself, such as
+//!   `tracing_log::LogTracer::init()` called directly.
+//!
+//! If duplicates are unacceptable and the host is an FFI layer, the clean answer
+//! is to build `aimdb-core` with `--no-default-features` plus `log` and leave
+//! `tracing` off entirely.
+//!
+//! ## What the `log` destination does not see
+//!
+//! Only events emitted through the facade. `aimdb-mqtt-connector`,
+//! `aimdb-knx-connector`, `aimdb-serial-connector` and `aimdb-uds-connector`
+//! still call `tracing::` directly (24 call sites between them); those reach a
+//! `tracing` subscriber only. Migrating them to the facade is follow-up work.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -20,6 +111,21 @@ extern crate alloc;
 // Must precede the other modules: `macro_rules!` visibility is textual.
 #[macro_use]
 mod log;
+
+/// Implementation detail of the `log_*` macros. Not a public API: it carries no
+/// stability guarantee and may change in a patch release.
+///
+/// The facade macros are `#[macro_export]`ed, so their bodies expand in the
+/// calling crate and can only name paths reachable from *there*. Re-exporting
+/// the `log` crate here is what lets a facade user enable the destination
+/// without also declaring `log` as a dependency of its own.
+#[doc(hidden)]
+pub mod __private {
+    // `::log` and not `log`: this crate has a private `log` module at its root,
+    // and the leading `::` says unambiguously that this is the external crate.
+    #[cfg(feature = "log")]
+    pub use ::log;
+}
 
 pub mod buffer;
 pub mod builder;

--- a/aimdb-core/src/log.rs
+++ b/aimdb-core/src/log.rs
@@ -15,35 +15,19 @@
 //!   `Vec<String>`). The few sites that mirror events to defmt (router.rs)
 //!   keep explicit `#[cfg(feature = "defmt")]` gates next to these macros.
 //!
-//! # Two destinations, and the feature that selects each
+//! # Mirroring the feature
 //!
-//! These macros are `#[macro_export]`ed, so their bodies expand in the *calling*
-//! crate and every `#[cfg(feature = ...)]` inside them is resolved against that
-//! crate's feature set — not against `aimdb-core`'s. A crate that expands the
-//! facade therefore has to declare a feature of the same name and forward it:
+//! These macros are `#[macro_export]`ed, so `#[cfg(feature = ...)]` inside them
+//! resolves against the *calling* crate. A crate expanding the facade must
+//! declare a feature of the same name and forward it, or its events silently go
+//! nowhere:
 //!
 //! ```toml
 //! tracing = ["dep:tracing", "aimdb-core/tracing"]
-//! log     = ["aimdb-core/log"]   # no `dep:log` — see below
+//! log     = ["aimdb-core/log"]   # no `dep:log`: the arm goes through `__private`
 //! ```
 //!
-//! Forgetting the mirror is silent: the arm simply never expands and that
-//! crate's events go nowhere. `aimdb-sync` is the only crate outside
-//! `aimdb-core` that expands the facade today, and `tests/log_facade_target.rs`
-//! asserts its events arrive.
-//!
-//! The `log` arm names `$crate::__private::log`, a re-export, so a facade user
-//! needs the *feature* but not the *dependency*. The `tracing` arm still names
-//! `::tracing` and so still requires `dep:tracing` downstream; routing it
-//! through `__private` the same way is a separate, non-breaking cleanup.
-//!
-//! # Emitting to both
-//!
-//! `tracing` and `log` may both be on, and then both arms run. That is the
-//! point when a process installed two destinations, and a duplicate when it
-//! installed one — see the `log` feature section of the crate docs for the ways
-//! a single-destination process ends up seeing an event twice, and how to
-//! switch them off.
+//! `aimdb-sync` is the only such crate today; its `tests/log_facade.rs` guards it.
 
 #[macro_export]
 macro_rules! log_debug {

--- a/aimdb-core/src/log.rs
+++ b/aimdb-core/src/log.rs
@@ -1,10 +1,11 @@
 //! Crate-private logging macros.
 //!
-//! `log_debug!`/`log_info!`/`log_warn!`/`log_error!` forward to the matching
-//! `tracing` event macro when the `tracing` feature is enabled; otherwise they
-//! expand to a no-op that still borrows the arguments, so call sites compile
-//! identically (no unused-variable warnings) under every feature combination.
-//! This replaces the per-call-site `#[cfg(feature = "tracing")]` gates.
+//! `log_debug!`/`log_info!`/`log_warn!`/`log_error!` forward to every enabled
+//! *destination* — the `tracing` event macro under the `tracing` feature, the
+//! `log` crate under the `log` feature — and otherwise expand to a no-op that
+//! still borrows the arguments, so call sites compile identically (no
+//! unused-variable warnings) under every feature combination. This replaces the
+//! per-call-site `#[cfg(feature = "tracing")]` gates.
 //!
 //! Notes:
 //! - The no-op branch *borrows* (and therefore evaluates) the arguments — keep
@@ -13,13 +14,45 @@
 //!   types that do not implement `defmt::Format` (e.g. `DbError`, `String`,
 //!   `Vec<String>`). The few sites that mirror events to defmt (router.rs)
 //!   keep explicit `#[cfg(feature = "defmt")]` gates next to these macros.
+//!
+//! # Two destinations, and the feature that selects each
+//!
+//! These macros are `#[macro_export]`ed, so their bodies expand in the *calling*
+//! crate and every `#[cfg(feature = ...)]` inside them is resolved against that
+//! crate's feature set — not against `aimdb-core`'s. A crate that expands the
+//! facade therefore has to declare a feature of the same name and forward it:
+//!
+//! ```toml
+//! tracing = ["dep:tracing", "aimdb-core/tracing"]
+//! log     = ["aimdb-core/log"]   # no `dep:log` — see below
+//! ```
+//!
+//! Forgetting the mirror is silent: the arm simply never expands and that
+//! crate's events go nowhere. `aimdb-sync` is the only crate outside
+//! `aimdb-core` that expands the facade today, and `tests/log_facade_target.rs`
+//! asserts its events arrive.
+//!
+//! The `log` arm names `$crate::__private::log`, a re-export, so a facade user
+//! needs the *feature* but not the *dependency*. The `tracing` arm still names
+//! `::tracing` and so still requires `dep:tracing` downstream; routing it
+//! through `__private` the same way is a separate, non-breaking cleanup.
+//!
+//! # Emitting to both
+//!
+//! `tracing` and `log` may both be on, and then both arms run. That is the
+//! point when a process installed two destinations, and a duplicate when it
+//! installed one — see the `log` feature section of the crate docs for the ways
+//! a single-destination process ends up seeing an event twice, and how to
+//! switch them off.
 
 #[macro_export]
 macro_rules! log_debug {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
         ::tracing::debug!($s $(, $x)*);
-        #[cfg(not(feature = "tracing"))]
+        #[cfg(feature = "log")]
+        $crate::__private::log::debug!($s $(, $x)*);
+        #[cfg(not(any(feature = "tracing", feature = "log")))]
         { let _ = ($( & $x ),*); }
     }};
 }
@@ -29,7 +62,9 @@ macro_rules! log_info {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
         ::tracing::info!($s $(, $x)*);
-        #[cfg(not(feature = "tracing"))]
+        #[cfg(feature = "log")]
+        $crate::__private::log::info!($s $(, $x)*);
+        #[cfg(not(any(feature = "tracing", feature = "log")))]
         { let _ = ($( & $x ),*); }
     }};
 }
@@ -39,7 +74,9 @@ macro_rules! log_warn {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
         ::tracing::warn!($s $(, $x)*);
-        #[cfg(not(feature = "tracing"))]
+        #[cfg(feature = "log")]
+        $crate::__private::log::warn!($s $(, $x)*);
+        #[cfg(not(any(feature = "tracing", feature = "log")))]
         { let _ = ($( & $x ),*); }
     }};
 }
@@ -49,7 +86,9 @@ macro_rules! log_error {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
         ::tracing::error!($s $(, $x)*);
-        #[cfg(not(feature = "tracing"))]
+        #[cfg(feature = "log")]
+        $crate::__private::log::error!($s $(, $x)*);
+        #[cfg(not(any(feature = "tracing", feature = "log")))]
         { let _ = ($( & $x ),*); }
     }};
 }

--- a/aimdb-core/tests/log_facade_delivery.rs
+++ b/aimdb-core/tests/log_facade_delivery.rs
@@ -1,8 +1,6 @@
-//! Design 050, acceptance criteria 3 and 4: an event reaches an installed `log`
+//! Design 050, criteria 3 and 4: an event reaches an installed `log`
 //! destination exactly once, carrying the emitting module as its target — and
-//! when `tracing` is enabled alongside, each destination sees it once.
-//!
-//! `log::set_logger` is once per process, so this criterion owns its binary.
+//! with `tracing` alongside, each destination sees it once.
 #![cfg(feature = "log")]
 
 mod log_support;
@@ -14,9 +12,8 @@ use log_support::Capture;
 
 static CAPTURE: Capture = Capture::new();
 
-/// The builder refuses to `build()` without a runtime, and the facade's most
-/// convenient call sites live past that check. Nothing here is exercised beyond
-/// being present.
+/// `build()` refuses without a runtime, and the call sites are past that check.
+/// Nothing here is exercised beyond being present.
 struct StubRuntime;
 
 impl RuntimeOps for StubRuntime {
@@ -39,10 +36,8 @@ impl RuntimeOps for StubRuntime {
     fn log(&self, _level: LogLevel, _msg: &str) {}
 }
 
-/// A `tracing` destination that counts what it is handed, so criterion 4 can
-/// check "once each" rather than "at least once somewhere". Deliberately not
-/// `tracing-subscriber`: the whole point of design 050 is that a consumer of
-/// the facade needs neither it nor its dependency tree.
+/// Counts what it is handed, so criterion 4 can check "once each". Hand-written
+/// rather than `tracing-subscriber`, since not needing that is the point.
 #[cfg(feature = "tracing")]
 mod trace_sink {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -86,9 +81,8 @@ async fn a_builder_event_arrives_once_with_its_module_as_target() {
         .await
         .expect("an empty builder with a runtime builds");
 
-    // Criterion 3: `Record::target()` is the *expansion site's* module path, so
-    // it stays the string a `tracing` subscriber has always seen — not the name
-    // of whatever crate happens to hold the destination.
+    // Criterion 3: the target is the *expansion site's* module path, so it stays
+    // the string a `tracing` subscriber has always seen.
     let builder_events: Vec<_> = CAPTURE
         .taken()
         .into_iter()
@@ -100,8 +94,7 @@ async fn a_builder_event_arrives_once_with_its_module_as_target() {
         CAPTURE.taken()
     );
 
-    // ...and exactly once: two arms are compiled into the macro, and only one
-    // of them may reach the `log` destination.
+    // ...and exactly once: two arms compile in, only one may reach `log`.
     let collecting = CAPTURE.with_message("Collecting futures for 0 records");
     assert_eq!(
         collecting.len(),
@@ -111,8 +104,7 @@ async fn a_builder_event_arrives_once_with_its_module_as_target() {
     assert_eq!(collecting[0].level, log::Level::Info);
     assert_eq!(collecting[0].target, "aimdb_core::builder");
 
-    // Criterion 4: with both features on, both arms run — once each, not twice
-    // into either.
+    // Criterion 4: both arms run, once each — not twice into either.
     #[cfg(feature = "tracing")]
     {
         use std::sync::atomic::Ordering;

--- a/aimdb-core/tests/log_facade_delivery.rs
+++ b/aimdb-core/tests/log_facade_delivery.rs
@@ -1,0 +1,131 @@
+//! Design 050, acceptance criteria 3 and 4: an event reaches an installed `log`
+//! destination exactly once, carrying the emitting module as its target — and
+//! when `tracing` is enabled alongside, each destination sees it once.
+//!
+//! `log::set_logger` is once per process, so this criterion owns its binary.
+#![cfg(feature = "log")]
+
+mod log_support;
+
+use std::sync::Arc;
+
+use aimdb_core::executor::{BoxFuture, LogLevel, RuntimeOps};
+use log_support::Capture;
+
+static CAPTURE: Capture = Capture::new();
+
+/// The builder refuses to `build()` without a runtime, and the facade's most
+/// convenient call sites live past that check. Nothing here is exercised beyond
+/// being present.
+struct StubRuntime;
+
+impl RuntimeOps for StubRuntime {
+    fn name(&self) -> &'static str {
+        "stub"
+    }
+
+    fn now_nanos(&self) -> u64 {
+        0
+    }
+
+    fn unix_time(&self) -> Option<(u64, u32)> {
+        None
+    }
+
+    fn sleep(&self, _d: core::time::Duration) -> BoxFuture {
+        Box::pin(core::future::pending())
+    }
+
+    fn log(&self, _level: LogLevel, _msg: &str) {}
+}
+
+/// A `tracing` destination that counts what it is handed, so criterion 4 can
+/// check "once each" rather than "at least once somewhere". Deliberately not
+/// `tracing-subscriber`: the whole point of design 050 is that a consumer of
+/// the facade needs neither it nor its dependency tree.
+#[cfg(feature = "tracing")]
+mod trace_sink {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tracing::span;
+
+    pub static BUILDER_EVENTS: AtomicUsize = AtomicUsize::new(0);
+
+    pub struct CountBuilderEvents;
+
+    impl tracing::Subscriber for CountBuilderEvents {
+        fn enabled(&self, _m: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _a: &span::Attributes<'_>) -> span::Id {
+            span::Id::from_u64(1)
+        }
+        fn record(&self, _s: &span::Id, _v: &span::Record<'_>) {}
+        fn record_follows_from(&self, _s: &span::Id, _f: &span::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            if event.metadata().target() == "aimdb_core::builder" {
+                BUILDER_EVENTS.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        fn enter(&self, _s: &span::Id) {}
+        fn exit(&self, _s: &span::Id) {}
+    }
+}
+
+#[tokio::test]
+async fn a_builder_event_arrives_once_with_its_module_as_target() {
+    log::set_logger(&CAPTURE).expect("no other logger may be installed in this binary");
+    log::set_max_level(log::LevelFilter::Trace);
+
+    #[cfg(feature = "tracing")]
+    tracing::subscriber::set_global_default(trace_sink::CountBuilderEvents)
+        .expect("no other subscriber may be installed in this binary");
+
+    let (_db, _runner) = aimdb_core::AimDbBuilder::new()
+        .runtime(Arc::new(StubRuntime))
+        .build()
+        .await
+        .expect("an empty builder with a runtime builds");
+
+    // Criterion 3: `Record::target()` is the *expansion site's* module path, so
+    // it stays the string a `tracing` subscriber has always seen — not the name
+    // of whatever crate happens to hold the destination.
+    let builder_events: Vec<_> = CAPTURE
+        .taken()
+        .into_iter()
+        .filter(|r| r.target == "aimdb_core::builder")
+        .collect();
+    assert!(
+        !builder_events.is_empty(),
+        "no event arrived with target aimdb_core::builder; got {:?}",
+        CAPTURE.taken()
+    );
+
+    // ...and exactly once: two arms are compiled into the macro, and only one
+    // of them may reach the `log` destination.
+    let collecting = CAPTURE.with_message("Collecting futures for 0 records");
+    assert_eq!(
+        collecting.len(),
+        1,
+        "expected one delivery of the builder's collect event, got {collecting:?}"
+    );
+    assert_eq!(collecting[0].level, log::Level::Info);
+    assert_eq!(collecting[0].target, "aimdb_core::builder");
+
+    // Criterion 4: with both features on, both arms run — once each, not twice
+    // into either.
+    #[cfg(feature = "tracing")]
+    {
+        use std::sync::atomic::Ordering;
+        assert!(
+            trace_sink::BUILDER_EVENTS.load(Ordering::Relaxed) > 0,
+            "the tracing arm stopped delivering when the log arm was added"
+        );
+        assert_eq!(
+            CAPTURE
+                .with_message("Record future collection complete")
+                .len(),
+            1,
+            "the log arm delivered more than once with tracing also enabled"
+        );
+    }
+}

--- a/aimdb-core/tests/log_facade_first_wins.rs
+++ b/aimdb-core/tests/log_facade_first_wins.rs
@@ -1,10 +1,8 @@
-//! Design 050, acceptance criterion 6: a second `set_logger` returns `Err` and
-//! the first destination keeps receiving.
+//! Design 050, criterion 6: a second `set_logger` returns `Err` and the first
+//! destination keeps receiving.
 //!
-//! This is the half the C++ door got wrong before design 050 — its header was
-//! last-wins while the C layer beneath it was first-wins, so a second install
-//! replaced the first caller's sink and returned `false` to say it had not.
-//! Deciding it once, in `log`, is what makes that unreproducible.
+//! This is the half the C++ door got wrong — a last-wins header over a
+//! first-wins C layer. Deciding it once, in `log`, makes that unreproducible.
 #![cfg(feature = "log")]
 
 mod log_support;
@@ -22,7 +20,6 @@ fn the_first_destination_wins_and_the_second_is_told() {
     aimdb_core::log_warn!("before the second install");
     assert_eq!(FIRST.count(), 1);
 
-    // Reported honestly, rather than silently replacing what is already there.
     assert!(
         log::set_logger(&SECOND).is_err(),
         "a second set_logger must fail"

--- a/aimdb-core/tests/log_facade_first_wins.rs
+++ b/aimdb-core/tests/log_facade_first_wins.rs
@@ -1,0 +1,43 @@
+//! Design 050, acceptance criterion 6: a second `set_logger` returns `Err` and
+//! the first destination keeps receiving.
+//!
+//! This is the half the C++ door got wrong before design 050 — its header was
+//! last-wins while the C layer beneath it was first-wins, so a second install
+//! replaced the first caller's sink and returned `false` to say it had not.
+//! Deciding it once, in `log`, is what makes that unreproducible.
+#![cfg(feature = "log")]
+
+mod log_support;
+
+use log_support::Capture;
+
+static FIRST: Capture = Capture::new();
+static SECOND: Capture = Capture::new();
+
+#[test]
+fn the_first_destination_wins_and_the_second_is_told() {
+    log::set_logger(&FIRST).expect("the first install succeeds");
+    log::set_max_level(log::LevelFilter::Trace);
+
+    aimdb_core::log_warn!("before the second install");
+    assert_eq!(FIRST.count(), 1);
+
+    // Reported honestly, rather than silently replacing what is already there.
+    assert!(
+        log::set_logger(&SECOND).is_err(),
+        "a second set_logger must fail"
+    );
+
+    aimdb_core::log_warn!("after the second install");
+
+    assert_eq!(
+        FIRST.count(),
+        2,
+        "the first destination stopped receiving after a refused second install"
+    );
+    assert_eq!(
+        SECOND.count(),
+        0,
+        "a refused destination received events anyway"
+    );
+}

--- a/aimdb-core/tests/log_facade_gate.rs
+++ b/aimdb-core/tests/log_facade_gate.rs
@@ -1,9 +1,8 @@
-//! Design 050, acceptance criterion 2: below the installed level, an event
-//! costs the two level loads and formats nothing.
+//! Design 050, criterion 2: below the installed level, an event costs the two
+//! level loads and formats nothing.
 //!
-//! Restricted to the `log`-only build. With `tracing` also on, its arm runs too
-//! and the formatting count would be measuring both arms at once — a
-//! `tracing`-shaped question, and not the one this criterion asks.
+//! `log`-only: with `tracing` also on, the formatting count would be measuring
+//! both arms at once.
 #![cfg(all(feature = "log", not(feature = "tracing")))]
 
 mod log_support;
@@ -17,8 +16,8 @@ static PROBE: FormatProbe = FormatProbe::new();
 fn a_filtered_event_never_reaches_its_arguments() {
     log::set_logger(&CAPTURE).expect("no other logger may be installed in this binary");
 
-    // Below the gate: `log`'s macro checks STATIC_MAX_LEVEL and max_level()
-    // before it builds the `Record`, so `Display` is never called.
+    // `log` checks STATIC_MAX_LEVEL and max_level() before building the
+    // `Record`, so `Display` is never called.
     log::set_max_level(log::LevelFilter::Warn);
     aimdb_core::log_info!("gate probe: {}", PROBE);
 
@@ -29,8 +28,8 @@ fn a_filtered_event_never_reaches_its_arguments() {
     );
     assert_eq!(CAPTURE.count(), 0, "a filtered-out event was delivered");
 
-    // Above the gate: the same call site now formats exactly once. Without this
-    // half, a facade that had quietly stopped emitting altogether would pass.
+    // Above the gate — without this half, a facade that had stopped emitting
+    // altogether would pass.
     log::set_max_level(log::LevelFilter::Trace);
     aimdb_core::log_info!("gate probe: {}", PROBE);
 

--- a/aimdb-core/tests/log_facade_gate.rs
+++ b/aimdb-core/tests/log_facade_gate.rs
@@ -1,0 +1,49 @@
+//! Design 050, acceptance criterion 2: below the installed level, an event
+//! costs the two level loads and formats nothing.
+//!
+//! Restricted to the `log`-only build. With `tracing` also on, its arm runs too
+//! and the formatting count would be measuring both arms at once — a
+//! `tracing`-shaped question, and not the one this criterion asks.
+#![cfg(all(feature = "log", not(feature = "tracing")))]
+
+mod log_support;
+
+use log_support::{Capture, FormatProbe};
+
+static CAPTURE: Capture = Capture::new();
+static PROBE: FormatProbe = FormatProbe::new();
+
+#[test]
+fn a_filtered_event_never_reaches_its_arguments() {
+    log::set_logger(&CAPTURE).expect("no other logger may be installed in this binary");
+
+    // Below the gate: `log`'s macro checks STATIC_MAX_LEVEL and max_level()
+    // before it builds the `Record`, so `Display` is never called.
+    log::set_max_level(log::LevelFilter::Warn);
+    aimdb_core::log_info!("gate probe: {}", PROBE);
+
+    assert_eq!(
+        PROBE.formatted(),
+        0,
+        "a filtered-out event formatted its arguments"
+    );
+    assert_eq!(CAPTURE.count(), 0, "a filtered-out event was delivered");
+
+    // Above the gate: the same call site now formats exactly once. Without this
+    // half, a facade that had quietly stopped emitting altogether would pass.
+    log::set_max_level(log::LevelFilter::Trace);
+    aimdb_core::log_info!("gate probe: {}", PROBE);
+
+    assert_eq!(
+        PROBE.formatted(),
+        1,
+        "an admitted event did not format its arguments exactly once"
+    );
+    let delivered = CAPTURE.taken();
+    assert_eq!(
+        delivered.len(),
+        1,
+        "expected one delivery, got {delivered:?}"
+    );
+    assert_eq!(delivered[0].message, "gate probe: probe");
+}

--- a/aimdb-core/tests/log_support/mod.rs
+++ b/aimdb-core/tests/log_support/mod.rs
@@ -1,0 +1,92 @@
+//! Shared scaffolding for the design-050 `log` destination tests.
+//!
+//! In a subdirectory so Cargo does not build it as a test binary of its own:
+//! `log::set_logger` is once per process, so each acceptance criterion that
+//! installs a logger needs its own test *binary*, and each needs this.
+#![allow(dead_code)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+/// One delivered event, flattened — `log::Record` borrows, so it cannot be kept.
+#[derive(Clone, Debug)]
+pub struct Captured {
+    pub target: String,
+    pub level: log::Level,
+    pub message: String,
+}
+
+/// A destination that keeps everything it is handed.
+pub struct Capture {
+    records: Mutex<Vec<Captured>>,
+}
+
+impl Capture {
+    pub const fn new() -> Self {
+        Self {
+            records: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn taken(&self) -> Vec<Captured> {
+        self.records.lock().unwrap().clone()
+    }
+
+    pub fn count(&self) -> usize {
+        self.records.lock().unwrap().len()
+    }
+
+    pub fn with_message(&self, needle: &str) -> Vec<Captured> {
+        self.taken()
+            .into_iter()
+            .filter(|r| r.message.contains(needle))
+            .collect()
+    }
+}
+
+impl log::Log for Capture {
+    fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        self.records.lock().unwrap().push(Captured {
+            target: record.target().to_string(),
+            level: record.level(),
+            // `args()` is a `fmt::Arguments`: formatting it here is exactly the
+            // work the level gate is supposed to avoid when the event is
+            // filtered out. `FormatProbe` below counts that.
+            message: record.args().to_string(),
+        });
+    }
+
+    fn flush(&self) {}
+}
+
+/// A format argument that reports whether it was ever actually formatted.
+///
+/// The point of the gate is that a filtered-out event never reaches
+/// `Display::fmt`. Counting the calls is the only way to observe that from
+/// outside.
+pub struct FormatProbe {
+    formatted: AtomicUsize,
+}
+
+impl FormatProbe {
+    pub const fn new() -> Self {
+        Self {
+            formatted: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn formatted(&self) -> usize {
+        self.formatted.load(Ordering::Relaxed)
+    }
+}
+
+impl core::fmt::Display for FormatProbe {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.formatted.fetch_add(1, Ordering::Relaxed);
+        f.write_str("probe")
+    }
+}

--- a/aimdb-core/tests/log_support/mod.rs
+++ b/aimdb-core/tests/log_support/mod.rs
@@ -1,8 +1,8 @@
 //! Shared scaffolding for the design-050 `log` destination tests.
 //!
-//! In a subdirectory so Cargo does not build it as a test binary of its own:
-//! `log::set_logger` is once per process, so each acceptance criterion that
-//! installs a logger needs its own test *binary*, and each needs this.
+//! `log::set_logger` is once per process, so each criterion that installs a
+//! logger owns a test binary — hence a subdirectory, which Cargo does not build
+//! as a binary of its own.
 #![allow(dead_code)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -53,9 +53,6 @@ impl log::Log for Capture {
         self.records.lock().unwrap().push(Captured {
             target: record.target().to_string(),
             level: record.level(),
-            // `args()` is a `fmt::Arguments`: formatting it here is exactly the
-            // work the level gate is supposed to avoid when the event is
-            // filtered out. `FormatProbe` below counts that.
             message: record.args().to_string(),
         });
     }
@@ -63,11 +60,8 @@ impl log::Log for Capture {
     fn flush(&self) {}
 }
 
-/// A format argument that reports whether it was ever actually formatted.
-///
-/// The point of the gate is that a filtered-out event never reaches
-/// `Display::fmt`. Counting the calls is the only way to observe that from
-/// outside.
+/// A format argument that counts its own formatting — the only way to observe
+/// from outside that a filtered-out event never reached `Display::fmt`.
 pub struct FormatProbe {
     formatted: AtomicUsize,
 }

--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A `log` feature, mirroring `aimdb-core`'s (design 050).** The `log_*` macros
+  are `#[macro_export]`ed, so their `#[cfg(feature = "log")]` arm is resolved
+  against *this* crate — `aimdb-core/log` on its own would leave this crate's
+  call sites unrouted. It forwards and adds nothing else; no `log` dependency is
+  needed here, because the macro reaches the crate through
+  `aimdb_core::__private`.
+
 ### Fixed
 
 - **A timed-out `detach_timeout` no longer strands a thread.** The wait used a

--- a/aimdb-sync/Cargo.toml
+++ b/aimdb-sync/Cargo.toml
@@ -49,6 +49,13 @@ std = ["aimdb-core/std", "dep:tokio", "dep:aimdb-tokio-adapter", "dep:libc"]
 # Enable tracing for debugging
 tracing = ["dep:tracing", "aimdb-core/tracing"]
 
+# The facade's second destination (design 050). The `log_*` macros expand here,
+# so the `#[cfg(feature = "log")]` arm is resolved against *this* crate's
+# features: without this mirror, enabling `aimdb-core/log` alone would silently
+# leave this crate's events unrouted. No `dep:log` — the macro reaches the crate
+# through `aimdb_core::__private::log`.
+log = ["aimdb-core/log"]
+
 # SyncProducer::set_value / try_set_value / set_value_at for Settable types
 data-contracts = ["dep:aimdb-data-contracts"]
 

--- a/aimdb-sync/Cargo.toml
+++ b/aimdb-sync/Cargo.toml
@@ -49,11 +49,9 @@ std = ["aimdb-core/std", "dep:tokio", "dep:aimdb-tokio-adapter", "dep:libc"]
 # Enable tracing for debugging
 tracing = ["dep:tracing", "aimdb-core/tracing"]
 
-# The facade's second destination (design 050). The `log_*` macros expand here,
-# so the `#[cfg(feature = "log")]` arm is resolved against *this* crate's
-# features: without this mirror, enabling `aimdb-core/log` alone would silently
-# leave this crate's events unrouted. No `dep:log` — the macro reaches the crate
-# through `aimdb_core::__private::log`.
+# The facade's second destination (design 050). Required, not cosmetic: the
+# `log_*` macros expand here, so the arm is selected by *this* crate's features
+# and `aimdb-core/log` alone would leave these call sites unrouted.
 log = ["aimdb-core/log"]
 
 # SyncProducer::set_value / try_set_value / set_value_at for Settable types

--- a/aimdb-sync/tests/log_facade.rs
+++ b/aimdb-sync/tests/log_facade.rs
@@ -1,0 +1,74 @@
+//! Design 050: this crate's facade events reach an installed `log` destination.
+//!
+//! Not a duplicate of `aimdb-core`'s coverage. The `log_*` macros are
+//! `#[macro_export]`ed, so their `#[cfg(feature = "log")]` arm is resolved
+//! against *this* crate's feature set — enabling `aimdb-core/log` alone leaves
+//! these ten call sites silently unrouted. `aimdb-sync/Cargo.toml`'s
+//! `log = ["aimdb-core/log"]` is what prevents that.
+//!
+//! Two of the three ways to break that mirror fail loudly on their own: a
+//! feature that stops forwarding to `aimdb-core/log` makes the arm name a
+//! re-export that is configured out (a compile error), and deleting the feature
+//! makes `--features log` unknown to Cargo. This test covers the third — a
+//! feature that is present and forwards, but whose events do not in fact
+//! arrive — and is the reason `make test` names the combination at all.
+#![cfg(all(feature = "std", feature = "log"))]
+
+use std::sync::Arc;
+
+use aimdb_core::{buffer::BufferCfg, AimDbBuilder};
+// Through the re-export, not a `log` dependency of this crate — the same path
+// the macro arm uses, and the reason a facade user needs only the feature.
+use aimdb_core::__private::log;
+use aimdb_sync::AimDbBuilderSyncExt;
+use aimdb_tokio_adapter::{TokioAdapter, TokioRecordRegistrarExt};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Reading {
+    value: u32,
+}
+
+struct Capture {
+    targets: std::sync::Mutex<Vec<String>>,
+}
+
+impl log::Log for Capture {
+    fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record<'_>) {
+        self.targets
+            .lock()
+            .unwrap()
+            .push(record.target().to_string());
+    }
+    fn flush(&self) {}
+}
+
+static CAPTURE: Capture = Capture {
+    targets: std::sync::Mutex::new(Vec::new()),
+};
+
+#[test]
+fn aimdb_sync_events_reach_the_log_destination() {
+    log::set_logger(&CAPTURE).expect("no other logger may be installed in this binary");
+    log::set_max_level(log::LevelFilter::Trace);
+
+    let mut builder = AimDbBuilder::new().runtime(Arc::new(TokioAdapter));
+    builder.configure::<Reading>("sensor.reading", |reg| {
+        reg.buffer(BufferCfg::SpmcRing { capacity: 8 })
+            .tap(|_ctx, _consumer| async move {});
+    });
+
+    // Dropping without `detach()` is the cheapest facade call site in this
+    // crate — two `log_warn!`s in `AimDbHandle::drop`, at `aimdb_sync::handle`.
+    drop(builder.attach().expect("attach"));
+
+    let targets = CAPTURE.targets.lock().unwrap().clone();
+    assert!(
+        targets.iter().any(|t| t.starts_with("aimdb_sync")),
+        "no aimdb-sync event reached the log destination — is the `log` feature \
+         still mirrored in aimdb-sync/Cargo.toml? got: {targets:?}"
+    );
+}

--- a/aimdb-sync/tests/log_facade.rs
+++ b/aimdb-sync/tests/log_facade.rs
@@ -1,24 +1,17 @@
 //! Design 050: this crate's facade events reach an installed `log` destination.
 //!
-//! Not a duplicate of `aimdb-core`'s coverage. The `log_*` macros are
-//! `#[macro_export]`ed, so their `#[cfg(feature = "log")]` arm is resolved
-//! against *this* crate's feature set — enabling `aimdb-core/log` alone leaves
-//! these ten call sites silently unrouted. `aimdb-sync/Cargo.toml`'s
-//! `log = ["aimdb-core/log"]` is what prevents that.
-//!
-//! Two of the three ways to break that mirror fail loudly on their own: a
-//! feature that stops forwarding to `aimdb-core/log` makes the arm name a
-//! re-export that is configured out (a compile error), and deleting the feature
-//! makes `--features log` unknown to Cargo. This test covers the third — a
-//! feature that is present and forwards, but whose events do not in fact
-//! arrive — and is the reason `make test` names the combination at all.
+//! Not a duplicate of `aimdb-core`'s coverage — the macros expand here, so the
+//! arm is selected by *this* crate's `log` feature. Breaking the mirror two of
+//! three ways already fails loudly (a feature that stops forwarding names a
+//! configured-out re-export; deleting it makes `--features log` unknown to
+//! Cargo). This covers the third: present, forwarding, but not arriving.
 #![cfg(all(feature = "std", feature = "log"))]
 
 use std::sync::Arc;
 
 use aimdb_core::{buffer::BufferCfg, AimDbBuilder};
-// Through the re-export, not a `log` dependency of this crate — the same path
-// the macro arm uses, and the reason a facade user needs only the feature.
+// Through the re-export, not a dependency of this crate — the same path the
+// macro arm uses.
 use aimdb_core::__private::log;
 use aimdb_sync::AimDbBuilderSyncExt;
 use aimdb_tokio_adapter::{TokioAdapter, TokioRecordRegistrarExt};
@@ -61,8 +54,7 @@ fn aimdb_sync_events_reach_the_log_destination() {
             .tap(|_ctx, _consumer| async move {});
     });
 
-    // Dropping without `detach()` is the cheapest facade call site in this
-    // crate — two `log_warn!`s in `AimDbHandle::drop`, at `aimdb_sync::handle`.
+    // The cheapest facade call site here: two `log_warn!`s in `Drop`.
     drop(builder.attach().expect("attach"));
 
     let targets = CAPTURE.targets.lock().unwrap().clone();

--- a/docs/design/050-log-destination-for-ffi.md
+++ b/docs/design/050-log-destination-for-ffi.md
@@ -1,0 +1,388 @@
+# 050 — A log destination an FFI layer can install
+
+**Status:** step 1 of §10 implemented (`aimdb-core` + the `aimdb-sync` mirror).
+Steps 2 and 3 are the FFI doors, which live outside this repository.
+
+**Scope:** additive to `aimdb-core` (1.2.0 → 1.3.0). No breaking change, and no
+behaviour change at all for a build that does not enable the new feature. The
+`tracing` path, the `defmt` path and every existing call site stay exactly as
+they are.
+
+**Vocabulary:** the **facade** is the crate-private `log_*` macro set in
+[`aimdb-core/src/log.rs`](../../aimdb-core/src/log.rs). A **destination** is
+whatever the process installed to receive what the facade emits. Before this
+change there was exactly one kind of destination — a global
+`tracing::Subscriber` — and that was the whole problem.
+
+---
+
+## 1. Where this sits
+
+AimDB has two FFI doors now: `weather-station-py` (pyo3) and
+`weather-station-cpp` (a C ABI). Both had to answer the same question — *how
+does a non-Rust application receive aimdb's reporting?* — and both arrived at
+the same unhappy answer: add `tracing` **and** `tracing-subscriber` to the
+manifest, write a `Layer`, and install the process's global subscriber on the
+application's behalf.
+
+That is the trespass the doors otherwise refuse. `weather-station`'s own
+`init_tracing` is a Rust convenience precisely because an *extension* deciding
+where its host's diagnostics go is not the extension's call. The FFI layers then
+do it anyway, because there is no other way in.
+
+It has already produced a real defect. The C++ door has to hold the caller's
+`void *user_data` somewhere, since a `tracing::Layer` has nowhere to put it — so
+the C++ header keeps a static `SinkHolder`, writes it non-atomically while
+aimdb's runtime thread reads it, and (because the C layer beneath is first-wins
+while the header is last-wins) a second `init_logging` silently replaces the
+first caller's sink while returning `false` to say it did not. Both halves of
+that bug exist only because `user_data` cannot travel with the callback.
+
+This design gives the facade a second, ordinary destination, so an FFI layer
+hands aimdb a function and a context pointer instead of installing a subscriber.
+
+**What it does not claim.** `log::set_logger` is a process-global, once-only
+install, exactly as `tracing`'s is. The win is not that the destination stops
+being global; it is that the destination is an ordinary value (so `user_data`
+lives inside it), that the first-wins decision is made once in Rust, and that
+`tracing-subscriber` leaves the FFI dependency graph. That a `cdylib` links its
+own copy of `log`'s statics, and so does not fight a Rust host for them, is a
+convenience of the layout rather than a property of the design.
+
+## 2. Current state (verified)
+
+**The facade is four macros over positional format arguments.** `log_debug!`,
+`log_info!`, `log_warn!`, `log_error!` take `$s:literal $(, $x:expr)*` and expand
+to the matching `tracing` event macro when the `tracing` feature is on, otherwise
+to a borrow-and-drop that keeps call sites warning-free. There is no
+`log_trace!`.
+
+Two consequences worth stating, because they decide how cheap this change is:
+
+- **No spans and no structured fields are in play.** Every call site is a
+  literal plus positional arguments, so a destination that receives
+  `(level, target, fmt::Arguments)` loses nothing that exists today.
+- **The target is the expansion site's `module_path!()`.** That is where
+  `aimdb_core::builder` and `aimdb_core::session::pump` come from in a
+  consumer's output, and any new arm must preserve it.
+
+**Volume:** 66 call sites in `aimdb-core`, 10 in `aimdb-sync` — and those two
+crates are the only facade users in the workspace. Four other crates
+(`aimdb-mqtt-connector`, `aimdb-knx-connector`, `aimdb-uds-connector`,
+`aimdb-serial-connector`) report through `tracing::` directly, 24 call sites
+between them; see §8.
+
+**The module is private** — `#[macro_use] mod log;`
+([`lib.rs:22`](../../aimdb-core/src/lib.rs#L22)) — while the macros are
+`#[macro_export]`ed to the crate root. Anything a macro arm names has to be
+reachable from the *consumer's* crate, which is why the current arm says
+`::tracing::info!` and why every crate using the facade must declare `tracing`
+itself and mirror the feature:
+
+```toml
+# aimdb-sync/Cargo.toml, aimdb-tokio-adapter, aimdb-mqtt-connector, and five more
+tracing = ["dep:tracing", "aimdb-core/tracing"]
+```
+
+**The only way to receive an event, before this change:**
+
+| Consumer | What it must do |
+|---|---|
+| A Rust binary | install a `tracing` subscriber — ordinary and correct |
+| An embedded build | `defmt`, via the explicit gates in `router.rs` |
+| A Python extension | add `tracing-subscriber`, write a `Layer`, `try_init()` |
+| A C/C++ shared library | the same, plus a static of its own for `user_data` |
+
+The last two rows are the finding. `weather-station-cpp` reaches
+`tracing_subscriber::registry().with(env_filter).with(CLoggingLayer).try_init()`
+from inside a `cdylib` that has been loaded into somebody else's process.
+
+## 3. Decision: emit through the `log` facade as well
+
+An optional `log` feature on `aimdb-core` whose only effect is a second arm in
+each macro:
+
+```rust
+#[macro_export]
+macro_rules! log_info {
+    ($s:literal $(, $x:expr)* $(,)?) => {{
+        #[cfg(feature = "tracing")]
+        ::tracing::info!($s $(, $x)*);
+        #[cfg(feature = "log")]
+        $crate::__private::log::info!($s $(, $x)*);
+        #[cfg(not(any(feature = "tracing", feature = "log")))]
+        { let _ = ($( & $x ),*); }
+    }};
+}
+```
+
+with
+
+```rust
+#[doc(hidden)]
+pub mod __private {
+    // `::log`, not `log`: this crate has a private `log` module at its root.
+    #[cfg(feature = "log")]
+    pub use ::log;
+}
+```
+
+That is the entire core change: one feature, one re-export, four macro arms.
+No new public API, no new `unsafe`, nothing to keep working for the next decade.
+
+**Why `log` rather than a bespoke hook.** `log` already is the thing CR-12 asked
+for, built and stabilised:
+
+| What the FFI layer needs | `log` gives it |
+|---|---|
+| a destination that is a value, not a subscriber written against a framework | `trait Log { fn log(&self, record: &Record) }` |
+| somewhere to keep `user_data` | the `Log` impl *is* the context — one leaked `Box` at install |
+| first-wins, reported honestly | `set_logger` / `set_boxed_logger` → `Result<(), SetLoggerError>` |
+| a cheap global level gate | `set_max_level` / `max_level()` |
+| the emitting module | `Record::target()`, defaulted to `module_path!()` |
+| no `tracing-subscriber` in the graph | `log` pulls in nothing |
+| `no_std` | `log` is `no_std` by default; `std` only adds `set_boxed_logger` |
+
+The alternative — a hand-written `set_log_sink(&'static dyn LogSink)` in
+`aimdb-core` — is in §7. It is a worse trade for a crate that already carries
+enough public surface.
+
+### 3.1 What the C++ door becomes
+
+```rust
+struct CSink { callback: ws_log_callback, user_data: *mut c_void }
+
+// SAFETY: the pointer is opaque to this layer; the C contract requires it to
+// outlive the process, and the callback to be callable from any thread.
+unsafe impl Send for CSink {}
+unsafe impl Sync for CSink {}
+
+impl log::Log for CSink {
+    fn enabled(&self, _: &log::Metadata<'_>) -> bool { true }
+    fn flush(&self) {}
+    fn log(&self, record: &log::Record<'_>) { /* CStrings, then callback(...) */ }
+}
+
+// ws_init_logging:
+let sink = Box::leak(Box::new(CSink { callback, user_data }));
+match log::set_logger(sink) {
+    Ok(()) => { log::set_max_level(level); true }
+    Err(_)  => false,
+}
+```
+
+`user_data` now travels with the callback through Rust, which deletes the
+defect that motivated this design:
+
+- `detail::SinkHolder`, `detail::sink_holder()` and `detail::sink_trampoline`
+  disappear from `weather_station.hpp`. There is no static to race on.
+- The first-wins decision lives in one place, in Rust, for every binding —
+  so neither the Python door nor the next one can reintroduce it.
+- `tracing` and `tracing-subscriber` leave both FFI manifests.
+
+`Record` also carries `file()` and `line()`. The C callback signature is being
+designed now and widening it later is a breaking ABI change, so decide then
+rather than after.
+
+### 3.2 Feature layout
+
+```toml
+# aimdb-core/Cargo.toml
+log = ["dep:log"]          # not in `default`
+
+# aimdb-sync/Cargo.toml
+log = ["aimdb-core/log"]   # no `dep:log` — see below
+```
+
+- **Not default.** 66 call sites on an MCU should not each grow a level check
+  because a host FFI layer wanted one.
+- **The feature must be mirrored by every facade user; the dependency need not
+  be.** The macros are `#[macro_export]`ed, so `#[cfg(feature = "log")]` inside
+  them is resolved against the *expanding* crate. `aimdb-core/log` alone leaves
+  `aimdb-sync`'s ten call sites unrouted, which is why `aimdb-sync` carries a
+  `log` feature of its own. What the `$crate::__private::log` re-export removes
+  is the `dep:log` half of the tax that `::tracing` still charges — routing
+  `::tracing` through `__private` the same way is worth doing and strictly
+  separable from this change.
+- **`tracing` and `log` may both be on**, and then both arms run. See §5.1:
+  "both on" is not the same as "the process wanted both".
+- **`defmt` is untouched.** The explicit `#[cfg(feature = "defmt")]` gates in
+  `router.rs` stay exactly where they are.
+
+## 4. The contract a destination must meet
+
+This lives in the crate docs, because it is the part no signature can carry and
+the part an FFI layer gets wrong:
+
+1. **It is called from any thread**, aimdb's runtime thread included — the same
+   thread every shutdown waits for.
+2. **It must not unwind.** For a `cdylib` reached from C or C++ this is
+   undefined behaviour, not a crash. The FFI layer catches on both sides.
+3. **It must not call back into aimdb on a path that itself logs.** A logger
+   that publishes a reading recurses without bound. Calling the *getters* is
+   fine and is exercised by the C++ spike, which reenters `ws_station_is_closed`
+   and `ws_station_slot` from inside the logging path on the runtime thread,
+   including during that station's own shutdown.
+4. **It must not block on anything a thread might hold while calling into
+   aimdb.** That is the whole lock ordering, and it is what makes rule 3 in the
+   C header ("must not call `ws_station_free`") a rule rather than a suggestion.
+5. **It cannot be uninstalled.** `set_logger` is once per process by
+   construction; the leaked `Box` and whatever it points at must outlive the
+   process.
+
+Rule 3 is stricter here than it was under `tracing`: `tracing`'s dispatcher
+carries a reentrancy guard, and `log` has none. Under `tracing` a violation cost
+a dropped event; under `log` it is an unbounded recursion on the runtime thread.
+
+## 5. Filtering, and the things that get worse
+
+Before this change the C++ door took a filter string in `tracing`'s `EnvFilter`
+syntax and got per-target directives (`aimdb_core::builder=debug`) for free,
+because `tracing-subscriber` was in the graph. Dropping it means dropping that.
+
+What replaces it, in order of who does the work:
+
+- **`log::set_max_level`** — one relaxed load and a compare, checked before the
+  arguments are formatted. Covers the common case ("info, and debug when I am
+  chasing something").
+- **Per-target directives are the destination's business.** A `Log` impl sees
+  `record.target()` and can match a prefix list; the C header already tells C
+  callers they filter with `strncmp`, since C has no logger hierarchy. Roughly
+  thirty lines in the FFI crate, and it keeps the filtering policy where the
+  policy-holder is.
+
+This is a real regression in convenience for the two FFI doors and should be
+named as one in their READMEs rather than discovered. It is not a regression for
+any Rust consumer, who keeps `tracing` and `EnvFilter` exactly as today.
+
+### 5.1 Duplicate delivery
+
+A process that installed two destinations sees each event once at each — that is
+the point. A process that installed *one* can still see an event twice, and
+because feature unification can turn `log` on for a workspace without anyone
+asking, this is not always a choice the process made. Three bridges cause it:
+
+- `tracing-subscriber`'s `tracing-log` feature, **on by default**:
+  `SubscriberInitExt::init`/`try_init` installs a `LogTracer` that converts
+  `log` records into `tracing` events. A Rust app that installed only a
+  subscriber then sees every aimdb event twice.
+- `tracing`'s own optional `log` feature, which emits a `log` record per
+  `tracing` event.
+- Any `log`→`tracing` bridge the host installs itself.
+
+Documented rather than prevented: making the arms mutually exclusive by
+precedence would mean the `log` arm silently vanishing whenever unification
+turned `tracing` on, which is the worse failure. An FFI door that wants no
+duplicates builds with `--no-default-features --features log` and leaves
+`tracing` off entirely.
+
+## 6. What it costs
+
+| Configuration | Per call site |
+|---|---|
+| feature off (default, including every MCU build) | nothing — the same expansion as before |
+| feature on, no logger installed | `log`'s `STATIC_MAX_LEVEL` check and a relaxed `max_level()` load; arguments are borrowed, never formatted |
+| feature on, logger installed, below the level | the same two loads |
+| feature on, event delivered | one virtual call plus whatever the destination does |
+
+No allocation is added on any path in `aimdb-core`. The FFI layer allocates two
+`CString`s per delivered event, as it does today.
+
+Binary size: one `log` crate (no proc macros, no `syn`, no `regex`) against
+`tracing-subscriber` leaving both FFI builds — a net reduction where it matters.
+
+One unification hazard worth knowing: `log`'s `release_max_level_*` features are
+additive and compile the gate out globally, so any crate in the graph that
+enables one silences the facade for everybody.
+
+## 7. Alternative considered: a bespoke `set_log_sink`
+
+```rust
+pub trait LogSink: Sync {
+    fn log(&self, level: LogLevel, target: &str, args: fmt::Arguments<'_>);
+}
+pub fn set_log_sink(sink: &'static dyn LogSink) -> Result<(), SinkAlreadySet>;
+```
+
+Same shape, and it is what `log::set_logger` *is*. Storing a `&'static dyn` with
+no `alloc` and no unstable `ptr::from_raw_parts` means the `log` crate's own
+state machine — an `AtomicU8` guarding a cell, with the write published by a
+release store — about sixty lines with `unsafe` in them, plus a `LogLevel` enum,
+a `SinkAlreadySet` error, a `set_max_level`, and a permanent public API in a
+crate at 1.2.0.
+
+`portable-atomic` is already an unconditional dependency
+([`Cargo.toml:105`](../../aimdb-core/Cargo.toml#L105)), so the CAS-less-target
+problem has a house answer if this route is ever taken.
+
+Take it only if a second facade in `log.rs` is judged worse than sixty lines of
+`unsafe` and a new public API. It buys one thing `log` does not: freedom from a
+dependency the embedded profile might not want — which the feature gate already
+provides.
+
+**Also considered and rejected: a `__private::emit()` function** in place of the
+cfg'd macro arm. It would move the feature decision into `aimdb-core` entirely
+and delete the mirroring requirement of §3.2. It also means constructing
+`fmt::Arguments` at all 76 call sites unconditionally and trusting the inliner to
+remove it when both destinations are off — which is exactly the guarantee the
+embedded profile is owed. Worth revisiting if the facade ever grows a third
+destination.
+
+## 8. Non-goals
+
+- **The four crates that call `tracing::` directly.** `aimdb-mqtt-connector`,
+  `aimdb-knx-connector`, `aimdb-uds-connector` and `aimdb-serial-connector`
+  report outside the facade, so a `log` destination will not see those 24 call
+  sites. Migrating them is ordinary follow-up work and is not this change.
+- **Per-`AimDbHandle` routing.** Two stations in one C++ process cannot separate
+  their events, which is a genuine limitation. Fixing it means threading a
+  context through 76 context-free macro call sites; it is a different design.
+- **Replacing `tracing`.** It stays the default and the recommended destination
+  for Rust consumers, with spans available to them if the facade ever grows
+  them.
+- **Structured fields.** The facade has none today; adding them is not this
+  change.
+- **Changing `defmt`.**
+
+## 9. Acceptance criteria
+
+`log::set_logger` is once per process, so each criterion that installs a logger
+owns its own integration-test binary.
+
+1. `aimdb-core` builds and tests unchanged with the feature off, and `log` does
+   not appear in `cargo tree` for such a build. *(`make test`, unchanged
+   combinations.)*
+2. With `--features log` and a logger installed above the emitted level, an
+   event costs the two level loads and never reaches `Display::fmt`; above the
+   level the same call site formats exactly once.
+   *(`tests/log_facade_gate.rs`, via an argument that counts its own
+   formatting.)*
+3. With a logger installed, an event arrives once, with
+   `target() == "aimdb_core::builder"` for a builder event — the same string a
+   `tracing` subscriber sees today. *(`tests/log_facade_delivery.rs`.)*
+4. `--features "log,tracing"` delivers to both, once each.
+   *(the same test, with a counting `tracing::Subscriber` written by hand —
+   deliberately not `tracing-subscriber`.)*
+5. `--no-default-features --features "alloc,log"` compiles for
+   `thumbv7em-none-eabihf`. *(`make test-embedded`.)*
+6. A second `set_logger` returns `Err` and the first destination keeps
+   receiving. *(`tests/log_facade_first_wins.rs`.)*
+7. `aimdb-sync`'s call sites reach the destination, so the mirrored feature of
+   §3.2 cannot be dropped unnoticed.
+   *(`aimdb-sync/tests/log_facade.rs`, named by `make test`.)*
+8. `weather-station-cpp` builds with no `tracing-subscriber` in `cargo tree`,
+   `make spike-cpp` stays green, and its sink round still reports `aimdb_core::*`
+   targets. *(Out of this repository; step 2 below.)*
+
+## 10. Sequencing
+
+1. **Done.** `aimdb-core`: feature, re-export, four macro arms, crate docs for
+   §4/§5.1; the `aimdb-sync` mirror; criteria 1–7. Releasable as 1.3.0.
+2. `weather-station-cpp`: `ws_init_logging` forwards to `set_logger`; the header
+   loses `SinkHolder` and the trampoline; the prefix filter replaces `EnvFilter`.
+   The two defects in the header are deleted rather than fixed.
+3. `weather-station-py`: the same, for the `logging` bridge.
+4. Optional, separable: route `::tracing` through `$crate::__private` too, and
+   drop the mirrored `tracing` feature from the eight crates that carry it.
+5. Optional, separable: move the four direct-`tracing::` connectors onto the
+   facade, so a `log` destination sees them too.


### PR DESCRIPTION
The `log_*` facade had exactly one kind of destination: a process-global
`tracing::Subscriber`. That left both FFI doors — `weather-station-py` and
`weather-station-cpp` — installing the host application's global subscriber
on its behalf, which is the trespass those doors otherwise refuse. It also
produced a real defect: a `tracing::Layer` has nowhere to put the caller's
`void *user_data`, so the C++ header kept a static `SinkHolder`, wrote it
non-atomically while the runtime thread read it, and (being last-wins over a
first-wins C layer) silently replaced the first caller's sink while returning
`false` to say it had not.

Add an optional, non-default `log` feature whose only effect is a second arm
in each of the four macros, plus a `#[doc(hidden)] __private` re-export of the
`log` crate so a facade user needs the feature but not the dependency. A
`log::Log` impl is an ordinary value, so the context pointer travels with the
callback, and `set_logger` decides first-wins once, in Rust, for every binding.

No new public API, no new `unsafe`. With the feature off — the default, and
every MCU build — the expansion is what it was. `tracing` stays the default and
the recommendation for Rust consumers; both may be on at once.

`aimdb-sync` mirrors the feature, which is required rather than cosmetic: the
macros are `#[macro_export]`ed, so `#[cfg(feature = "log")]` inside them is
resolved against the expanding crate, and `aimdb-core/log` alone would leave
its ten call sites unrouted. `aimdb-sync/tests/log_facade.rs` guards that.

Two things the design doc understated, now written down where they will be
read (crate docs, §4/§5.1 of the design):

- `tracing`'s dispatcher has a reentrancy guard and `log` has none, so a
  destination that logs back into aimdb recurses without bound rather than
  dropping an event.
- "both features on" is not the same as "the process wanted both": with
  `tracing-subscriber`'s default `tracing-log` feature, a process that
  installed only a subscriber sees every event twice.

Tests cover acceptance criteria 1-7. `log::set_logger` is once per process, so
each criterion that installs a logger owns its own integration-test binary.
Criterion 4 uses a hand-written counting `tracing::Subscriber` rather than
`tracing-subscriber`, since not needing it is the point.

Steps 2 and 3 of the sequencing are the FFI doors themselves, which live
outside this repository.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QgaHbjCPgkNS6Y34jxqVYH