### PR TITLE
feat(core): finish design 050 — one facade for every crate that reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — Design 050 §10.4/§10.5: one facade, both destinations, no dependency tax
+
+`::tracing` now goes through `$crate::__private` exactly as `log` already did, so
+a crate using the `log_*` macros declares **neither** dependency — only the
+matching feature, which cannot be delegated because a `#[cfg]` inside a
+`#[macro_export]`ed macro is resolved where it expands. Forgetting one is no
+longer silent: `unexpected_cfgs` fires at every call site, which `make clippy`
+turns into an error.
+
+The four connectors that still reported through `tracing::` directly —
+`aimdb-mqtt-connector`, `aimdb-knx-connector`, `aimdb-uds-connector`,
+`aimdb-serial-connector` — are on the facade, so a `log` destination sees their
+24 events too. Every crate in the workspace that reports at all now reports
+through the facade. Each converted site also shed the hand-written
+`#[cfg(feature = "tracing")]` the facade carries itself.
+
+`aimdb-core` gains `log_trace!`, the fifth macro, for a KNX site that needed it.
+
+The design doc's §10.4 said the re-export would let the mirrored `tracing`
+feature be dropped. It would not, and that contradicted its own §3.2; the
+sequencing section now says so and explains what mirroring actually costs.
+
 ### Added — Design 050: a log destination an FFI layer can install
 
 `aimdb-core` gains an optional, non-default `log` feature: a second destination

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-test",
- "tracing",
  "uuid",
 ]
 
@@ -311,7 +310,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-test",
- "tracing",
  "uuid",
 ]
 
@@ -356,7 +354,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-serial",
- "tracing",
 ]
 
 [[package]]
@@ -371,7 +368,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -421,7 +417,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/aimdb-core/CHANGELOG.md
+++ b/aimdb-core/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`log_trace!`.** The fifth facade macro, completing the set both destinations
+  support. Added for a KNX call site that was `tracing::trace!` before design
+  050 §10.5 moved it onto the facade.
+
+### Changed
+
+- **`::tracing` is reached through `$crate::__private`,** as `log` already was.
+  A crate using the `log_*` macros now declares neither `tracing` nor `log` as a
+  dependency of its own — only the matching feature, which cannot be delegated:
+  a `#[cfg]` inside a `#[macro_export]`ed macro is resolved where it expands.
+  Non-breaking; a crate that still declares `dep:tracing` is unaffected.
+
+### Added
+
 - **Design 050: an optional `log` feature, a second destination for the `log_*`
   facade.** With it on, every facade call site also emits a `log` record; with it
   off (the default, and every MCU build) the expansion is what it was. It exists

--- a/aimdb-core/src/lib.rs
+++ b/aimdb-core/src/lib.rs
@@ -21,8 +21,10 @@
 //! context pointer to live somewhere a `tracing::Layer` has no room for. Both
 //! may be on at once; both off emits nothing. Events carry the emitting module
 //! as their target (`aimdb_core::builder`) either way.
-//! See [docs/design/050](https://github.com/aimdb-dev/aimdb/blob/main/docs/design/050-log-destination-for-ffi.md)
-//! for filtering, duplicate delivery, and what the destination does not see.
+//! Every crate in this workspace that reports at all now does so through the
+//! facade, so a destination sees the connectors too. See
+//! [docs/design/050](https://github.com/aimdb-dev/aimdb/blob/main/docs/design/050-log-destination-for-ffi.md)
+//! for filtering and duplicate delivery.
 //!
 //! ## What a `log` destination must guarantee
 //!
@@ -56,6 +58,8 @@ pub mod __private {
     // `::log`, not `log`: this crate has a private `log` module at its root.
     #[cfg(feature = "log")]
     pub use ::log;
+    #[cfg(feature = "tracing")]
+    pub use ::tracing;
 }
 
 pub mod buffer;

--- a/aimdb-core/src/log.rs
+++ b/aimdb-core/src/log.rs
@@ -1,6 +1,6 @@
 //! Crate-private logging macros.
 //!
-//! `log_debug!`/`log_info!`/`log_warn!`/`log_error!` forward to every enabled
+//! `log_trace!`/`log_debug!`/`log_info!`/`log_warn!`/`log_error!` forward to every enabled
 //! *destination* — the `tracing` event macro under the `tracing` feature, the
 //! `log` crate under the `log` feature — and otherwise expand to a no-op that
 //! still borrows the arguments, so call sites compile identically (no
@@ -23,17 +23,37 @@
 //! nowhere:
 //!
 //! ```toml
-//! tracing = ["dep:tracing", "aimdb-core/tracing"]
-//! log     = ["aimdb-core/log"]   # no `dep:log`: the arm goes through `__private`
+//! tracing = ["aimdb-core/tracing"]   # no `dep:tracing`
+//! log     = ["aimdb-core/log"]       # no `dep:log`
 //! ```
 //!
-//! `aimdb-sync` is the only such crate today; its `tests/log_facade.rs` guards it.
+//! Neither arm needs the dependency declared: both go through `$crate::__private`.
+//! The *feature* is what cannot be dropped — a `#[cfg]` in a `#[macro_export]`ed
+//! macro is resolved where it expands, so a crate without it would emit nothing.
+//!
+//! That is not a silent failure any more: an undeclared feature name makes
+//! `unexpected_cfgs` fire at every call site, which is a warning in an ordinary
+//! build and an error under `-D warnings`, as `make clippy` runs it. A dropped
+//! mirror therefore breaks CI rather than quietly muting a crate.
+//! `aimdb-sync/tests/log_facade.rs` additionally proves delivery end to end.
+
+#[macro_export]
+macro_rules! log_trace {
+    ($s:literal $(, $x:expr)* $(,)?) => {{
+        #[cfg(feature = "tracing")]
+        $crate::__private::tracing::trace!($s $(, $x)*);
+        #[cfg(feature = "log")]
+        $crate::__private::log::trace!($s $(, $x)*);
+        #[cfg(not(any(feature = "tracing", feature = "log")))]
+        { let _ = ($( & $x ),*); }
+    }};
+}
 
 #[macro_export]
 macro_rules! log_debug {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
-        ::tracing::debug!($s $(, $x)*);
+        $crate::__private::tracing::debug!($s $(, $x)*);
         #[cfg(feature = "log")]
         $crate::__private::log::debug!($s $(, $x)*);
         #[cfg(not(any(feature = "tracing", feature = "log")))]
@@ -45,7 +65,7 @@ macro_rules! log_debug {
 macro_rules! log_info {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
-        ::tracing::info!($s $(, $x)*);
+        $crate::__private::tracing::info!($s $(, $x)*);
         #[cfg(feature = "log")]
         $crate::__private::log::info!($s $(, $x)*);
         #[cfg(not(any(feature = "tracing", feature = "log")))]
@@ -57,7 +77,7 @@ macro_rules! log_info {
 macro_rules! log_warn {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
-        ::tracing::warn!($s $(, $x)*);
+        $crate::__private::tracing::warn!($s $(, $x)*);
         #[cfg(feature = "log")]
         $crate::__private::log::warn!($s $(, $x)*);
         #[cfg(not(any(feature = "tracing", feature = "log")))]
@@ -69,7 +89,7 @@ macro_rules! log_warn {
 macro_rules! log_error {
     ($s:literal $(, $x:expr)* $(,)?) => {{
         #[cfg(feature = "tracing")]
-        ::tracing::error!($s $(, $x)*);
+        $crate::__private::tracing::error!($s $(, $x)*);
         #[cfg(feature = "log")]
         $crate::__private::log::error!($s $(, $x)*);
         #[cfg(not(any(feature = "tracing", feature = "log")))]

--- a/aimdb-knx-connector/CHANGELOG.md
+++ b/aimdb-knx-connector/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Reports through the `log_*` facade instead of `tracing::` directly** (design
+  050 §10.5), so a `log` destination — an FFI layer's, say — sees this crate's
+  events too. Each call site also shed the hand-written
+  `#[cfg(feature = "tracing")]` the facade carries itself. The `tracing` feature
+  no longer pulls `dep:tracing`; a mirrored `log` feature is added alongside it.
+  No change to what is emitted, or to a consumer that enables `tracing`.
+
 ### Added
 
 - **Spec-conformant TUNNELING_REQUEST retransmission — `TunnelConfig::ack_retransmits` (036 W4, default `1`).** When a tracked outbound telegram's ACK does not arrive within `ack_timeout_ms`, the engine now retransmits the byte-identical frame (same sequence counter, buffered in the pending-ACK slot per KNXnet/IP 3.8.4) and, when the repeat also goes unanswered, reports `Action::AckTimeout` **and tears the connection down** — so subsequent commands queue for the re-handshake instead of being sent into a dead tunnel. Hardware-bench evidence motivating this: ten button-press writes issued during a link outage's heartbeat-detection window (up to ~65 s) were silently lost with only warnings; with retransmission the loss window shrinks to ~2× `ack_timeout_ms`. `ack_retransmits: 0` restores the previous expire-and-warn behavior (no retransmit, no disconnect, no frame buffering — though the 16-slot frame capacity, ~4.5 KiB, is statically reserved either way on `heapless`). The retransmit delay is `ack_timeout_ms` (default 3 s, the constant both pre-engine implementations used); set it to `1_000` for strict spec timing. Covered by engine unit tests and a fake-gateway test that drops the first ACK and asserts the identical repeat.

--- a/aimdb-knx-connector/Cargo.toml
+++ b/aimdb-knx-connector/Cargo.toml
@@ -27,7 +27,12 @@ embassy-runtime = [
     "embassy-futures",
     "static_cell",
 ]
-tracing = ["dep:tracing", "aimdb-core/tracing"]
+# Design 050 §10.4/§10.5: the facade reaches both destinations through
+# `aimdb_core::__private`, so neither dependency is declared here any more.
+# The *features* stay: a `#[cfg]` in a `#[macro_export]`ed macro is resolved
+# where it expands, so without them this crate would emit nothing.
+tracing = ["aimdb-core/tracing"]
+log = ["aimdb-core/log"]
 defmt = [
     "dep:defmt",
     "aimdb-core/defmt",
@@ -81,7 +86,6 @@ heapless = { workspace = true }
 static_cell = { version = "2.0", optional = true }
 
 # Optional observability
-tracing = { workspace = true, optional = true }
 defmt = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/aimdb-knx-connector/src/tokio_client.rs
+++ b/aimdb-knx-connector/src/tokio_client.rs
@@ -17,6 +17,7 @@ use crate::tunnel::{
 use crate::GroupAddress;
 use aimdb_core::connector::ConnectorUrl;
 use aimdb_core::transport::{Connector, ConnectorConfig, PublishError};
+use aimdb_core::{log_debug, log_error, log_info, log_trace, log_warn};
 use aimdb_core::{pump_sink, pump_source, BoxFut, ConnectorBuilder, Payload, Source};
 use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
@@ -146,8 +147,7 @@ impl KnxConnectorImpl {
                 )
             })?;
 
-        #[cfg(feature = "tracing")]
-        tracing::info!("Creating KNX connector for gateway {}", gateway_addr);
+        log_info!("Creating KNX connector for gateway {}", gateway_addr);
 
         // Outbound commands (publishers → connection task) and inbound telegrams
         // (connection task → `KnxSource`/`pump_source`).
@@ -216,8 +216,7 @@ async fn connection_task(
     telegram_tx: mpsc::Sender<(String, Payload)>,
     mut command_rx: mpsc::Receiver<GroupWrite>,
 ) {
-    #[cfg(feature = "tracing")]
-    tracing::info!("KNX connection task started for {}", gateway_addr);
+    log_info!("KNX connection task started for {}", gateway_addr);
 
     let epoch = tokio::time::Instant::now();
     let now_ms = || epoch.elapsed().as_millis() as u64;
@@ -242,14 +241,12 @@ async fn connection_task(
                             port: local.port(),
                         });
                     }
-                    #[cfg(feature = "tracing")]
-                    tracing::debug!("KNX: Connecting from {} to {}", local, gateway_addr);
+                    log_debug!("KNX: Connecting from {} to {}", local, gateway_addr);
                 }
                 s
             }
             Err(_e) => {
-                #[cfg(feature = "tracing")]
-                tracing::error!("Failed to bind UDP socket: {}, retrying in 5s", _e);
+                log_error!("Failed to bind UDP socket: {}, retrying in 5s", _e);
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 continue;
             }
@@ -273,13 +270,11 @@ async fn connection_task(
             tokio::select! {
                 result = socket.recv_from(&mut buf) => match result {
                     Ok((len, _)) => {
-                        #[cfg(feature = "tracing")]
-                        tracing::trace!("Received {} bytes from gateway", len);
+                        log_trace!("Received {} bytes from gateway", len);
                         engine.handle_datagram(&buf[..len], now_ms());
                     }
                     Err(_e) => {
-                        #[cfg(feature = "tracing")]
-                        tracing::error!("Socket error: {}", _e);
+                        log_error!("Socket error: {}", _e);
                         engine.handle_socket_error(now_ms());
                     }
                 },
@@ -305,8 +300,7 @@ async fn connection_task(
             }
         }
 
-        #[cfg(feature = "tracing")]
-        tracing::error!("KNX connection lost, reconnecting after backoff...");
+        log_error!("KNX connection lost, reconnecting after backoff...");
         // The engine is backing off: nothing can be sent until its deadline,
         // so wait it out before binding the fresh socket. This also paces the
         // rebind cycle when a socket errors persistently (the old client
@@ -332,24 +326,21 @@ impl TunnelIo for TokioIo<'_> {
         match self.socket.send_to(frame, self.gateway).await {
             Ok(_) => true,
             Err(_e) => {
-                #[cfg(feature = "tracing")]
-                tracing::error!("KNX send failed: {}", _e);
+                log_error!("KNX send failed: {}", _e);
                 false
             }
         }
     }
 
     fn forward(&mut self, addr: GroupAddress, payload: Vec<u8>) {
-        #[cfg(feature = "tracing")]
-        tracing::debug!("KNX telegram: {} ({} bytes)", addr, payload.len());
+        log_debug!("KNX telegram: {} ({} bytes)", addr, payload.len());
 
         if self
             .telegram_tx
             .try_send((addr.to_string(), Payload::from(payload)))
             .is_err()
         {
-            #[cfg(feature = "tracing")]
-            tracing::warn!(
+            log_warn!(
                 "KNX inbound: dropping telegram for {} (channel full/closed)",
                 addr
             );
@@ -357,8 +348,7 @@ impl TunnelIo for TokioIo<'_> {
     }
 
     fn warn_ack_timeout(&mut self, _seq: u8) {
-        #[cfg(feature = "tracing")]
-        tracing::warn!("⚠️  ACK timeout for seq={}", _seq);
+        log_warn!("⚠️  ACK timeout for seq={}", _seq);
     }
 }
 

--- a/aimdb-mqtt-connector/CHANGELOG.md
+++ b/aimdb-mqtt-connector/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Reports through the `log_*` facade instead of `tracing::` directly** (design
+  050 §10.5), so a `log` destination — an FFI layer's, say — sees this crate's
+  events too. Each call site also shed the hand-written
+  `#[cfg(feature = "tracing")]` the facade carries itself. The `tracing` feature
+  no longer pulls `dep:tracing`; a mirrored `log` feature is added alongside it.
+  No change to what is emitted, or to a consumer that enables `tracing`.
+
 ### Added
 
 - **Tokio client: the TLS backend for `mqtts://` is now a build-time choice.**

--- a/aimdb-mqtt-connector/Cargo.toml
+++ b/aimdb-mqtt-connector/Cargo.toml
@@ -60,7 +60,12 @@ embassy-tls = [
     "embassy-net/dns",
     "embassy-net/udp",
 ]
-tracing = ["dep:tracing", "aimdb-core/tracing"]
+# Design 050 §10.4/§10.5: the facade reaches both destinations through
+# `aimdb_core::__private`, so neither dependency is declared here any more.
+# The *features* stay: a `#[cfg]` in a `#[macro_export]`ed macro is resolved
+# where it expands, so without them this crate would emit nothing.
+tracing = ["aimdb-core/tracing"]
+log = ["aimdb-core/log"]
 defmt = ["dep:defmt", "aimdb-core/defmt"]
 
 [dependencies]
@@ -126,7 +131,6 @@ heapless = { workspace = true, optional = true }
 static_cell = { version = "2.0", optional = true }
 
 # Optional observability
-tracing = { workspace = true, optional = true }
 defmt = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/aimdb-mqtt-connector/src/tokio_client.rs
+++ b/aimdb-mqtt-connector/src/tokio_client.rs
@@ -9,6 +9,7 @@
 use aimdb_core::connector::ConnectorUrl;
 use aimdb_core::router::{Router, RouterBuilder};
 use aimdb_core::transport::{Connector, ConnectorConfig, PublishError};
+use aimdb_core::{log_debug, log_error, log_info};
 use aimdb_core::{pump_sink, pump_source, BoxFut, ConnectorBuilder, Payload, Source};
 use rumqttc::{AsyncClient, Event, EventLoop, MqttOptions, Packet};
 use std::future::Future;
@@ -76,8 +77,7 @@ impl ConnectorBuilder for MqttConnectorBuilder {
             let inbound_routes = db.collect_inbound_routes("mqtt");
             let router = RouterBuilder::from_routes(inbound_routes).build();
 
-            #[cfg(feature = "tracing")]
-            tracing::info!("MQTT subscribing to {} topics", router.resource_ids().len());
+            log_info!("MQTT subscribing to {} topics", router.resource_ids().len());
 
             // Connect, subscribe, and hand back the raw event loop.
             let (client, event_loop) =
@@ -98,7 +98,6 @@ impl ConnectorBuilder for MqttConnectorBuilder {
                 "mqtt",
                 MqttEventLoopSource {
                     event_loop,
-                    #[cfg(feature = "tracing")]
                     broker_key: self.broker_url.clone(),
                 },
             ));
@@ -160,8 +159,7 @@ impl MqttConnectorImpl {
             }
         });
 
-        #[cfg(feature = "tracing")]
-        tracing::info!("Creating MQTT client for {}:{}", host, port);
+        log_info!("Creating MQTT client for {}:{}", host, port);
 
         // Use provided client_id or generate a UUID-based one
         let client_id = client_id.unwrap_or_else(|| format!("aimdb-{}", uuid::Uuid::new_v4()));
@@ -208,8 +206,7 @@ impl MqttConnectorImpl {
         const CHANNEL_HEADROOM: usize = 10;
         let channel_capacity = topic_count + CHANNEL_HEADROOM;
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
+        log_debug!(
             "MQTT channel capacity set to {} (for {} topics)",
             channel_capacity,
             topic_count
@@ -221,12 +218,10 @@ impl MqttConnectorImpl {
 
         let topics = router_arc.resource_ids();
 
-        #[cfg(feature = "tracing")]
-        tracing::info!("Subscribing to {} MQTT topics...", topics.len());
+        log_info!("Subscribing to {} MQTT topics...", topics.len());
 
         for topic in &topics {
-            #[cfg(feature = "tracing")]
-            tracing::debug!("Subscribing to MQTT topic: {}", topic);
+            log_debug!("Subscribing to MQTT topic: {}", topic);
 
             client_arc
                 .subscribe(topic.as_ref(), rumqttc::QoS::AtLeastOnce)
@@ -234,8 +229,7 @@ impl MqttConnectorImpl {
                 .map_err(|e| format!("Failed to subscribe to topic '{}': {}", topic, e))?;
         }
 
-        #[cfg(feature = "tracing")]
-        tracing::info!("MQTT subscriptions complete");
+        log_info!("MQTT subscriptions complete");
 
         Ok((client_arc, event_loop))
     }
@@ -286,21 +280,21 @@ impl Connector for MqttSink {
                 _ => return Err(PublishError::UnsupportedQoS),
             };
 
-            #[cfg(feature = "tracing")]
-            let topic_for_log = topic.clone();
+            // Borrowed before `topic` is moved into `publish`, which is why this
+            // reads "Publishing" and sits above the call: the alternative was a
+            // `String` clone on every publish just to name the topic afterwards.
+            // A failed publish is reported by the `map_err` below.
+            log_debug!("Publishing to topic: {}", topic);
 
             client
                 .publish(topic, qos_level, retain, payload_owned)
                 .await
                 .map_err(|_e| {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!("MQTT publish failed: {}", _e);
+                    log_error!("MQTT publish failed: {}", _e);
 
                     PublishError::ConnectionFailed
                 })?;
 
-            #[cfg(feature = "tracing")]
-            tracing::debug!("Published to topic: {}", topic_for_log);
             Ok(())
         })
     }
@@ -315,7 +309,9 @@ impl Connector for MqttSink {
 /// for the lifetime of the connector.
 struct MqttEventLoopSource {
     event_loop: EventLoop,
-    #[cfg(feature = "tracing")]
+    /// Only ever used to name the broker in an error line. One `String` per
+    /// connection, held for its lifetime — no longer feature-gated, because the
+    /// facade decides its own gating and a `#[cfg]` here could not follow it.
     broker_key: String,
 }
 
@@ -328,8 +324,7 @@ impl Source for MqttEventLoopSource {
                         let topic = publish.topic.clone();
                         let payload: Payload = Arc::from(publish.payload.as_ref());
 
-                        #[cfg(feature = "tracing")]
-                        tracing::debug!(
+                        log_debug!(
                             "Received MQTT message on topic '{}' ({} bytes)",
                             topic,
                             payload.len()
@@ -340,8 +335,7 @@ impl Source for MqttEventLoopSource {
                     // Non-publish packets (PUBACK/PINGRESP/…) keep driving the protocol.
                     Ok(_) => continue,
                     Err(_e) => {
-                        #[cfg(feature = "tracing")]
-                        tracing::error!("MQTT event loop error for {}: {:?}", self.broker_key, _e);
+                        log_error!("MQTT event loop error for {}: {:?}", self.broker_key, _e);
 
                         // Wait before reconnecting.
                         tokio::time::sleep(Duration::from_secs(5)).await;

--- a/aimdb-serial-connector/CHANGELOG.md
+++ b/aimdb-serial-connector/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Reports through the `log_*` facade instead of `tracing::` directly** (design
+  050 §10.5), so a `log` destination — an FFI layer's, say — sees this crate's
+  events too. Each call site also shed the hand-written
+  `#[cfg(feature = "tracing")]` the facade carries itself. The `tracing` feature
+  no longer pulls `dep:tracing`; a mirrored `log` feature is added alongside it.
+  No change to what is emitted, or to a consumer that enables `tracing`.
+
 ### Added
 
 - **New crate — the COBS-framed serial/UART transport for AimDB remote access (Issue #122, follow-up to #39).** The serial sibling of `aimdb-uds-connector`: it contributes only the `Dialer`/`Listener`/`Connection` triple plus thin sugar; the AimX codec + dispatch and the runtime-neutral session engines (`run_client`/`serve`) are reused from `aimdb-core`. The wire is the same compact AimX JSON, framed with **COBS** (Consistent Overhead Byte Stuffing) and a `0x00` sentinel instead of a newline — self-synchronizing on a lossy/unframed serial medium, so a receiver that joins mid-stream resynchronizes on the next sentinel. Default scheme `"serial"`. Two runtime halves:

--- a/aimdb-serial-connector/Cargo.toml
+++ b/aimdb-serial-connector/Cargo.toml
@@ -46,7 +46,12 @@ embassy-runtime = [
     "dep:embedded-io-async",
 ]
 
-tracing = ["dep:tracing", "aimdb-core/tracing"]
+# Design 050 §10.4/§10.5: the facade reaches both destinations through
+# `aimdb_core::__private`, so neither dependency is declared here any more.
+# The *features* stay: a `#[cfg]` in a `#[macro_export]`ed macro is resolved
+# where it expands, so without them this crate would emit nothing.
+tracing = ["aimdb-core/tracing"]
+log = ["aimdb-core/log"]
 defmt = ["dep:defmt", "aimdb-core/defmt"]
 
 # Internal: host tokio integration tests need a concrete adapter. Kept off the
@@ -77,7 +82,6 @@ embedded-io-async = { workspace = true, optional = true }
 aimdb-tokio-adapter = { version = "0.6.0", path = "../aimdb-tokio-adapter", optional = true }
 
 # --- logging ---
-tracing = { version = "0.1", optional = true }
 defmt = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/aimdb-serial-connector/src/tokio_transport.rs
+++ b/aimdb-serial-connector/src/tokio_transport.rs
@@ -14,6 +14,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio_serial::{SerialPortBuilderExt, SerialStream};
 
 use aimdb_core::connector::ConnectorBuilder;
+use aimdb_core::log_info;
 use aimdb_core::remote::{AimxConfig, SecurityPolicy};
 use aimdb_core::session::aimx::{AimxCodec, AimxDispatch};
 use aimdb_core::session::{
@@ -295,8 +296,7 @@ impl ConnectorBuilder for SerialServer {
 
 /// Open the serial port synchronously so an open error surfaces from `build`.
 fn open_serial_listener(path: &str, baud: u32) -> DbResult<SerialListener> {
-    #[cfg(feature = "tracing")]
-    tracing::info!(
+    log_info!(
         "Initializing AimX serial server on {} @ {} baud",
         path,
         baud

--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`tracing` no longer pulls `dep:tracing`** (design 050 §10.4): that arm now
+  reaches the crate through `aimdb_core::__private`, as the `log` arm already
+  did. Both features stay — they select the arms.
 - **A `log` feature, mirroring `aimdb-core`'s (design 050).** The `log_*` macros
   are `#[macro_export]`ed, so their `#[cfg(feature = "log")]` arm is resolved
   against *this* crate — `aimdb-core/log` on its own would leave this crate's

--- a/aimdb-sync/Cargo.toml
+++ b/aimdb-sync/Cargo.toml
@@ -19,7 +19,6 @@ aimdb-core = { path = "../aimdb-core", version = "1.1.0", default-features = fal
     "alloc",
 ] }
 aimdb-tokio-adapter = { path = "../aimdb-tokio-adapter", version = "0.6.0", optional = true }
-tracing = { workspace = true, optional = true }
 
 # Tokio for channels and runtime
 tokio = { version = "1.40", features = ["sync", "rt", "time", "macros"], optional = true }
@@ -46,12 +45,12 @@ default = ["std"]
 
 std = ["aimdb-core/std", "dep:tokio", "dep:aimdb-tokio-adapter", "dep:libc"]
 
-# Enable tracing for debugging
-tracing = ["dep:tracing", "aimdb-core/tracing"]
-
-# The facade's second destination (design 050). Required, not cosmetic: the
-# `log_*` macros expand here, so the arm is selected by *this* crate's features
-# and `aimdb-core/log` alone would leave these call sites unrouted.
+# The facade's two destinations. Required, not cosmetic: the `log_*` macros
+# expand in this crate, so each arm is selected by *this* crate's features and
+# `aimdb-core/{tracing,log}` alone would leave these call sites unrouted.
+# Neither dependency is declared here — since design 050 §10.4 both arms reach
+# their crate through `aimdb_core::__private`.
+tracing = ["aimdb-core/tracing"]
 log = ["aimdb-core/log"]
 
 # SyncProducer::set_value / try_set_value / set_value_at for Settable types

--- a/aimdb-uds-connector/CHANGELOG.md
+++ b/aimdb-uds-connector/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Reports through the `log_*` facade instead of `tracing::` directly** (design
+  050 §10.5), so a `log` destination — an FFI layer's, say — sees this crate's
+  events too. Each call site also shed the hand-written
+  `#[cfg(feature = "tracing")]` the facade carries itself. The `tracing` feature
+  no longer pulls `dep:tracing`; a mirrored `log` feature is added alongside it.
+  No change to what is emitted, or to a consumer that enables `tracing`.
+
 ### Added
 
 - **New crate — the Unix-domain-socket transport for AimDB remote access (Issue #39, [design doc](../docs/design/remote-access-via-connectors.md)).** A thin, swappable transport that rides the shared session engine in `aimdb-core::session`: it contributes only the `Dialer`/`Listener`/`Connection` triple (`UdsDialer` / `UdsListener` / `UdsConnection`, NDJSON framing in the transport — one line per logical frame); the AimX codec + dispatch and the engine wiring are reused verbatim from core. Two ergonomic constructors:

--- a/aimdb-uds-connector/Cargo.toml
+++ b/aimdb-uds-connector/Cargo.toml
@@ -11,7 +11,12 @@ categories = ["network-programming", "database"]
 
 [features]
 default = []
-tracing = ["dep:tracing", "aimdb-core/tracing"]
+# Design 050 §10.4/§10.5: the facade reaches both destinations through
+# `aimdb_core::__private`, so neither dependency is declared here any more.
+# The *features* stay: a `#[cfg]` in a `#[macro_export]`ed macro is resolved
+# where it expands, so without them this crate would emit nothing.
+tracing = ["aimdb-core/tracing"]
+log = ["aimdb-core/log"]
 
 [dependencies]
 # AimX protocol (codec + dispatch) and the generic session connectors live in
@@ -23,7 +28,6 @@ aimdb-core = { version = "1.1.0", path = "../aimdb-core", features = [
 ] }
 tokio = { version = "1", features = ["net", "io-util"] }
 
-tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 aimdb-tokio-adapter = { version = "0.6.0", path = "../aimdb-tokio-adapter" }

--- a/aimdb-uds-connector/src/lib.rs
+++ b/aimdb-uds-connector/src/lib.rs
@@ -56,6 +56,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use aimdb_core::connector::ConnectorBuilder;
+use aimdb_core::log_info;
 use aimdb_core::remote::AimxConfig;
 use aimdb_core::session::aimx::{AimxCodec, AimxDispatch};
 use aimdb_core::session::{
@@ -207,8 +208,7 @@ impl ConnectorBuilder for UdsServer {
 fn bind_uds_listener(config: &AimxConfig) -> DbResult<UdsListener> {
     let socket_path = &config.socket_path;
 
-    #[cfg(feature = "tracing")]
-    tracing::info!("Initializing AimX UDS server on socket: {}", socket_path);
+    log_info!("Initializing AimX UDS server on socket: {}", socket_path);
 
     if std::path::Path::new(socket_path).exists() {
         std::fs::remove_file(socket_path).map_err(|e| DbError::IoWithContext {
@@ -236,8 +236,7 @@ fn bind_uds_listener(config: &AimxConfig) -> DbResult<UdsListener> {
         source: e,
     })?;
 
-    #[cfg(feature = "tracing")]
-    tracing::info!(
+    log_info!(
         "AimX socket bound at {} (mode {:o})",
         socket_path,
         permissions

--- a/docs/design/050-log-destination-for-ffi.md
+++ b/docs/design/050-log-destination-for-ffi.md
@@ -1,7 +1,7 @@
 # 050 — A log destination an FFI layer can install
 
-**Status:** step 1 of §10 implemented (`aimdb-core` + the `aimdb-sync` mirror).
-Steps 2 and 3 are the FFI doors, which live outside this repository.
+**Status:** implemented. §10.1, §10.4 and §10.5 are in this repository; §10.2
+and §10.3 are the FFI doors, which live in `aimdb-weather-mesh`.
 
 **Scope:** additive to `aimdb-core` (1.2.0 → 1.3.0). No breaking change, and no
 behaviour change at all for a build that does not enable the new feature. The
@@ -55,7 +55,7 @@ convenience of the layout rather than a property of the design.
 `log_info!`, `log_warn!`, `log_error!` take `$s:literal $(, $x:expr)*` and expand
 to the matching `tracing` event macro when the `tracing` feature is on, otherwise
 to a borrow-and-drop that keeps call sites warning-free. There is no
-`log_trace!`.
+`log_trace!` (§10.5 later added one, for a KNX site that needed it).
 
 Two consequences worth stating, because they decide how cheap this change is:
 
@@ -201,9 +201,9 @@ log = ["aimdb-core/log"]   # no `dep:log` — see below
   them is resolved against the *expanding* crate. `aimdb-core/log` alone leaves
   `aimdb-sync`'s ten call sites unrouted, which is why `aimdb-sync` carries a
   `log` feature of its own. What the `$crate::__private::log` re-export removes
-  is the `dep:log` half of the tax that `::tracing` still charges — routing
-  `::tracing` through `__private` the same way is worth doing and strictly
-  separable from this change.
+  is the `dep:log` half of the tax; §10.4 has since given `::tracing` the same
+  treatment, so a facade user declares neither dependency. Forgetting the
+  feature is loud rather than silent — see §10.4.
 - **`tracing` and `log` may both be on**, and then both arms run. See §5.1:
   "both on" is not the same as "the process wanted both".
 - **`defmt` is untouched.** The explicit `#[cfg(feature = "defmt")]` gates in
@@ -330,10 +330,6 @@ destination.
 
 ## 8. Non-goals
 
-- **The four crates that call `tracing::` directly.** `aimdb-mqtt-connector`,
-  `aimdb-knx-connector`, `aimdb-uds-connector` and `aimdb-serial-connector`
-  report outside the facade, so a `log` destination will not see those 24 call
-  sites. Migrating them is ordinary follow-up work and is not this change.
 - **Per-`AimDbHandle` routing.** Two stations in one C++ process cannot separate
   their events, which is a genuine limitation. Fixing it means threading a
   context through 76 context-free macro call sites; it is a different design.
@@ -382,7 +378,37 @@ owns its own integration-test binary.
    loses `SinkHolder` and the trampoline; the prefix filter replaces `EnvFilter`.
    The two defects in the header are deleted rather than fixed.
 3. `weather-station-py`: the same, for the `logging` bridge.
-4. Optional, separable: route `::tracing` through `$crate::__private` too, and
-   drop the mirrored `tracing` feature from the eight crates that carry it.
-5. Optional, separable: move the four direct-`tracing::` connectors onto the
-   facade, so a `log` destination sees them too.
+4. **Done.** Route `::tracing` through `$crate::__private` too, so a facade user
+   declares neither dependency.
+
+   The original wording — "and drop the mirrored `tracing` feature from the
+   eight crates that carry it" — was wrong, and contradicted §3.2. The
+   re-export removes the *dependency*; it cannot remove the *feature*, because
+   a `#[cfg]` inside a `#[macro_export]`ed macro is resolved where the macro
+   expands. Mirroring is inherent to this design; only §7's rejected `__emit`
+   shim would end it.
+
+   What the mirror costs is now much less, because forgetting it is no longer
+   silent: an undeclared feature name makes `unexpected_cfgs` fire at every
+   call site — a warning ordinarily, an error under `-D warnings`, which is how
+   `make clippy` runs. A dropped mirror breaks CI.
+
+   Three crates (`aimdb-tokio-adapter`, `aimdb-tcp-connector`,
+   `aimdb-embassy-adapter`) still carry a `tracing` feature that forwards to
+   `aimdb-core/tracing` while emitting nothing themselves. That is a live
+   pass-through for their consumers, not dead weight, so it stays.
+5. **Done.** The four direct-`tracing::` connectors are on the facade, so a
+   `log` destination sees them too: `aimdb-mqtt-connector` (10 sites),
+   `aimdb-knx-connector` (11), `aimdb-uds-connector` (2),
+   `aimdb-serial-connector` (1). Each site shed the hand-written
+   `#[cfg(feature = "tracing")]` the facade now carries itself, and each crate
+   gained the mirrored `log` feature.
+
+   Two things the conversion had to fix rather than translate. `log_trace!` did
+   not exist — §2 recorded its absence — and one KNX site needed it, so the
+   facade grew a fifth macro. And two bindings in `aimdb-mqtt-connector` were
+   themselves `#[cfg(feature = "tracing")]`, which an unconditional call site
+   cannot see: `broker_key` became unconditional (one `String` per connection),
+   and a per-publish `topic.clone()` was removed outright by logging before the
+   move rather than after it — an allocation that had been paid on every
+   publish under `tracing`.


### PR DESCRIPTION
Two steps §10 left as optional, done together because the second needs the
first, plus a correction to what the first was supposed to achieve.

§10.4 — `::tracing` now goes through `$crate::__private`, as `log` already did,
so a crate expanding the `log_*` macros declares neither dependency. The doc
also said this would let the mirrored `tracing` feature be dropped. It does not,
and that contradicted its own §3.2: a `#[cfg]` inside a `#[macro_export]`ed
macro is resolved where it expands, so the feature is what selects the arm and
no re-export can stand in for it. Mirroring is inherent to this design; only
§7's rejected `__emit` shim would end it, at the MCU cost §7 declined to pay.
The sequencing section now says so.

What makes that cost acceptable is that forgetting a mirror is no longer silent,
which is how the original was framed. An undeclared feature name makes
`unexpected_cfgs` fire at every call site — a warning ordinarily, an error under
`-D warnings`, which is how `make clippy` runs. Verified by dropping the mirror
from `aimdb-uds-connector`: hard errors, not quiet muting.

§10.5 — the four connectors that still called `tracing::` directly are on the
facade, so a `log` destination sees their 24 events too: mqtt 10, knx 11, uds 2,
serial 1. Every crate in the workspace that reports at all now reports through
the facade. Each site also shed the hand-written `#[cfg(feature = "tracing")]`
that the facade carries itself.

Two things the conversion had to fix rather than translate:

- `log_trace!` did not exist — §2 recorded its absence — and one KNX site was
  `tracing::trace!`. Added as the fifth macro rather than demoting the site to
  debug.
- Two bindings in `aimdb-mqtt-connector` were themselves gated on `tracing`,
  which an unconditional call site cannot see. `broker_key` became
  unconditional: one `String` per connection, held for its lifetime. The other
  was a `topic.clone()` per publish, existing only so the topic could be named
  after it had been moved into `publish`; logging before the move borrows
  instead, so the allocation is gone rather than made unconditional. That line
  now reads "Publishing" — a failed publish is still reported by the `map_err`
  below it.

Three crates keep a `tracing` feature that forwards to `aimdb-core/tracing`
while emitting nothing themselves (`aimdb-tokio-adapter`, `aimdb-tcp-connector`,
`aimdb-embassy-adapter`). That is a live pass-through for their consumers, not
dead weight, so it stays.

Non-breaking throughout: a crate that still declares `dep:tracing` is
unaffected, and nothing changes about what is emitted or when.

Verified: `make clippy`, `make test`, `make test-embedded`, `make fmt-check`,
`make readme-check`, `make codegen-drift`, `make check-no-sim` all clean, and
the design-050 acceptance criteria still pass on this branch.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QgaHbjCPgkNS6Y34jxqVYH