### PR TITLE
feat(sync): give `AimDbHandle` the shutdown contract an FFI door needs (CR-10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
     - name: Prove production is simulation-free
       run: make check-no-sim
 
+    - name: Prove no library crate installs a process-global
+      run: make check-no-globals
+
   # Embedded target testing
   embedded-targets:
     name: Embedded Cross-compilation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,41 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added — CR-4 and CR-9: two rules that were true, now checked
+### Added — CR-4, CR-9, CR-10
 
-**A panic is a bug, not an error channel (CR-4).** `aimdb-core` joins
-`aimdb-sync` under `deny(clippy::unwrap_used, clippy::expect_used,
-clippy::panic)` outside its own tests, with the rule stated in its module docs.
-Four sites were fixed rather than annotated — poisoned-mutex recovery in the
-`record_id` and `typed_record` lock helpers, an `unwrap` under a `len()` check
-in `record_origin`, and an `expect` on the AimX session pump — and the rest
-carry an `allow` with a `reason`. It matters below an FFI door, where a
-consumer's `panic = "abort"` compiles the layer's own `catch_unwind` out.
-([aimdb-core](aimdb-core/CHANGELOG.md))
-
-**No library crate installs a process-global (CR-9).** `make check-no-globals`,
-also run in CI, scans the crates that get linked into somebody else's process
-for subscriber installs, panic hooks, signal handlers, `pthread_atfork` and
-`set_var`. It has a positive control, so a pattern that stops matching cannot
-pass silently, and exactly one allowed exception: `aimdb-sync`'s fork detector,
-which may register `pthread_atfork` because it owns the runtime thread it
-protects — never an FFI shim on the application's behalf. `tools/`, `examples/`
-and `aimdb-codegen`'s generated `main` are applications and are not scanned.
-
-### Added — CR-10: the shutdown contract moves into `aimdb-sync`
-
-`AimDbHandle` gains `shutdown(&self)`, `shutdown_timeout(&self, _)` and
-`is_closed()`. The four properties an FFI layer needs — a shutdown through a
-shared reference, idempotent, safe during a publish, and a `is_closed` that
-never takes the lock the shutdown holds — lived only in
-`weather-station::StationHandle`, one crate above the thread they are about, so
-every binding that reached for `aimdb-sync` directly had to rediscover them.
-The pyo3 door measured what that costs: 200/200 closes refused by pyo3's borrow
-flag while one thread published in a loop. Pinned by
-`aimdb-sync/tests/shutdown_contract_test.rs`; `detach(self)` is unchanged and
-now delegates. A shutdown also releases the database — the runtime holds it
-weakly now — which closes the buffers and so wakes a consumer parked in `get()`.
-([aimdb-sync](aimdb-sync/CHANGELOG.md))
+- **`AimDbHandle::shutdown(&self)` / `is_closed()` (CR-10).** The shutdown
+  contract a foreign-language binding needs, moved into the crate whose thread
+  it is about; pinned by `aimdb-sync/tests/shutdown_contract_test.rs`.
+  `detach(self)` is unchanged. A shutdown now also releases the database, waking
+  a consumer parked in `get()`. ([aimdb-sync](aimdb-sync/CHANGELOG.md))
+- **A panic is a bug, not an error channel (CR-4).** `aimdb-core` joins
+  `aimdb-sync` under `deny(clippy::unwrap_used, clippy::expect_used,
+  clippy::panic)`. ([aimdb-core](aimdb-core/CHANGELOG.md))
+- **No library crate installs a process-global (CR-9).**
+  `make check-no-globals`, in CI, with a positive control and one allowed
+  exception: `aimdb-sync`'s fork detector.
 
 ### Changed — Design 050 §10.4/§10.5: one facade, both destinations, no dependency tax
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,19 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added — CR-4, CR-9, CR-10
+### Added
 
-- **`AimDbHandle::shutdown(&self)` / `is_closed()` (CR-10).** The shutdown
-  contract a foreign-language binding needs, moved into the crate whose thread
-  it is about; pinned by `aimdb-sync/tests/shutdown_contract_test.rs`.
-  `detach(self)` is unchanged. A shutdown now also releases the database, waking
-  a consumer parked in `get()`. ([aimdb-sync](aimdb-sync/CHANGELOG.md))
-- **A panic is a bug, not an error channel (CR-4).** `aimdb-core` joins
-  `aimdb-sync` under `deny(clippy::unwrap_used, clippy::expect_used,
-  clippy::panic)`. ([aimdb-core](aimdb-core/CHANGELOG.md))
-- **No library crate installs a process-global (CR-9).**
-  `make check-no-globals`, in CI, with a positive control and one allowed
-  exception: `aimdb-sync`'s fork detector.
+- **`AimDbHandle::shutdown(&self)` / `is_closed()`.** The shutdown contract a
+  foreign-language binding needs, moved into the crate whose thread it is
+  about; pinned by `aimdb-sync/tests/shutdown_contract_test.rs`. `detach(self)`
+  is unchanged. A shutdown now also releases the database, waking a consumer
+  parked in `get()`. ([aimdb-sync](aimdb-sync/CHANGELOG.md))
+- **A panic is a bug, not an error channel.** `aimdb-core` joins `aimdb-sync`
+  under `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)`.
+  ([aimdb-core](aimdb-core/CHANGELOG.md))
+- **No library crate installs a process-global.** `make check-no-globals`, in
+  CI, with a positive control and one allowed exception: `aimdb-sync`'s fork
+  detector.
 
 ### Changed — Design 050 §10.4/§10.5: one facade, both destinations, no dependency tax
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — CR-4 and CR-9: two rules that were true, now checked
+
+**A panic is a bug, not an error channel (CR-4).** `aimdb-core` joins
+`aimdb-sync` under `deny(clippy::unwrap_used, clippy::expect_used,
+clippy::panic)` outside its own tests, with the rule stated in its module docs.
+Four sites were fixed rather than annotated — poisoned-mutex recovery in the
+`record_id` and `typed_record` lock helpers, an `unwrap` under a `len()` check
+in `record_origin`, and an `expect` on the AimX session pump — and the rest
+carry an `allow` with a `reason`. It matters below an FFI door, where a
+consumer's `panic = "abort"` compiles the layer's own `catch_unwind` out.
+([aimdb-core](aimdb-core/CHANGELOG.md))
+
+**No library crate installs a process-global (CR-9).** `make check-no-globals`,
+also run in CI, scans the crates that get linked into somebody else's process
+for subscriber installs, panic hooks, signal handlers, `pthread_atfork` and
+`set_var`. It has a positive control, so a pattern that stops matching cannot
+pass silently, and exactly one allowed exception: `aimdb-sync`'s fork detector,
+which may register `pthread_atfork` because it owns the runtime thread it
+protects — never an FFI shim on the application's behalf. `tools/`, `examples/`
+and `aimdb-codegen`'s generated `main` are applications and are not scanned.
+
+### Added — CR-10: the shutdown contract moves into `aimdb-sync`
+
+`AimDbHandle` gains `shutdown(&self)`, `shutdown_timeout(&self, _)` and
+`is_closed()`. The four properties an FFI layer needs — a shutdown through a
+shared reference, idempotent, safe during a publish, and a `is_closed` that
+never takes the lock the shutdown holds — lived only in
+`weather-station::StationHandle`, one crate above the thread they are about, so
+every binding that reached for `aimdb-sync` directly had to rediscover them.
+The pyo3 door measured what that costs: 200/200 closes refused by pyo3's borrow
+flag while one thread published in a loop. Pinned by
+`aimdb-sync/tests/shutdown_contract_test.rs`; `detach(self)` is unchanged and
+now delegates. A shutdown also releases the database — the runtime holds it
+weakly now — which closes the buffers and so wakes a consumer parked in `get()`.
+([aimdb-sync](aimdb-sync/CHANGELOG.md))
+
 ### Changed — Design 050 §10.4/§10.5: one facade, both destinations, no dependency tax
 
 `::tracing` now goes through `$crate::__private` exactly as `log` already did, so

--- a/Makefile
+++ b/Makefile
@@ -665,28 +665,14 @@ check-no-sim:
 	printf "$(BLUE)✓ 'simulatable' is not a default feature of aimdb-data-contracts$(NC)\n"; \
 	printf "$(GREEN)✓ Production is simulation-free$(NC)\n"
 
-# CR-9: no aimdb library may install a process-global on its host's behalf.
-#
-# A library linked into somebody else's process does not get to decide where
-# that process's diagnostics go, what happens on a panic, which signals are
-# handled, or what is in its environment. The rule held by discipline until two
-# FFI doors made it load-bearing: an extension module that installs a logging
-# subscriber writes behind the interpreter's back, and one that installs a panic
-# hook decides where an application's crashes are reported.
-#
-# Scanned: the crates that are linked into a host process. Not scanned, and
-# deliberately: `tools/` and `examples/` *are* applications, and `aimdb-codegen`
-# emits an application's `main` — the `tracing_subscriber::fmt::init()` in
-# `rust.rs` is inside a `quote!`, i.e. generated code, not this crate's.
-#
-# The one exception is the fork detector, and it is the exception that states
-# the rule: `pthread_atfork` is process-global, so it may only be registered by
-# the crate that owns the runtime thread it protects — never by an FFI shim on
-# the application's behalf.
-#
-# The guard must not fail open, so a positive control runs the same scanner over
-# a file that does violate the rule: a pattern that has stopped matching cannot
-# pass this silently.
+# CR-9: no aimdb library may install a process-global on its host's behalf —
+# a subscriber, a panic hook, a signal handler, `pthread_atfork`, `set_var`.
+# Scanned are the crates linked into somebody else's process; `tools/`,
+# `examples/` and `aimdb-codegen`'s generated `main` are applications, and are
+# not. The one exception states the rule: `pthread_atfork` may be registered by
+# the crate that owns the runtime thread it protects, never by an FFI shim.
+# The guard must not fail open, so a positive control proves the scanner still
+# scans.
 GLOBALS_SCANNED := aimdb-core aimdb-data-contracts aimdb-derive aimdb-client \
 	aimdb-tokio-adapter aimdb-embassy-adapter aimdb-wasm-adapter aimdb-sync \
 	aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector \

--- a/Makefile
+++ b/Makefile
@@ -665,7 +665,7 @@ check-no-sim:
 	printf "$(BLUE)✓ 'simulatable' is not a default feature of aimdb-data-contracts$(NC)\n"; \
 	printf "$(GREEN)✓ Production is simulation-free$(NC)\n"
 
-# CR-9: no library crate may install a process-global on its host's behalf.
+# No library crate may install a process-global on its host's behalf.
 # Applications may, so `tools/`, `examples/` and codegen's generated `main` are
 # not scanned. The one exception: the fork detector owns the runtime thread it
 # protects. A positive control keeps the guard from failing open.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # AimDB Makefile
 # Simple automation for common development tasks
 
-.PHONY: help build test clean clean-embedded fmt fmt-check clippy doc all check test-embedded test-wasm wasm wasm-test wasm-test-deps examples deny audit security publish publish-check readme-check codegen-drift check-no-sim
+.PHONY: help build test clean clean-embedded fmt fmt-check clippy doc all check test-embedded test-wasm wasm wasm-test wasm-test-deps examples deny audit security publish publish-check readme-check codegen-drift check-no-sim check-no-globals
 .DEFAULT_GOAL := help
 
 # Separate target dir for embedded checks so an interrupted example build
@@ -665,8 +665,64 @@ check-no-sim:
 	printf "$(BLUE)✓ 'simulatable' is not a default feature of aimdb-data-contracts$(NC)\n"; \
 	printf "$(GREEN)✓ Production is simulation-free$(NC)\n"
 
+# CR-9: no aimdb library may install a process-global on its host's behalf.
+#
+# A library linked into somebody else's process does not get to decide where
+# that process's diagnostics go, what happens on a panic, which signals are
+# handled, or what is in its environment. The rule held by discipline until two
+# FFI doors made it load-bearing: an extension module that installs a logging
+# subscriber writes behind the interpreter's back, and one that installs a panic
+# hook decides where an application's crashes are reported.
+#
+# Scanned: the crates that are linked into a host process. Not scanned, and
+# deliberately: `tools/` and `examples/` *are* applications, and `aimdb-codegen`
+# emits an application's `main` — the `tracing_subscriber::fmt::init()` in
+# `rust.rs` is inside a `quote!`, i.e. generated code, not this crate's.
+#
+# The one exception is the fork detector, and it is the exception that states
+# the rule: `pthread_atfork` is process-global, so it may only be registered by
+# the crate that owns the runtime thread it protects — never by an FFI shim on
+# the application's behalf.
+#
+# The guard must not fail open, so a positive control runs the same scanner over
+# a file that does violate the rule: a pattern that has stopped matching cannot
+# pass this silently.
+GLOBALS_SCANNED := aimdb-core aimdb-data-contracts aimdb-derive aimdb-client \
+	aimdb-tokio-adapter aimdb-embassy-adapter aimdb-wasm-adapter aimdb-sync \
+	aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector \
+	aimdb-knx-connector aimdb-websocket-connector aimdb-uds-connector \
+	aimdb-serial-connector aimdb-tcp-connector
+GLOBALS_PATTERN := tracing_subscriber::|set_global_default|set_boxed_logger|set_logger\(|set_max_level|panic::set_hook|panic::take_hook|pthread_atfork|sigaction|signal_hook|set_var\(
+GLOBALS_ALLOWED := aimdb-sync/src/fork\.rs
+check-no-globals:
+	@printf "$(GREEN)Checking that no library crate installs a process-global...$(NC)\n"
+	@scan() { \
+		grep -rnE '$(GLOBALS_PATTERN)' --include='*.rs' "$$@" 2>/dev/null \
+			| grep -vE ':[0-9]+:[[:space:]]*(//|\*)' || true; \
+	}; \
+	control=$$(mktemp -d) || exit 1; \
+	printf 'fn main() { tracing_subscriber::fmt().init(); }\n' > "$$control/probe.rs"; \
+	control_hit=$$(scan "$$control"); \
+	rm -rf "$$control"; \
+	if [ -z "$$control_hit" ]; then \
+		printf "$(RED)✗ positive control failed: the scanner no longer flags a subscriber install, so a clean result proves nothing$(NC)\n"; \
+		exit 1; \
+	fi; \
+	found=$$(scan $(addsuffix /src,$(GLOBALS_SCANNED)) | grep -vE '^($(GLOBALS_ALLOWED)):' || true); \
+	if [ -n "$$found" ]; then \
+		printf "$(RED)✗ a library crate installs a process-global:$(NC)\n"; \
+		printf '%s\n' "$$found"; \
+		printf "$(YELLOW)  A library does not get to make this decision for its host. Hand the$(NC)\n"; \
+		printf "$(YELLOW)  application a way to make it instead — see design 050 for how the log$(NC)\n"; \
+		printf "$(YELLOW)  destination does it. If the global genuinely belongs to the crate that$(NC)\n"; \
+		printf "$(YELLOW)  owns the runtime thread, add it to GLOBALS_ALLOWED with the reason.$(NC)\n"; \
+		exit 1; \
+	fi; \
+	printf "$(BLUE)✓ scanner verified against a positive control$(NC)\n"; \
+	printf "$(GREEN)✓ No library crate installs a process-global$(NC)\n"
+
 ## Convenience commands
-check: fmt-check clippy test test-embedded test-wasm deny readme-check codegen-drift check-no-sim
+check: fmt-check clippy test test-embedded test-wasm deny readme-check codegen-drift check-no-sim check-no-globals
 	@printf "$(GREEN)Comprehensive development checks completed!$(NC)\n"
 	@printf "$(BLUE)✓ Code formatting verified$(NC)\n"
 	@printf "$(BLUE)✓ Linter passed$(NC)\n"
@@ -676,6 +732,7 @@ check: fmt-check clippy test test-embedded test-wasm deny readme-check codegen-d
 	@printf "$(BLUE)✓ Dependencies verified (deny)$(NC)\n"
 	@printf "$(BLUE)✓ README quickstart in sync and compiling$(NC)\n"
 	@printf "$(BLUE)✓ Codegen output compiles against the workspace$(NC)\n"
+	@printf "$(BLUE)✓ No library crate installs a process-global$(NC)\n"
 
 ## WASM commands
 wasm:

--- a/Makefile
+++ b/Makefile
@@ -665,14 +665,10 @@ check-no-sim:
 	printf "$(BLUE)✓ 'simulatable' is not a default feature of aimdb-data-contracts$(NC)\n"; \
 	printf "$(GREEN)✓ Production is simulation-free$(NC)\n"
 
-# CR-9: no aimdb library may install a process-global on its host's behalf —
-# a subscriber, a panic hook, a signal handler, `pthread_atfork`, `set_var`.
-# Scanned are the crates linked into somebody else's process; `tools/`,
-# `examples/` and `aimdb-codegen`'s generated `main` are applications, and are
-# not. The one exception states the rule: `pthread_atfork` may be registered by
-# the crate that owns the runtime thread it protects, never by an FFI shim.
-# The guard must not fail open, so a positive control proves the scanner still
-# scans.
+# CR-9: no library crate may install a process-global on its host's behalf.
+# Applications may, so `tools/`, `examples/` and codegen's generated `main` are
+# not scanned. The one exception: the fork detector owns the runtime thread it
+# protects. A positive control keeps the guard from failing open.
 GLOBALS_SCANNED := aimdb-core aimdb-data-contracts aimdb-derive aimdb-client \
 	aimdb-tokio-adapter aimdb-embassy-adapter aimdb-wasm-adapter aimdb-sync \
 	aimdb-persistence aimdb-persistence-sqlite aimdb-mqtt-connector \

--- a/aimdb-core/CHANGELOG.md
+++ b/aimdb-core/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **A panic is a bug, not an error channel — checked (CR-4).** The crate is
-  compiled under `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)`
-  outside its own tests. Four sites fixed: poisoned-mutex recovery in the
+- **A panic is a bug, not an error channel — checked.** The crate is compiled
+  under `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)` outside
+  its own tests. Four sites fixed: poisoned-mutex recovery in the
   `record_id` and `typed_record` lock helpers, an `unwrap` under a `len()` check
   in `record_origin`, and an `expect` on the AimX drain path. The rest carry an
   `allow` with a reason.

--- a/aimdb-core/CHANGELOG.md
+++ b/aimdb-core/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A panic is a bug, not an error channel — checked (CR-4).** The crate is
+  compiled under `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)`
+  outside its own tests, mirroring `aimdb-sync`, and the module docs say so. The
+  rule is not new; what is new is that it is checked. It matters most below an
+  FFI door: unwinding past a C ABI is undefined behaviour, an FFI layer's
+  `catch_unwind` is compiled out by a consumer whose profile sets
+  `panic = "abort"`, and a panic's message goes to fd 2 past whatever log
+  destination the host installed, because no aimdb library may install a panic
+  hook.
+
+  Four sites were fixed rather than annotated: the `record_id` and
+  `typed_record` mutex helpers now recover from poisoning instead of
+  re-panicking on it (the first panic is the bug; a second only spreads it),
+  `TypedRecord::record_origin` asks the iterator for "exactly one input" instead
+  of trusting an `unwrap` two lines under a `len()` check, and the AimX drain
+  path reports a missing reader instead of asserting it — that one runs on the
+  session pump, where a panic takes the connection down. The rest carry an
+  `allow` with a `reason`: the buffer contract suite, which is a test harness
+  and reports by panicking; two unreachable downcasts in `configure`, guarded by
+  a `TypeId` comparison two lines above; the two connector factories, whose
+  signatures return no `Result`; and `SecurityPolicy`'s documented `# Panics`,
+  which should become a `Result` before the crates reach a registry.
+
+### Added
+
 - **`log_trace!`.** The fifth facade macro, completing the set both destinations
   support. Added for a KNX call site that was `tracing::trace!` before design
   050 §10.5 moved it onto the facade.

--- a/aimdb-core/CHANGELOG.md
+++ b/aimdb-core/CHANGELOG.md
@@ -11,29 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A panic is a bug, not an error channel — checked (CR-4).** The crate is
   compiled under `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)`
-  outside its own tests, mirroring `aimdb-sync`, and the module docs say so. The
-  rule is not new; what is new is that it is checked. It matters most below an
-  FFI door: unwinding past a C ABI is undefined behaviour, an FFI layer's
-  `catch_unwind` is compiled out by a consumer whose profile sets
-  `panic = "abort"`, and a panic's message goes to fd 2 past whatever log
-  destination the host installed, because no aimdb library may install a panic
-  hook.
-
-  Four sites were fixed rather than annotated: the `record_id` and
-  `typed_record` mutex helpers now recover from poisoning instead of
-  re-panicking on it (the first panic is the bug; a second only spreads it),
-  `TypedRecord::record_origin` asks the iterator for "exactly one input" instead
-  of trusting an `unwrap` two lines under a `len()` check, and the AimX drain
-  path reports a missing reader instead of asserting it — that one runs on the
-  session pump, where a panic takes the connection down. The rest carry an
-  `allow` with a `reason`: the buffer contract suite, which is a test harness
-  and reports by panicking; two unreachable downcasts in `configure`, guarded by
-  a `TypeId` comparison two lines above; the two connector factories, whose
-  signatures return no `Result`; and `SecurityPolicy`'s documented `# Panics`,
-  which should become a `Result` before the crates reach a registry.
-
-### Added
-
+  outside its own tests. Four sites fixed: poisoned-mutex recovery in the
+  `record_id` and `typed_record` lock helpers, an `unwrap` under a `len()` check
+  in `record_origin`, and an `expect` on the AimX drain path. The rest carry an
+  `allow` with a reason.
 - **`log_trace!`.** The fifth facade macro, completing the set both destinations
   support. Added for a KNX call site that was `tracing::trace!` before design
   050 §10.5 moved it onto the facade.

--- a/aimdb-core/src/buffer/test_support.rs
+++ b/aimdb-core/src/buffer/test_support.rs
@@ -1,11 +1,10 @@
 //! Shared behavioral contract for [`Buffer`] implementations.
 //!
-//! A test harness, so panicking *is* its report: the crate-wide
-//! `deny(clippy::unwrap_used, …)` is lifted for this module and nowhere else.
+//! A test harness, so panicking *is* its report.
 #![allow(
     clippy::unwrap_used,
     clippy::panic,
-    reason = "a test harness reports by panicking; this module is never on a production path"
+    reason = "a test harness reports by panicking"
 )]
 //!
 //! Each adapter crate calls these from a test running under its own executor

--- a/aimdb-core/src/buffer/test_support.rs
+++ b/aimdb-core/src/buffer/test_support.rs
@@ -1,6 +1,6 @@
 //! Shared behavioral contract for [`Buffer`] implementations.
 //!
-//! A test harness, so panicking *is* its report.
+//! Panicking is how a harness reports.
 #![allow(
     clippy::unwrap_used,
     clippy::panic,

--- a/aimdb-core/src/buffer/test_support.rs
+++ b/aimdb-core/src/buffer/test_support.rs
@@ -1,5 +1,13 @@
 //! Shared behavioral contract for [`Buffer`] implementations.
 //!
+//! A test harness, so panicking *is* its report: the crate-wide
+//! `deny(clippy::unwrap_used, …)` is lifted for this module and nowhere else.
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "a test harness reports by panicking; this module is never on a production path"
+)]
+//!
 //! Each adapter crate calls these from a test running under its own executor
 //! (`#[tokio::test]`, `block_on`, or a host `#[test]` + `block_on`), so the one
 //! contract is exercised against every runtime buffer implementation — the

--- a/aimdb-core/src/builder.rs
+++ b/aimdb-core/src/builder.rs
@@ -451,6 +451,17 @@ impl AimDbBuilder {
         // Find existing record with this key, or create new one
         let record_index = self.record_index.get(&record_key).copied();
 
+        // The two downcasts below are unreachable: the `TypeId` is compared
+        // first, and the mismatch path returns before reaching them. Reporting
+        // them as configuration errors instead would need a second mutable
+        // borrow of `self` while the first is still live, which is a borrow-check
+        // fight for no behavioural gain — the message already says it is a bug in
+        // aimdb-core rather than something a caller did.
+        #[allow(
+            clippy::expect_used,
+            clippy::unwrap_used,
+            reason = "unreachable given the TypeId check above; see the note"
+        )]
         let (rec, is_new_record) = match record_index {
             Some(idx) => {
                 // Use existing record. A key re-registered with a different

--- a/aimdb-core/src/builder.rs
+++ b/aimdb-core/src/builder.rs
@@ -451,16 +451,13 @@ impl AimDbBuilder {
         // Find existing record with this key, or create new one
         let record_index = self.record_index.get(&record_key).copied();
 
-        // The two downcasts below are unreachable: the `TypeId` is compared
-        // first, and the mismatch path returns before reaching them. Reporting
-        // them as configuration errors instead would need a second mutable
-        // borrow of `self` while the first is still live, which is a borrow-check
-        // fight for no behavioural gain — the message already says it is a bug in
-        // aimdb-core rather than something a caller did.
+        // Both downcasts are unreachable: the `TypeId` is compared first and
+        // the mismatch path returns. Reporting them instead would need a second
+        // mutable borrow of `self` while the first is live.
         #[allow(
             clippy::expect_used,
             clippy::unwrap_used,
-            reason = "unreachable given the TypeId check above; see the note"
+            reason = "unreachable given the TypeId check above"
         )]
         let (rec, is_new_record) = match record_index {
             Some(idx) => {

--- a/aimdb-core/src/builder.rs
+++ b/aimdb-core/src/builder.rs
@@ -451,9 +451,8 @@ impl AimDbBuilder {
         // Find existing record with this key, or create new one
         let record_index = self.record_index.get(&record_key).copied();
 
-        // Both downcasts are unreachable: the `TypeId` is compared first and
-        // the mismatch path returns. Reporting them instead would need a second
-        // mutable borrow of `self` while the first is live.
+        // Reporting these instead would need a second mutable borrow of `self`
+        // while the first is live.
         #[allow(
             clippy::expect_used,
             clippy::unwrap_used,

--- a/aimdb-core/src/lib.rs
+++ b/aimdb-core/src/lib.rs
@@ -15,15 +15,10 @@
 //!
 //! # A panic is a bug, not an error channel
 //!
-//! Every failure is a [`DbError`], classified by [`DbError::kind`]. The crate
-//! is compiled under `deny(clippy::unwrap_used, clippy::expect_used,
-//! clippy::panic)` outside its own tests; the few remaining sites carry an
-//! `allow` with a reason. It matters below an FFI door: unwinding past a C ABI
-//! is undefined behaviour, and a consumer's `panic = "abort"` compiles that
-//! layer's own `catch_unwind` out.
-//!
-//! Not promised: a dependency can still panic on its own, and a poisoned lock
-//! is recovered from rather than re-panicked on.
+//! Every failure is a [`DbError`]. The crate is compiled under
+//! `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)` outside its
+//! tests; the sites that remain carry an `allow` with a reason. A dependency
+//! can still panic on its own, and a poisoned lock is recovered from.
 //!
 //! # Where aimdb's own reporting goes
 //!
@@ -52,9 +47,8 @@
 //! 5. **Cannot be uninstalled.** `set_logger` is once per process; a second
 //!    call returns `Err` and the first destination keeps receiving.
 
-// A panic here is a bug, not an error channel: two FFI doors sit above this
-// crate, and a consumer's `panic = "abort"` compiles their guard out. Checked
-// rather than remembered, as in `aimdb-sync`.
+// A panic here is a bug: two FFI doors sit above this crate, and a consumer's
+// `panic = "abort"` compiles their guard out.
 #![cfg_attr(
     not(test),
     deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)

--- a/aimdb-core/src/lib.rs
+++ b/aimdb-core/src/lib.rs
@@ -15,25 +15,15 @@
 //!
 //! # A panic is a bug, not an error channel
 //!
-//! Every failure this crate reports is a [`DbError`], classified by
-//! [`DbError::kind`] into something a caller can act on. A panic is neither:
-//! it is a defect in aimdb. The crate is compiled under
-//! `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)` outside its
-//! own tests, so the property is checked rather than remembered, and the few
-//! sites that remain each carry an `allow` with a reason naming why.
+//! Every failure is a [`DbError`], classified by [`DbError::kind`]. The crate
+//! is compiled under `deny(clippy::unwrap_used, clippy::expect_used,
+//! clippy::panic)` outside its own tests; the few remaining sites carry an
+//! `allow` with a reason. It matters below an FFI door: unwinding past a C ABI
+//! is undefined behaviour, and a consumer's `panic = "abort"` compiles that
+//! layer's own `catch_unwind` out.
 //!
-//! This matters most to callers arriving from another language. A panic
-//! unwinding past a C ABI is undefined behaviour; an FFI layer's `catch_unwind`
-//! is compiled out by a consumer whose profile sets `panic = "abort"`, which
-//! turns the same panic into the whole process dying; and a panic's message
-//! goes to fd 2 past whatever log destination the host installed, because
-//! Rust's panic hook is process-global and no aimdb library may install one.
-//! So the guard has to be here, not above.
-//!
-//! Two things this does not promise: a dependency reached through this crate
-//! can still panic on its own, and a lock left poisoned by a panic elsewhere is
-//! recovered from rather than re-panicked on — the first panic is the bug to
-//! fix, and a second one only spreads it.
+//! Not promised: a dependency can still panic on its own, and a poisoned lock
+//! is recovered from rather than re-panicked on.
 //!
 //! # Where aimdb's own reporting goes
 //!
@@ -62,12 +52,9 @@
 //! 5. **Cannot be uninstalled.** `set_logger` is once per process; a second
 //!    call returns `Err` and the first destination keeps receiving.
 
-// A panic on this crate's surface is not an error channel, it is a bug. Two
-// FFI doors now sit above it, where unwinding past the boundary is undefined
-// behaviour and a consumer's `panic = "abort"` turns any panic into the whole
-// process dying — and their `catch_unwind` is compiled out by exactly that
-// profile, so the property has to hold here rather than be caught above.
-// Checked rather than remembered, as in `aimdb-sync`.
+// A panic here is a bug, not an error channel: two FFI doors sit above this
+// crate, and a consumer's `panic = "abort"` compiles their guard out. Checked
+// rather than remembered, as in `aimdb-sync`.
 #![cfg_attr(
     not(test),
     deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)

--- a/aimdb-core/src/lib.rs
+++ b/aimdb-core/src/lib.rs
@@ -13,6 +13,28 @@
 //!
 //! See examples in the repository for usage patterns.
 //!
+//! # A panic is a bug, not an error channel
+//!
+//! Every failure this crate reports is a [`DbError`], classified by
+//! [`DbError::kind`] into something a caller can act on. A panic is neither:
+//! it is a defect in aimdb. The crate is compiled under
+//! `deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)` outside its
+//! own tests, so the property is checked rather than remembered, and the few
+//! sites that remain each carry an `allow` with a reason naming why.
+//!
+//! This matters most to callers arriving from another language. A panic
+//! unwinding past a C ABI is undefined behaviour; an FFI layer's `catch_unwind`
+//! is compiled out by a consumer whose profile sets `panic = "abort"`, which
+//! turns the same panic into the whole process dying; and a panic's message
+//! goes to fd 2 past whatever log destination the host installed, because
+//! Rust's panic hook is process-global and no aimdb library may install one.
+//! So the guard has to be here, not above.
+//!
+//! Two things this does not promise: a dependency reached through this crate
+//! can still panic on its own, and a lock left poisoned by a panic elsewhere is
+//! recovered from rather than re-panicked on — the first panic is the bug to
+//! fix, and a second one only spreads it.
+//!
 //! # Where aimdb's own reporting goes
 //!
 //! Two optional destinations, neither on by default: **`tracing`**, the ordinary
@@ -40,6 +62,16 @@
 //! 5. **Cannot be uninstalled.** `set_logger` is once per process; a second
 //!    call returns `Err` and the first destination keeps receiving.
 
+// A panic on this crate's surface is not an error channel, it is a bug. Two
+// FFI doors now sit above it, where unwinding past the boundary is undefined
+// behaviour and a consumer's `panic = "abort"` turns any panic into the whole
+// process dying — and their `catch_unwind` is compiled out by exactly that
+// profile, so the property has to hold here rather than be caught above.
+// Checked rather than remembered, as in `aimdb-sync`.
+#![cfg_attr(
+    not(test),
+    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
+)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/aimdb-core/src/record_id.rs
+++ b/aimdb-core/src/record_id.rs
@@ -66,7 +66,7 @@ type Mutex<T> = spin::Mutex<T>;
 /// the correct response. Same pattern as the `TypedRecord` field mutexes.
 #[cfg(feature = "std")]
 fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
-    m.lock().unwrap()
+    m.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 #[cfg(not(feature = "std"))]
 fn lock<T>(m: &Mutex<T>) -> spin::MutexGuard<'_, T> {

--- a/aimdb-core/src/remote/config.rs
+++ b/aimdb-core/src/remote/config.rs
@@ -140,6 +140,10 @@ impl SecurityPolicy {
     /// Adds a record key to the writable set
     ///
     /// Only has effect for ReadWrite policies. Panics if policy is ReadOnly.
+    #[allow(
+        clippy::panic,
+        reason = "documented API contract (see # Panics). Returning a Result instead is a breaking change worth making before the crates reach a registry, not a lint fix."
+    )]
     pub fn allow_write_key(&mut self, key: impl Into<String>) {
         match self {
             Self::ReadWrite { writable_records } => {
@@ -155,6 +159,10 @@ impl SecurityPolicy {
     ///
     /// # Panics
     /// Panics if called on a ReadOnly policy
+    #[allow(
+        clippy::panic,
+        reason = "documented API contract (see # Panics). Returning a Result instead is a breaking change worth making before the crates reach a registry, not a lint fix."
+    )]
     pub fn with_writable_key(mut self, key: impl Into<String>) -> Self {
         match self {
             Self::ReadWrite {

--- a/aimdb-core/src/remote/config.rs
+++ b/aimdb-core/src/remote/config.rs
@@ -142,7 +142,7 @@ impl SecurityPolicy {
     /// Only has effect for ReadWrite policies. Panics if policy is ReadOnly.
     #[allow(
         clippy::panic,
-        reason = "documented API contract (see # Panics). Returning a Result instead is a breaking change worth making before the crates reach a registry, not a lint fix."
+        reason = "documented API contract; a Result instead is a breaking change worth making before the registry release"
     )]
     pub fn allow_write_key(&mut self, key: impl Into<String>) {
         match self {
@@ -161,7 +161,7 @@ impl SecurityPolicy {
     /// Panics if called on a ReadOnly policy
     #[allow(
         clippy::panic,
-        reason = "documented API contract (see # Panics). Returning a Result instead is a breaking change worth making before the crates reach a registry, not a lint fix."
+        reason = "documented API contract; a Result instead is a breaking change worth making before the registry release"
     )]
     pub fn with_writable_key(mut self, key: impl Into<String>) -> Self {
         match self {

--- a/aimdb-core/src/remote/config.rs
+++ b/aimdb-core/src/remote/config.rs
@@ -142,7 +142,7 @@ impl SecurityPolicy {
     /// Only has effect for ReadWrite policies. Panics if policy is ReadOnly.
     #[allow(
         clippy::panic,
-        reason = "documented API contract; a Result instead is a breaking change worth making before the registry release"
+        reason = "documented API contract; a Result instead is a breaking change"
     )]
     pub fn allow_write_key(&mut self, key: impl Into<String>) {
         match self {
@@ -161,7 +161,7 @@ impl SecurityPolicy {
     /// Panics if called on a ReadOnly policy
     #[allow(
         clippy::panic,
-        reason = "documented API contract; a Result instead is a breaking change worth making before the registry release"
+        reason = "documented API contract; a Result instead is a breaking change"
     )]
     pub fn with_writable_key(mut self, key: impl Into<String>) -> Self {
         match self {

--- a/aimdb-core/src/session/aimx/dispatch.rs
+++ b/aimdb-core/src/session/aimx/dispatch.rs
@@ -335,8 +335,8 @@ impl AimxSession {
             self.drain_readers.insert(name.to_string(), reader);
         }
 
-        // Unreachable — inserted above when absent — but reported rather than
-        // asserted: this runs on the session pump.
+        // Unreachable, but reported rather than asserted: this is the session
+        // pump.
         let reader = self.drain_readers.get_mut(name).ok_or_else(|| {
             map_db_err(DbError::runtime_error(alloc::format!(
                 "Record '{name}' drain reader vanished between insert and use"

--- a/aimdb-core/src/session/aimx/dispatch.rs
+++ b/aimdb-core/src/session/aimx/dispatch.rs
@@ -335,7 +335,14 @@ impl AimxSession {
             self.drain_readers.insert(name.to_string(), reader);
         }
 
-        let reader = self.drain_readers.get_mut(name).expect("inserted above");
+        // Inserted immediately above when absent, so this is unreachable — but
+        // reported rather than asserted: this runs on the session pump, where a
+        // panic takes the connection down with it.
+        let reader = self.drain_readers.get_mut(name).ok_or_else(|| {
+            map_db_err(DbError::runtime_error(alloc::format!(
+                "Record '{name}' drain reader vanished between insert and use"
+            )))
+        })?;
         let mut values = Vec::new();
         while values.len() < limit {
             match reader.try_recv_json() {

--- a/aimdb-core/src/session/aimx/dispatch.rs
+++ b/aimdb-core/src/session/aimx/dispatch.rs
@@ -335,9 +335,8 @@ impl AimxSession {
             self.drain_readers.insert(name.to_string(), reader);
         }
 
-        // Inserted immediately above when absent, so this is unreachable — but
-        // reported rather than asserted: this runs on the session pump, where a
-        // panic takes the connection down with it.
+        // Unreachable — inserted above when absent — but reported rather than
+        // asserted: this runs on the session pump.
         let reader = self.drain_readers.get_mut(name).ok_or_else(|| {
             map_db_err(DbError::runtime_error(alloc::format!(
                 "Record '{name}' drain reader vanished between insert and use"

--- a/aimdb-core/src/typed_api.rs
+++ b/aimdb-core/src/typed_api.rs
@@ -972,7 +972,7 @@ where
         // failures here are aimdb bugs, not user mistakes.
         #[allow(
             clippy::panic,
-            reason = "the factory signature returns no Result and these lookups were validated at build() time; a fallible signature is the real fix"
+            reason = "the factory returns no Result and these lookups were validated at build() time"
         )]
         let source_factory: crate::connector::SourceFactoryFn = {
             let record_key = self.registrar.record_key.clone();
@@ -1173,7 +1173,7 @@ where
         // user mistakes.
         #[allow(
             clippy::panic,
-            reason = "the factory signature returns no Result and these lookups were validated at build() time; a fallible signature is the real fix"
+            reason = "the factory returns no Result and these lookups were validated at build() time"
         )]
         let ingest_factory: crate::connector::IngestFactoryFn = {
             let record_key = self.registrar.record_key.clone();

--- a/aimdb-core/src/typed_api.rs
+++ b/aimdb-core/src/typed_api.rs
@@ -970,6 +970,10 @@ where
         // The factory runs during build() after every record is registered and
         // validated (including the linked-records-need-a-buffer check), so
         // failures here are aimdb bugs, not user mistakes.
+        #[allow(
+            clippy::panic,
+            reason = "factory signature returns no Result; the lookups it makes were validated at build() time, so a failure here is an aimdb bug. Giving the factories a fallible signature is the fix, and it is bigger than this lint."
+        )]
         let source_factory: crate::connector::SourceFactoryFn = {
             let record_key = self.registrar.record_key.clone();
             let topic_provider = self.topic_provider;
@@ -1167,6 +1171,10 @@ where
         // crossing. The factory runs during build() after every record is
         // registered and validated, so failures here are aimdb bugs, not
         // user mistakes.
+        #[allow(
+            clippy::panic,
+            reason = "factory signature returns no Result; the lookups it makes were validated at build() time, so a failure here is an aimdb bug. Giving the factories a fallible signature is the fix, and it is bigger than this lint."
+        )]
         let ingest_factory: crate::connector::IngestFactoryFn = {
             let record_key = self.registrar.record_key.clone();
             Arc::new(move |db: &AimDb| {

--- a/aimdb-core/src/typed_api.rs
+++ b/aimdb-core/src/typed_api.rs
@@ -972,7 +972,7 @@ where
         // failures here are aimdb bugs, not user mistakes.
         #[allow(
             clippy::panic,
-            reason = "factory signature returns no Result; the lookups it makes were validated at build() time, so a failure here is an aimdb bug. Giving the factories a fallible signature is the fix, and it is bigger than this lint."
+            reason = "the factory signature returns no Result and these lookups were validated at build() time; a fallible signature is the real fix"
         )]
         let source_factory: crate::connector::SourceFactoryFn = {
             let record_key = self.registrar.record_key.clone();
@@ -1173,7 +1173,7 @@ where
         // user mistakes.
         #[allow(
             clippy::panic,
-            reason = "factory signature returns no Result; the lookups it makes were validated at build() time, so a failure here is an aimdb bug. Giving the factories a fallible signature is the fix, and it is bigger than this lint."
+            reason = "the factory signature returns no Result and these lookups were validated at build() time; a fallible signature is the real fix"
         )]
         let ingest_factory: crate::connector::IngestFactoryFn = {
             let record_key = self.registrar.record_key.clone();

--- a/aimdb-core/src/typed_record.rs
+++ b/aimdb-core/src/typed_record.rs
@@ -701,9 +701,8 @@ impl<T: Send + 'static + Debug + Clone> TypedRecord<T> {
         let transform_keys = lock(&self.transform).as_ref().map(|t| t.input_keys.clone());
 
         if let Some(input_keys) = transform_keys {
-            // Asked of the iterator rather than of `len()`, so "exactly one
-            // input" is a pattern the compiler checks instead of an invariant
-            // an `unwrap` two lines down has to trust.
+            // Asked of the iterator, not of `len()`: "exactly one input" is
+            // then a pattern the compiler checks.
             let mut inputs = input_keys.into_iter();
             return match (inputs.next(), inputs.next()) {
                 (Some(input), None) => crate::graph::RecordOrigin::Transform { input },

--- a/aimdb-core/src/typed_record.rs
+++ b/aimdb-core/src/typed_record.rs
@@ -701,8 +701,8 @@ impl<T: Send + 'static + Debug + Clone> TypedRecord<T> {
         let transform_keys = lock(&self.transform).as_ref().map(|t| t.input_keys.clone());
 
         if let Some(input_keys) = transform_keys {
-            // Asked of the iterator, not of `len()`: "exactly one input" is
-            // then a pattern the compiler checks.
+            // Asked of the iterator, not of `len()`: a pattern, not a trusted
+            // invariant.
             let mut inputs = input_keys.into_iter();
             return match (inputs.next(), inputs.next()) {
                 (Some(input), None) => crate::graph::RecordOrigin::Transform { input },

--- a/aimdb-core/src/typed_record.rs
+++ b/aimdb-core/src/typed_record.rs
@@ -45,7 +45,7 @@ type Mutex<T> = spin::Mutex<T>;
 /// both sides, so call sites are identical.
 #[cfg(feature = "std")]
 fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
-    m.lock().unwrap()
+    m.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 #[cfg(not(feature = "std"))]
 fn lock<T>(m: &Mutex<T>) -> spin::MutexGuard<'_, T> {
@@ -701,13 +701,16 @@ impl<T: Send + 'static + Debug + Clone> TypedRecord<T> {
         let transform_keys = lock(&self.transform).as_ref().map(|t| t.input_keys.clone());
 
         if let Some(input_keys) = transform_keys {
-            if input_keys.len() == 1 {
-                return crate::graph::RecordOrigin::Transform {
-                    input: input_keys.into_iter().next().unwrap(),
-                };
-            } else {
-                return crate::graph::RecordOrigin::TransformJoin { inputs: input_keys };
-            }
+            // Asked of the iterator rather than of `len()`, so "exactly one
+            // input" is a pattern the compiler checks instead of an invariant
+            // an `unwrap` two lines down has to trust.
+            let mut inputs = input_keys.into_iter();
+            return match (inputs.next(), inputs.next()) {
+                (Some(input), None) => crate::graph::RecordOrigin::Transform { input },
+                (first, second) => crate::graph::RecordOrigin::TransformJoin {
+                    inputs: first.into_iter().chain(second).chain(inputs).collect(),
+                },
+            };
         }
 
         // Check for inbound connector (link)

--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`AimDbHandle::shutdown(&self)` and `is_closed()` (CR-10).** The shutdown
+  contract an FFI layer needs now lives in the crate whose thread it is about,
+  rather than only in a station crate above it. Four properties, each pinned by
+  `tests/shutdown_contract_test.rs`: `shutdown` takes `&self`, because a C ABI's
+  free function and a `#[pymethods]` method never receive `self` by value; it is
+  idempotent, including when two threads race for it; it is safe to call while
+  producers publish, since they reach the database through their own `Weak` and
+  never take the lock it holds; and `is_closed` reads an atomic and never that
+  lock, so a caller holding an interpreter lock can ask it while a shutdown is
+  joining — including from aimdb's own runtime thread, where a logging bridge
+  runs. `is_closed` also reports closed in a `fork`ed child, whose inherited
+  handle names a thread that did not come across. `shutdown_timeout(&self, _)`
+  is the bounded form.
+
+  Without these, each new binding rediscovered them: the pyo3 door measured
+  200/200 closes refused by pyo3's borrow flag while one thread published in a
+  loop, and the C ABI door inherited the fix rather than re-solving it only
+  because a station crate had already made it. Nothing is deprecated —
+  `detach(self)` and `detach_timeout(self, _)` are the same calls for an owner
+  that has the handle by value, and both now delegate.
+
 - **`tracing` no longer pulls `dep:tracing`** (design 050 §10.4): that arm now
   reaches the crate through `aimdb_core::__private`, as the `log` arm already
   did. Both features stay — they select the arms.
@@ -18,6 +39,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call sites unrouted. It forwards and adds nothing else; no `log` dependency is
   needed here, because the macro reaches the crate through
   `aimdb_core::__private`.
+
+### Changed
+
+- **A shutdown releases the database, where dropping the handle used to.** The
+  runtime holds the built `AimDb` weakly and the handle owns the one strong
+  reference, so `shutdown` can release it through `&self`. Dropping the last
+  `Arc<AimDb>` is what closes the buffers, and closing them is what wakes a
+  consumer parked in `get()` — `aimdb-core` has no explicit close. For
+  `detach(self)` the timing is unchanged, since the handle was dropped on the
+  way out anyway; for a `shutdown` through a handle the caller keeps, this is
+  what makes "shut down, then join the reader threads" terminate instead of
+  hanging, and what refuses the publish after rather than accepting it into a
+  graph nobody pumps. It costs one atomic increment on the publish path, where a
+  lock would have been the alternative.
 
 ### Fixed
 

--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -9,27 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`AimDbHandle::shutdown(&self)` and `is_closed()` (CR-10).** The shutdown
-  contract an FFI layer needs now lives in the crate whose thread it is about,
-  rather than only in a station crate above it. Four properties, each pinned by
-  `tests/shutdown_contract_test.rs`: `shutdown` takes `&self`, because a C ABI's
-  free function and a `#[pymethods]` method never receive `self` by value; it is
-  idempotent, including when two threads race for it; it is safe to call while
-  producers publish, since they reach the database through their own `Weak` and
-  never take the lock it holds; and `is_closed` reads an atomic and never that
-  lock, so a caller holding an interpreter lock can ask it while a shutdown is
-  joining — including from aimdb's own runtime thread, where a logging bridge
-  runs. `is_closed` also reports closed in a `fork`ed child, whose inherited
-  handle names a thread that did not come across. `shutdown_timeout(&self, _)`
-  is the bounded form.
-
-  Without these, each new binding rediscovered them: the pyo3 door measured
-  200/200 closes refused by pyo3's borrow flag while one thread published in a
-  loop, and the C ABI door inherited the fix rather than re-solving it only
-  because a station crate had already made it. Nothing is deprecated —
-  `detach(self)` and `detach_timeout(self, _)` are the same calls for an owner
-  that has the handle by value, and both now delegate.
-
+- **`AimDbHandle::shutdown(&self)`, `shutdown_timeout(&self, _)` and
+  `is_closed()` (CR-10).** The shutdown contract a foreign-language binding
+  needs — `&self`, idempotent, safe during a publish, and an `is_closed` that
+  never takes the shutdown's lock — pinned by `tests/shutdown_contract_test.rs`.
+  `detach(self)` and `detach_timeout(self, _)` are unchanged and delegate.
 - **`tracing` no longer pulls `dep:tracing`** (design 050 §10.4): that arm now
   reaches the crate through `aimdb_core::__private`, as the `log` arm already
   did. Both features stay — they select the arms.
@@ -43,16 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **A shutdown releases the database, where dropping the handle used to.** The
-  runtime holds the built `AimDb` weakly and the handle owns the one strong
-  reference, so `shutdown` can release it through `&self`. Dropping the last
-  `Arc<AimDb>` is what closes the buffers, and closing them is what wakes a
-  consumer parked in `get()` — `aimdb-core` has no explicit close. For
-  `detach(self)` the timing is unchanged, since the handle was dropped on the
-  way out anyway; for a `shutdown` through a handle the caller keeps, this is
-  what makes "shut down, then join the reader threads" terminate instead of
-  hanging, and what refuses the publish after rather than accepting it into a
-  graph nobody pumps. It costs one atomic increment on the publish path, where a
-  lock would have been the alternative.
+  runtime holds it weakly; the handle owns the strong reference and drops it
+  after the join. That closes the buffers, so a consumer parked in `get()` is
+  woken and the publish after is refused. Unchanged for `detach(self)`. Costs
+  one atomic increment per publish.
 
 ### Fixed
 

--- a/aimdb-sync/CHANGELOG.md
+++ b/aimdb-sync/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`AimDbHandle::shutdown(&self)`, `shutdown_timeout(&self, _)` and
-  `is_closed()` (CR-10).** The shutdown contract a foreign-language binding
-  needs — `&self`, idempotent, safe during a publish, and an `is_closed` that
-  never takes the shutdown's lock — pinned by `tests/shutdown_contract_test.rs`.
+  `is_closed()`.** The shutdown contract a foreign-language binding needs —
+  `&self`, idempotent, safe during a publish, and an `is_closed` that never
+  takes the shutdown's lock — pinned by `tests/shutdown_contract_test.rs`.
   `detach(self)` and `detach_timeout(self, _)` are unchanged and delegate.
 - **`tracing` no longer pulls `dep:tracing`** (design 050 §10.4): that arm now
   reaches the crate through `aimdb_core::__private`, as the `log` arm already

--- a/aimdb-sync/src/handle.rs
+++ b/aimdb-sync/src/handle.rs
@@ -107,21 +107,9 @@ impl AimDbSyncExt for AimDb {
 ///
 /// # Resource Management
 ///
-/// Call [`shutdown`](Self::shutdown) — or [`detach`](Self::detach), the same
-/// thing for a caller that owns the handle by value — to stop the runtime
-/// thread deliberately. A handle dropped without either logs a warning and
-/// signals shutdown without waiting for it.
-///
-/// # Shutting down through a shared reference
-///
-/// [`shutdown`](Self::shutdown) takes `&self`, is idempotent, and is safe to
-/// call while producers publish; [`is_closed`](Self::is_closed) never takes the
-/// lock it holds. Those four properties are what a binding in another language
-/// needs, and none of them is expressible in a signature: a C ABI's free
-/// function and a `#[pymethods]` method never receive `self` by value, and a
-/// `&mut self` shutdown collides at run time with a publish already in flight
-/// — measured, in the two FFI doors this crate was hardened for. Pinned by
-/// `tests/shutdown_contract_test.rs`.
+/// [`shutdown`](Self::shutdown) stops the thread; [`detach`](Self::detach) is
+/// the same call by value. Dropping without either warns and signals without
+/// waiting.
 pub struct AimDbHandle {
     /// The runtime thread and everything reached through it, shared with every
     /// producer and consumer made from this handle. See [`crate::runtime`].
@@ -136,25 +124,16 @@ pub struct AimDbHandle {
     /// it, join it.
     ///
     /// `None` once shut down, or once a `fork` proved the thread is not this
-    /// process's to reap. One field, so releasing it cannot be half-done — the
-    /// previous shape was four loose fields and a release path that forgot one
-    /// of them the moment a fifth was added.
+    /// process's to reap. One field, so releasing it cannot be half-done.
     ///
-    /// Behind a `Mutex` so [`shutdown`](Self::shutdown) can take `&self`.
-    /// Nothing on the publish path ever waits for it: a
-    /// [`SyncProducer`](crate::SyncProducer) reaches the database through its
-    /// own [`Weak`](alloc::sync::Weak), so a shutdown cannot queue behind an
-    /// in-flight publish and a publish cannot queue behind a shutdown.
+    /// Behind a `Mutex` so [`shutdown`](Self::shutdown) can take `&self`. The
+    /// publish path never waits for it — producers hold their own
+    /// [`Weak`](alloc::sync::Weak).
     owned: std::sync::Mutex<Option<OwnedThread>>,
 
     /// Whether [`shutdown`](Self::shutdown) has taken the thread out of
-    /// `owned`.
-    ///
-    /// An atomic rather than a peek at the mutex beside it, because
-    /// [`is_closed`](Self::is_closed) is what an FFI layer calls while holding
-    /// its own interpreter lock. Waiting there on the lock a shutdown holds —
-    /// while that shutdown waits for the very interpreter lock its logging
-    /// bridge needs — is the deadlock this field exists to keep impossible.
+    /// `owned`. An atomic, not a peek at the mutex beside it: an FFI layer asks
+    /// this holding its interpreter lock, and the shutdown wants that lock.
     closed: AtomicBool,
 }
 
@@ -163,16 +142,9 @@ struct OwnedThread {
     /// Joined by `shutdown`; released, never joined, by `Drop`.
     join: JoinHandle<()>,
 
-    /// The one strong reference to the database.
-    ///
-    /// Here rather than in [`Runtime`], which holds a `Weak`, so that a
-    /// shutdown through `&self` releases it: dropping the last `Arc<AimDb>`
-    /// closes the buffers, and that is what wakes a consumer parked in `get()`.
-    /// It also refuses the publish after, since a producer reaches the database
-    /// only through `Runtime::db`.
-    ///
-    /// Released *after* the join, so the graph is not pulled out from under a
-    /// runtime thread that is still draining it.
+    /// The one strong reference to the database — [`Runtime`] holds a `Weak`.
+    /// Released after the join, which closes the buffers: that wakes a consumer
+    /// parked in `get()` and refuses the publish after.
     db: Arc<AimDb>,
 
     /// Commands the thread to stop. Distinct from dropping it: the thread also
@@ -437,41 +409,23 @@ impl AimDbHandle {
 
     /// Stop the runtime thread, through a shared reference.
     ///
-    /// Signals the thread, waits for it, and joins it. Prefer this — or
-    /// [`detach`](Self::detach), which is this call for an owner that has the
-    /// handle by value — over dropping the handle, which signals without
-    /// waiting.
-    ///
-    /// **Idempotent.** The call that finds the thread already taken returns
-    /// `Ok(())`, so two threads racing to shut down do not manufacture an
-    /// error between them, and a shutdown after a `Drop`-less close is a no-op
-    /// rather than a fault.
-    ///
-    /// **Safe during a publish.** A [`SyncProducer`](crate::SyncProducer)
-    /// reaches the database through its own [`Weak`](alloc::sync::Weak) and
-    /// never takes the lock this does, so a shutdown cannot queue behind an
-    /// in-flight publish. A publish that arrives after the thread stops fails
-    /// with [`SyncError::RuntimeShutdown`].
-    ///
-    /// Blocks the calling thread, so it must not be called from inside a Tokio
-    /// runtime. It *may* be called from aimdb's own runtime thread only in the
-    /// sense every other method may — see [`is_closed`](Self::is_closed) for
-    /// the one that is meant to be.
+    /// Signals, waits, joins. `&self` because a C ABI's free function and a
+    /// `#[pymethods]` method never receive `self` by value. Idempotent, so
+    /// racing callers do not manufacture an error. Safe during a publish:
+    /// producers hold their own [`Weak`](alloc::sync::Weak) and never take this
+    /// lock. Blocks, so not from inside a Tokio runtime.
     ///
     /// # Errors
     ///
-    /// - [`SyncError::ForkedChild`] if this process `fork`ed since the handle
-    ///   was created: the thread did not come across, so there is nothing here
-    ///   to stop. The handle releases it rather than joining a thread that
-    ///   does not exist, which would panic inside `std`.
-    /// - [`SyncError::DetachFailed`] if the runtime thread panicked.
+    /// - [`SyncError::ForkedChild`] — this is a `fork`ed child, so the thread
+    ///   is not here to stop; the handle releases it rather than joining it.
+    /// - [`SyncError::DetachFailed`] — the runtime thread panicked.
     ///
     /// # Lock ordering
     ///
-    /// The lock guarding the thread is released *before* the join, so a caller
-    /// that blocks on it while holding something the runtime thread needs — an
-    /// FFI layer's interpreter lock, when that thread logs through a bridge
-    /// into it — cannot deadlock against its own shutdown.
+    /// The lock is released before the join, so a caller holding something the
+    /// runtime thread needs (an FFI layer's interpreter lock, when that thread
+    /// logs into it) cannot deadlock against its own shutdown.
     ///
     /// # Example
     ///
@@ -479,9 +433,7 @@ impl AimDbHandle {
     /// # use aimdb_sync::*;
     /// # use std::sync::Arc;
     /// # fn example(handle: Arc<AimDbHandle>) -> SyncResult<()> {
-    /// let signal_handler = Arc::clone(&handle);
-    /// // … from another thread, while this one publishes:
-    /// signal_handler.shutdown()?;
+    /// Arc::clone(&handle).shutdown()?; // from a signal handler, say
     /// assert!(handle.is_closed());
     /// # Ok(())
     /// # }
@@ -494,56 +446,41 @@ impl AimDbHandle {
     ///
     /// # Errors
     ///
-    /// - [`SyncError::DetachFailed`] if the thread had not finished in time
-    /// - the errors [`shutdown`](Self::shutdown) documents
+    /// [`SyncError::DetachFailed`] if the thread had not finished in time, plus
+    /// what [`shutdown`](Self::shutdown) documents.
     ///
     /// # What a timeout leaves behind
     ///
-    /// `DetachFailed` from an expired timeout means the runtime thread had not
-    /// finished in time — not that shutdown failed. Concretely:
-    ///
-    /// - The shutdown signal **was** delivered, so the thread stops on its own
-    ///   and drops the database when it does. Nothing is stranded: no thread is
-    ///   left parked waiting to reap it.
-    /// - The handle has already released the thread, so a later
-    ///   [`shutdown`](Self::shutdown) returns `Ok(())` immediately rather than
-    ///   waiting longer. [`is_closed`](Self::is_closed) reports `true` from the
-    ///   moment the shutdown began.
-    /// - Any [`SyncProducer`](crate::SyncProducer) or
-    ///   [`SyncConsumer`](crate::SyncConsumer) you still hold keeps working
-    ///   until the thread stops, then fails with
-    ///   [`SyncError::RuntimeShutdown`].
-    /// - Resources are therefore released *eventually*, not by the time this
-    ///   returns. Use [`shutdown`](Self::shutdown), which has no timeout, when
-    ///   you need to know the thread is down.
+    /// The signal *was* delivered, so the thread stops on its own and drops the
+    /// database with it; nothing is stranded. The handle has already released
+    /// it, so a later [`shutdown`](Self::shutdown) returns at once rather than
+    /// waiting longer, and [`is_closed`](Self::is_closed) was `true` from the
+    /// moment this began. Surviving producers and consumers work until the
+    /// thread stops, then fail with [`SyncError::RuntimeShutdown`]. Resources
+    /// are released eventually, not by the time this returns — use
+    /// [`shutdown`](Self::shutdown) when you need to know the thread is down.
     pub fn shutdown_timeout(&self, timeout: Duration) -> SyncResult<()> {
         self.shutdown_internal(Some(timeout))
     }
 
     /// Whether this handle can still reach the runtime thread.
     ///
-    /// `true` from the moment a [`shutdown`](Self::shutdown) begins — not when
-    /// it finishes — and `true` in a child of `fork()`, whose inherited handle
-    /// names a thread that did not come across.
+    /// `true` from the moment a [`shutdown`](Self::shutdown) begins, and in a
+    /// `fork`ed child. One atomic load and the fork check a publish makes —
+    /// never the lock a shutdown holds, so an FFI layer may ask this from
+    /// aimdb's own runtime thread while another thread is joining.
     ///
-    /// Never takes the lock [`shutdown`](Self::shutdown) holds: one atomic load
-    /// and the same relaxed fork check a publish makes. So a caller holding an
-    /// interpreter lock may ask this while another thread's shutdown is joining,
-    /// which is exactly what an FFI layer's logging bridge does from aimdb's own
-    /// runtime thread. Pinned by `tests/shutdown_contract_test.rs`.
-    ///
-    /// A `false` is a statement about this handle, not a promise about the next
-    /// call: the thread may stop between the two. Producers and consumers report
-    /// that for themselves, on the call that would have used it.
+    /// `false` describes this handle now, not the next call: producers and
+    /// consumers report for themselves, on the call that would have used it.
     pub fn is_closed(&self) -> bool {
         self.closed.load(Ordering::Acquire) || self.rt.check().is_err()
     }
 
-    /// [`shutdown`](Self::shutdown) for a caller that owns the handle by value.
+    /// [`shutdown`](Self::shutdown) for an owner that has the handle by value.
     ///
     /// # Errors
     ///
-    /// The errors [`shutdown`](Self::shutdown) documents.
+    /// What [`shutdown`](Self::shutdown) documents.
     ///
     /// # Example
     ///
@@ -558,13 +495,13 @@ impl AimDbHandle {
         self.shutdown()
     }
 
-    /// [`shutdown_timeout`](Self::shutdown_timeout) for a caller that owns the
+    /// [`shutdown_timeout`](Self::shutdown_timeout) for an owner that has the
     /// handle by value.
     ///
     /// # Errors
     ///
-    /// The errors [`shutdown_timeout`](Self::shutdown_timeout) documents,
-    /// including what an expired timeout leaves behind.
+    /// What [`shutdown_timeout`](Self::shutdown_timeout) documents, including
+    /// what an expired timeout leaves behind.
     ///
     /// # Example
     ///
@@ -582,13 +519,9 @@ impl AimDbHandle {
 
     /// Take the runtime thread out of the handle.
     ///
-    /// Written as one statement on purpose: the guard is a temporary, so it is
-    /// dropped when the statement ends and cannot be held across the join the
-    /// callers do next. See the lock-ordering note on
-    /// [`shutdown`](Self::shutdown).
-    ///
-    /// Poisoning is recovered from rather than reported: the only thing under
-    /// this lock is an `Option`, and a panic cannot leave one half-taken.
+    /// One statement, so the guard cannot be held across the join the callers
+    /// do next. Poisoning is recovered from: nothing under this lock but an
+    /// `Option`, which a panic cannot leave half-taken.
     fn take_owned(&self) -> Option<OwnedThread> {
         self.owned
             .lock()
@@ -610,10 +543,8 @@ impl AimDbHandle {
 
         let taken = self.take_owned();
 
-        // Before the wait rather than after it: a thread that asks `is_closed`
-        // while this one is still joining must be told the database is going
-        // down, not that it is open. That is the window an FFI layer's signal
-        // handler and its sensor threads actually share.
+        // Before the wait, not after: a thread asking `is_closed` while this
+        // one joins must be told the database is going down.
         self.closed.store(true, Ordering::Release);
 
         let Some(OwnedThread {
@@ -623,8 +554,8 @@ impl AimDbHandle {
             alive,
         }) = taken
         else {
-            // Someone else already took it. Nothing to join, nothing to report:
-            // shutdown is idempotent by construction, not by bookkeeping.
+            // Someone else took it: idempotent by construction, not by
+            // bookkeeping.
             return Ok(());
         };
 
@@ -663,11 +594,8 @@ impl AimDbHandle {
             message: "Runtime thread panicked during shutdown".to_string(),
         })?;
 
-        // Last, and only now: the thread is down, so nothing is still draining
-        // the graph. This is what closes the buffers — and closing them is what
-        // wakes a consumer parked in `get()` and refuses the next publish,
-        // rather than accepting it into a graph nobody pumps. See
-        // `OwnedThread::db`.
+        // Only now the thread is down: closing the buffers wakes a parked
+        // consumer and refuses the next publish. See `OwnedThread::db`.
         drop(db);
 
         Ok(())
@@ -742,8 +670,8 @@ impl Drop for AimDbHandle {
     ///
     /// Call [`shutdown`](Self::shutdown) if you need to know that it did.
     fn drop(&mut self) {
-        // `get_mut` rather than `lock`: a destructor has exclusive access, so it
-        // need neither block nor care whether a panic poisoned the lock.
+        // `get_mut`, not `lock`: exclusive access, so neither blocking nor
+        // poisoning applies.
         let owned = self
             .owned
             .get_mut()

--- a/aimdb-sync/src/handle.rs
+++ b/aimdb-sync/src/handle.rs
@@ -108,8 +108,7 @@ impl AimDbSyncExt for AimDb {
 /// # Resource Management
 ///
 /// [`shutdown`](Self::shutdown) stops the thread; [`detach`](Self::detach) is
-/// the same call by value. Dropping without either warns and signals without
-/// waiting.
+/// the same call by value. Dropping does neither: it warns and signals.
 pub struct AimDbHandle {
     /// The runtime thread and everything reached through it, shared with every
     /// producer and consumer made from this handle. See [`crate::runtime`].
@@ -124,16 +123,11 @@ pub struct AimDbHandle {
     /// it, join it.
     ///
     /// `None` once shut down, or once a `fork` proved the thread is not this
-    /// process's to reap. One field, so releasing it cannot be half-done.
-    ///
-    /// Behind a `Mutex` so [`shutdown`](Self::shutdown) can take `&self`. The
-    /// publish path never waits for it — producers hold their own
-    /// [`Weak`](alloc::sync::Weak).
+    /// process's to reap. Behind a `Mutex` so `shutdown` can take `&self`;
+    /// nothing on the publish path waits for it.
     owned: std::sync::Mutex<Option<OwnedThread>>,
 
-    /// Whether [`shutdown`](Self::shutdown) has taken the thread out of
-    /// `owned`. An atomic, not a peek at the mutex beside it: an FFI layer asks
-    /// this holding its interpreter lock, and the shutdown wants that lock.
+    /// Shut down. An atomic, so `is_closed` need not take the lock above.
     closed: AtomicBool,
 }
 
@@ -142,9 +136,8 @@ struct OwnedThread {
     /// Joined by `shutdown`; released, never joined, by `Drop`.
     join: JoinHandle<()>,
 
-    /// The one strong reference to the database — [`Runtime`] holds a `Weak`.
-    /// Released after the join, which closes the buffers: that wakes a consumer
-    /// parked in `get()` and refuses the publish after.
+    /// The one strong reference — [`Runtime`] holds a `Weak`. Released after
+    /// the join, closing the buffers: that wakes a parked consumer.
     db: Arc<AimDb>,
 
     /// Commands the thread to stop. Distinct from dropping it: the thread also
@@ -409,74 +402,45 @@ impl AimDbHandle {
 
     /// Stop the runtime thread, through a shared reference.
     ///
-    /// Signals, waits, joins. `&self` because a C ABI's free function and a
-    /// `#[pymethods]` method never receive `self` by value. Idempotent, so
-    /// racing callers do not manufacture an error. Safe during a publish:
-    /// producers hold their own [`Weak`](alloc::sync::Weak) and never take this
-    /// lock. Blocks, so not from inside a Tokio runtime.
+    /// `&self` because an FFI door never receives `self` by value. Idempotent,
+    /// safe during a publish, and blocking — so not from inside a Tokio
+    /// runtime. The lock is released before the join, so a caller holding what
+    /// the runtime thread needs cannot deadlock against its own shutdown.
     ///
     /// # Errors
     ///
-    /// - [`SyncError::ForkedChild`] — this is a `fork`ed child, so the thread
-    ///   is not here to stop; the handle releases it rather than joining it.
-    /// - [`SyncError::DetachFailed`] — the runtime thread panicked.
-    ///
-    /// # Lock ordering
-    ///
-    /// The lock is released before the join, so a caller holding something the
-    /// runtime thread needs (an FFI layer's interpreter lock, when that thread
-    /// logs into it) cannot deadlock against its own shutdown.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use aimdb_sync::*;
-    /// # use std::sync::Arc;
-    /// # fn example(handle: Arc<AimDbHandle>) -> SyncResult<()> {
-    /// Arc::clone(&handle).shutdown()?; // from a signal handler, say
-    /// assert!(handle.is_closed());
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// [`SyncError::ForkedChild`] in a `fork`ed child, whose thread is not here
+    /// to stop; [`SyncError::DetachFailed`] if that thread panicked.
     pub fn shutdown(&self) -> SyncResult<()> {
         self.shutdown_internal(None)
     }
 
     /// [`shutdown`](Self::shutdown) with a bound on the wait.
     ///
+    /// A timeout means the thread had not finished, not that shutdown failed:
+    /// the signal was delivered, nothing is stranded, the thread is already
+    /// released — so a later `shutdown` returns at once rather than waiting
+    /// longer — and resources go eventually rather than by the time this
+    /// returns. Use [`shutdown`](Self::shutdown) to know the thread is down.
+    ///
     /// # Errors
     ///
-    /// [`SyncError::DetachFailed`] if the thread had not finished in time, plus
-    /// what [`shutdown`](Self::shutdown) documents.
-    ///
-    /// # What a timeout leaves behind
-    ///
-    /// The signal *was* delivered, so the thread stops on its own and drops the
-    /// database with it; nothing is stranded. The handle has already released
-    /// it, so a later [`shutdown`](Self::shutdown) returns at once rather than
-    /// waiting longer, and [`is_closed`](Self::is_closed) was `true` from the
-    /// moment this began. Surviving producers and consumers work until the
-    /// thread stops, then fail with [`SyncError::RuntimeShutdown`]. Resources
-    /// are released eventually, not by the time this returns — use
-    /// [`shutdown`](Self::shutdown) when you need to know the thread is down.
+    /// [`SyncError::DetachFailed`] on an expired timeout, plus what
+    /// [`shutdown`](Self::shutdown) documents.
     pub fn shutdown_timeout(&self, timeout: Duration) -> SyncResult<()> {
         self.shutdown_internal(Some(timeout))
     }
 
     /// Whether this handle can still reach the runtime thread.
     ///
-    /// `true` from the moment a [`shutdown`](Self::shutdown) begins, and in a
-    /// `fork`ed child. One atomic load and the fork check a publish makes —
-    /// never the lock a shutdown holds, so an FFI layer may ask this from
-    /// aimdb's own runtime thread while another thread is joining.
-    ///
-    /// `false` describes this handle now, not the next call: producers and
-    /// consumers report for themselves, on the call that would have used it.
+    /// `true` from the moment a shutdown begins, and in a `fork`ed child. An
+    /// atomic load and the fork check a publish makes, never the shutdown's
+    /// lock — so an FFI layer may ask from aimdb's runtime thread mid-shutdown.
     pub fn is_closed(&self) -> bool {
         self.closed.load(Ordering::Acquire) || self.rt.check().is_err()
     }
 
-    /// [`shutdown`](Self::shutdown) for an owner that has the handle by value.
+    /// [`shutdown`](Self::shutdown), by value.
     ///
     /// # Errors
     ///
@@ -495,13 +459,11 @@ impl AimDbHandle {
         self.shutdown()
     }
 
-    /// [`shutdown_timeout`](Self::shutdown_timeout) for an owner that has the
-    /// handle by value.
+    /// [`shutdown_timeout`](Self::shutdown_timeout), by value.
     ///
     /// # Errors
     ///
-    /// What [`shutdown_timeout`](Self::shutdown_timeout) documents, including
-    /// what an expired timeout leaves behind.
+    /// What [`shutdown_timeout`](Self::shutdown_timeout) documents.
     ///
     /// # Example
     ///
@@ -517,11 +479,8 @@ impl AimDbHandle {
         self.shutdown_timeout(timeout)
     }
 
-    /// Take the runtime thread out of the handle.
-    ///
-    /// One statement, so the guard cannot be held across the join the callers
-    /// do next. Poisoning is recovered from: nothing under this lock but an
-    /// `Option`, which a panic cannot leave half-taken.
+    /// Take the thread out. One statement, so the guard cannot be held across
+    /// the callers' join.
     fn take_owned(&self) -> Option<OwnedThread> {
         self.owned
             .lock()
@@ -542,9 +501,8 @@ impl AimDbHandle {
         }
 
         let taken = self.take_owned();
-
-        // Before the wait, not after: a thread asking `is_closed` while this
-        // one joins must be told the database is going down.
+        // Before the wait: a thread asking `is_closed` while this one joins
+        // must be told the database is going down.
         self.closed.store(true, Ordering::Release);
 
         let Some(OwnedThread {
@@ -554,8 +512,7 @@ impl AimDbHandle {
             alive,
         }) = taken
         else {
-            // Someone else took it: idempotent by construction, not by
-            // bookkeeping.
+            // Someone else took it: idempotent by construction.
             return Ok(());
         };
 
@@ -594,8 +551,7 @@ impl AimDbHandle {
             message: "Runtime thread panicked during shutdown".to_string(),
         })?;
 
-        // Only now the thread is down: closing the buffers wakes a parked
-        // consumer and refuses the next publish. See `OwnedThread::db`.
+        // Only now the thread is down. See `OwnedThread::db`.
         drop(db);
 
         Ok(())
@@ -670,8 +626,7 @@ impl Drop for AimDbHandle {
     ///
     /// Call [`shutdown`](Self::shutdown) if you need to know that it did.
     fn drop(&mut self) {
-        // `get_mut`, not `lock`: exclusive access, so neither blocking nor
-        // poisoning applies.
+        // `get_mut`, not `lock`: exclusive access here.
         let owned = self
             .owned
             .get_mut()

--- a/aimdb-sync/src/handle.rs
+++ b/aimdb-sync/src/handle.rs
@@ -5,6 +5,7 @@ use crate::{SyncError, SyncResult};
 use aimdb_core::{log_error, log_warn, AimDb, AimDbBuilder, DbError};
 use alloc::sync::Arc;
 use core::fmt::Debug;
+use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
 use std::thread::{self, JoinHandle};
 use tokio::sync::mpsc;
@@ -106,9 +107,21 @@ impl AimDbSyncExt for AimDb {
 ///
 /// # Resource Management
 ///
-/// Call `detach()` explicitly to ensure clean shutdown. If the handle
-/// is dropped without calling `detach()`, a warning will be logged
-/// and an emergency shutdown will be attempted.
+/// Call [`shutdown`](Self::shutdown) — or [`detach`](Self::detach), the same
+/// thing for a caller that owns the handle by value — to stop the runtime
+/// thread deliberately. A handle dropped without either logs a warning and
+/// signals shutdown without waiting for it.
+///
+/// # Shutting down through a shared reference
+///
+/// [`shutdown`](Self::shutdown) takes `&self`, is idempotent, and is safe to
+/// call while producers publish; [`is_closed`](Self::is_closed) never takes the
+/// lock it holds. Those four properties are what a binding in another language
+/// needs, and none of them is expressible in a signature: a C ABI's free
+/// function and a `#[pymethods]` method never receive `self` by value, and a
+/// `&mut self` shutdown collides at run time with a publish already in flight
+/// — measured, in the two FFI doors this crate was hardened for. Pinned by
+/// `tests/shutdown_contract_test.rs`.
 pub struct AimDbHandle {
     /// The runtime thread and everything reached through it, shared with every
     /// producer and consumer made from this handle. See [`crate::runtime`].
@@ -122,17 +135,45 @@ pub struct AimDbHandle {
     /// What only the handle that started the thread may do: signal it, wait for
     /// it, join it.
     ///
-    /// `None` once detached, or once a `fork` proved the thread is not this
+    /// `None` once shut down, or once a `fork` proved the thread is not this
     /// process's to reap. One field, so releasing it cannot be half-done — the
     /// previous shape was four loose fields and a release path that forgot one
     /// of them the moment a fifth was added.
-    owned: Option<OwnedThread>,
+    ///
+    /// Behind a `Mutex` so [`shutdown`](Self::shutdown) can take `&self`.
+    /// Nothing on the publish path ever waits for it: a
+    /// [`SyncProducer`](crate::SyncProducer) reaches the database through its
+    /// own [`Weak`](alloc::sync::Weak), so a shutdown cannot queue behind an
+    /// in-flight publish and a publish cannot queue behind a shutdown.
+    owned: std::sync::Mutex<Option<OwnedThread>>,
+
+    /// Whether [`shutdown`](Self::shutdown) has taken the thread out of
+    /// `owned`.
+    ///
+    /// An atomic rather than a peek at the mutex beside it, because
+    /// [`is_closed`](Self::is_closed) is what an FFI layer calls while holding
+    /// its own interpreter lock. Waiting there on the lock a shutdown holds —
+    /// while that shutdown waits for the very interpreter lock its logging
+    /// bridge needs — is the deadlock this field exists to keep impossible.
+    closed: AtomicBool,
 }
 
 /// The parts of a runtime thread that only its owner may touch.
 struct OwnedThread {
-    /// Joined by `detach`; released, never joined, by `Drop`.
+    /// Joined by `shutdown`; released, never joined, by `Drop`.
     join: JoinHandle<()>,
+
+    /// The one strong reference to the database.
+    ///
+    /// Here rather than in [`Runtime`], which holds a `Weak`, so that a
+    /// shutdown through `&self` releases it: dropping the last `Arc<AimDb>`
+    /// closes the buffers, and that is what wakes a consumer parked in `get()`.
+    /// It also refuses the publish after, since a producer reaches the database
+    /// only through `Runtime::db`.
+    ///
+    /// Released *after* the join, so the graph is not pulled out from under a
+    /// runtime thread that is still draining it.
+    db: Arc<AimDb>,
 
     /// Commands the thread to stop. Distinct from dropping it: the thread also
     /// ends when every sender is gone, but *sending* ends it now.
@@ -300,12 +341,14 @@ impl AimDbHandle {
         alive: std::sync::mpsc::Receiver<()>,
     ) -> Self {
         Self {
-            rt: Arc::new(Runtime::new(runtime_handle, db)),
-            owned: Some(OwnedThread {
+            rt: Arc::new(Runtime::new(runtime_handle, &db)),
+            owned: std::sync::Mutex::new(Some(OwnedThread {
                 join,
                 shutdown,
+                db,
                 alive: std::sync::Mutex::new(alive),
-            }),
+            })),
+            closed: AtomicBool::new(false),
         }
     }
 
@@ -392,15 +435,115 @@ impl AimDbHandle {
         Ok(crate::SyncConsumer::new(self.rt.view()?, reader))
     }
 
-    /// Gracefully shut down the runtime thread.
+    /// Stop the runtime thread, through a shared reference.
     ///
-    /// Signals the runtime to stop, waits for all pending operations
-    /// to complete, then joins the thread. This is the preferred way
-    /// to shut down.
+    /// Signals the thread, waits for it, and joins it. Prefer this — or
+    /// [`detach`](Self::detach), which is this call for an owner that has the
+    /// handle by value — over dropping the handle, which signals without
+    /// waiting.
+    ///
+    /// **Idempotent.** The call that finds the thread already taken returns
+    /// `Ok(())`, so two threads racing to shut down do not manufacture an
+    /// error between them, and a shutdown after a `Drop`-less close is a no-op
+    /// rather than a fault.
+    ///
+    /// **Safe during a publish.** A [`SyncProducer`](crate::SyncProducer)
+    /// reaches the database through its own [`Weak`](alloc::sync::Weak) and
+    /// never takes the lock this does, so a shutdown cannot queue behind an
+    /// in-flight publish. A publish that arrives after the thread stops fails
+    /// with [`SyncError::RuntimeShutdown`].
+    ///
+    /// Blocks the calling thread, so it must not be called from inside a Tokio
+    /// runtime. It *may* be called from aimdb's own runtime thread only in the
+    /// sense every other method may — see [`is_closed`](Self::is_closed) for
+    /// the one that is meant to be.
     ///
     /// # Errors
     ///
-    /// - `SyncError::DetachFailed` if shutdown fails or times out
+    /// - [`SyncError::ForkedChild`] if this process `fork`ed since the handle
+    ///   was created: the thread did not come across, so there is nothing here
+    ///   to stop. The handle releases it rather than joining a thread that
+    ///   does not exist, which would panic inside `std`.
+    /// - [`SyncError::DetachFailed`] if the runtime thread panicked.
+    ///
+    /// # Lock ordering
+    ///
+    /// The lock guarding the thread is released *before* the join, so a caller
+    /// that blocks on it while holding something the runtime thread needs — an
+    /// FFI layer's interpreter lock, when that thread logs through a bridge
+    /// into it — cannot deadlock against its own shutdown.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use aimdb_sync::*;
+    /// # use std::sync::Arc;
+    /// # fn example(handle: Arc<AimDbHandle>) -> SyncResult<()> {
+    /// let signal_handler = Arc::clone(&handle);
+    /// // … from another thread, while this one publishes:
+    /// signal_handler.shutdown()?;
+    /// assert!(handle.is_closed());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn shutdown(&self) -> SyncResult<()> {
+        self.shutdown_internal(None)
+    }
+
+    /// [`shutdown`](Self::shutdown) with a bound on the wait.
+    ///
+    /// # Errors
+    ///
+    /// - [`SyncError::DetachFailed`] if the thread had not finished in time
+    /// - the errors [`shutdown`](Self::shutdown) documents
+    ///
+    /// # What a timeout leaves behind
+    ///
+    /// `DetachFailed` from an expired timeout means the runtime thread had not
+    /// finished in time — not that shutdown failed. Concretely:
+    ///
+    /// - The shutdown signal **was** delivered, so the thread stops on its own
+    ///   and drops the database when it does. Nothing is stranded: no thread is
+    ///   left parked waiting to reap it.
+    /// - The handle has already released the thread, so a later
+    ///   [`shutdown`](Self::shutdown) returns `Ok(())` immediately rather than
+    ///   waiting longer. [`is_closed`](Self::is_closed) reports `true` from the
+    ///   moment the shutdown began.
+    /// - Any [`SyncProducer`](crate::SyncProducer) or
+    ///   [`SyncConsumer`](crate::SyncConsumer) you still hold keeps working
+    ///   until the thread stops, then fails with
+    ///   [`SyncError::RuntimeShutdown`].
+    /// - Resources are therefore released *eventually*, not by the time this
+    ///   returns. Use [`shutdown`](Self::shutdown), which has no timeout, when
+    ///   you need to know the thread is down.
+    pub fn shutdown_timeout(&self, timeout: Duration) -> SyncResult<()> {
+        self.shutdown_internal(Some(timeout))
+    }
+
+    /// Whether this handle can still reach the runtime thread.
+    ///
+    /// `true` from the moment a [`shutdown`](Self::shutdown) begins — not when
+    /// it finishes — and `true` in a child of `fork()`, whose inherited handle
+    /// names a thread that did not come across.
+    ///
+    /// Never takes the lock [`shutdown`](Self::shutdown) holds: one atomic load
+    /// and the same relaxed fork check a publish makes. So a caller holding an
+    /// interpreter lock may ask this while another thread's shutdown is joining,
+    /// which is exactly what an FFI layer's logging bridge does from aimdb's own
+    /// runtime thread. Pinned by `tests/shutdown_contract_test.rs`.
+    ///
+    /// A `false` is a statement about this handle, not a promise about the next
+    /// call: the thread may stop between the two. Producers and consumers report
+    /// that for themselves, on the call that would have used it.
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire) || self.rt.check().is_err()
+    }
+
+    /// [`shutdown`](Self::shutdown) for a caller that owns the handle by value.
+    ///
+    /// # Errors
+    ///
+    /// The errors [`shutdown`](Self::shutdown) documents.
     ///
     /// # Example
     ///
@@ -411,40 +554,17 @@ impl AimDbHandle {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn detach(mut self) -> SyncResult<()> {
-        self.detach_internal(None)
+    pub fn detach(self) -> SyncResult<()> {
+        self.shutdown()
     }
 
-    /// Gracefully shut down with a timeout.
-    ///
-    /// Like `detach()`, but fails if shutdown takes longer than
-    /// the specified duration.
-    ///
-    /// # Arguments
-    ///
-    /// - `timeout`: Maximum time to wait for shutdown
+    /// [`shutdown_timeout`](Self::shutdown_timeout) for a caller that owns the
+    /// handle by value.
     ///
     /// # Errors
     ///
-    /// - `SyncError::DetachFailed` if shutdown fails or times out
-    ///
-    /// # What a timeout leaves behind
-    ///
-    /// `DetachFailed` from an expired timeout means the runtime thread had not
-    /// finished in time — not that shutdown failed. Concretely:
-    ///
-    /// - The shutdown signal **was** delivered, so the thread stops on its own
-    ///   and drops the database when it does. Nothing is stranded: no thread is
-    ///   left parked waiting to reap it.
-    /// - The handle is consumed either way, so there is nothing left to retry
-    ///   with and no way to wait longer on this handle.
-    /// - Any [`SyncProducer`](crate::SyncProducer) or
-    ///   [`SyncConsumer`](crate::SyncConsumer) you still hold keeps working
-    ///   until the thread stops, then fails with
-    ///   [`SyncError::RuntimeShutdown`].
-    /// - Resources are therefore released *eventually*, not by the time this
-    ///   returns. Use [`detach`](Self::detach), which has no timeout, when you
-    ///   need to know the thread is down.
+    /// The errors [`shutdown_timeout`](Self::shutdown_timeout) documents,
+    /// including what an expired timeout leaves behind.
     ///
     /// # Example
     ///
@@ -456,35 +576,55 @@ impl AimDbHandle {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn detach_timeout(mut self, timeout: Duration) -> SyncResult<()> {
-        self.detach_internal(Some(timeout))
+    pub fn detach_timeout(self, timeout: Duration) -> SyncResult<()> {
+        self.shutdown_timeout(timeout)
     }
 
-    /// Internal detach implementation.
+    /// Take the runtime thread out of the handle.
     ///
-    /// Deliberate shutdown: *sends* the signal rather than merely dropping a
-    /// sender, so the thread stops at once rather than when the last sender
-    /// goes. Producers and consumers hold only a [`Weak`](alloc::sync::Weak)
-    /// and cannot keep it alive, but one mid-call when it stops fails with
-    /// [`SyncError::RuntimeShutdown`] — `detach` means "stop now", not "stop
-    /// when everyone has finished".
-    fn detach_internal(&mut self, timeout: Option<Duration>) -> SyncResult<()> {
+    /// Written as one statement on purpose: the guard is a temporary, so it is
+    /// dropped when the statement ends and cannot be held across the join the
+    /// callers do next. See the lock-ordering note on
+    /// [`shutdown`](Self::shutdown).
+    ///
+    /// Poisoning is recovered from rather than reported: the only thing under
+    /// this lock is an `Option`, and a panic cannot leave one half-taken.
+    fn take_owned(&self) -> Option<OwnedThread> {
+        self.owned
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
+    fn shutdown_internal(&self, timeout: Option<Duration>) -> SyncResult<()> {
         // A forked child holds a `JoinHandle` for a thread that does not exist
         // here, and joining it is not merely useless: it panics inside `std`
         // with "threads should not terminate unexpectedly", which for an FFI
         // caller means a Rust backtrace on stderr from a destructor. Release
         // it instead — the thread is the parent's to reap.
         if self.rt.check().is_err() {
-            self.owned = None;
+            drop(self.take_owned());
+            self.closed.store(true, Ordering::Release);
             return Err(SyncError::ForkedChild);
         }
+
+        let taken = self.take_owned();
+
+        // Before the wait rather than after it: a thread that asks `is_closed`
+        // while this one is still joining must be told the database is going
+        // down, not that it is open. That is the window an FFI layer's signal
+        // handler and its sensor threads actually share.
+        self.closed.store(true, Ordering::Release);
 
         let Some(OwnedThread {
             join,
             shutdown,
+            db,
             alive,
-        }) = self.owned.take()
+        }) = taken
         else {
+            // Someone else already took it. Nothing to join, nothing to report:
+            // shutdown is idempotent by construction, not by bookkeeping.
             return Ok(());
         };
 
@@ -522,6 +662,13 @@ impl AimDbHandle {
         join.join().map_err(|_| SyncError::DetachFailed {
             message: "Runtime thread panicked during shutdown".to_string(),
         })?;
+
+        // Last, and only now: the thread is down, so nothing is still draining
+        // the graph. This is what closes the buffers — and closing them is what
+        // wakes a consumer parked in `get()` and refuses the next publish,
+        // rather than accepting it into a graph nobody pumps. See
+        // `OwnedThread::db`.
+        drop(db);
 
         Ok(())
     }
@@ -593,17 +740,25 @@ impl Drop for AimDbHandle {
     /// signal is what actually causes cleanup, and it is delivered either way;
     /// joining would only change when the caller learns it finished.
     ///
-    /// Call [`detach`](Self::detach) if you need to know that it did.
+    /// Call [`shutdown`](Self::shutdown) if you need to know that it did.
     fn drop(&mut self) {
+        // `get_mut` rather than `lock`: a destructor has exclusive access, so it
+        // need neither block nor care whether a panic poisoned the lock.
+        let owned = self
+            .owned
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        self.closed.store(true, Ordering::Release);
+
         // A forked child's handle owns nothing that runs here: signalling would
         // reach a thread this process never had. Release and say nothing.
         if self.rt.check().is_err() {
-            self.owned = None;
             return;
         }
 
-        if let Some(owned) = self.owned.take() {
-            log_warn!("AimDbHandle dropped without calling detach()");
+        if let Some(owned) = owned {
+            log_warn!("AimDbHandle dropped without calling shutdown()");
             log_warn!("Shutdown was signalled; the runtime thread stops on its own");
             // Non-blocking. Released rather than joined — see the note above.
             let _ = owned.shutdown.try_send(ShutdownSignal);

--- a/aimdb-sync/src/lib.rs
+++ b/aimdb-sync/src/lib.rs
@@ -187,25 +187,16 @@
 //!
 //! ## Shutting down from another language
 //!
-//! Four properties make a binding possible, and none of them is visible in a
-//! signature — so each is pinned by `tests/shutdown_contract_test.rs` rather
-//! than remembered:
+//! Four properties make a binding possible, none of them visible in a
+//! signature, all pinned by `tests/shutdown_contract_test.rs`:
+//! [`AimDbHandle::shutdown`] takes `&self` (a C ABI's free function and a
+//! `#[pymethods]` method never receive `self` by value); it is idempotent; it
+//! is safe to call while producers publish; and [`AimDbHandle::is_closed`]
+//! reads an atomic rather than the lock it holds, so a caller may ask it from
+//! aimdb's runtime thread mid-shutdown.
 //!
-//! 1. [`AimDbHandle::shutdown`] takes `&self`. A C ABI's free function and a
-//!    `#[pymethods]` method never receive `self` by value, and a `&mut self`
-//!    shutdown collides at run time with a publish already in flight.
-//! 2. It is idempotent, so a `with` block ending inside a signal handler is not
-//!    an error.
-//! 3. It is safe to call while producers publish: they reach the database
-//!    through their own [`Weak`](alloc::sync::Weak) and never take the lock it
-//!    holds.
-//! 4. [`AimDbHandle::is_closed`] reads an atomic and never that lock, so a
-//!    caller holding an interpreter lock may ask it while a shutdown is joining
-//!    — including from aimdb's own runtime thread, where a logging bridge runs.
-//!
-//! A shutdown also releases the database, which closes the buffers and so wakes
-//! a consumer parked in `get()`. Shut down first, then join your reader
-//! threads.
+//! A shutdown also releases the database, closing the buffers and waking a
+//! consumer parked in `get()`. Shut down first, then join your readers.
 //!
 //! **A panic from this crate is a bug, not an error channel.** Every failure is
 //! a [`SyncError`]. The blocking surface is compiled under

--- a/aimdb-sync/src/lib.rs
+++ b/aimdb-sync/src/lib.rs
@@ -39,7 +39,9 @@
 //! ```
 //!
 //! The runtime thread is created automatically when you call `attach()` on the builder.
-//! It stays alive until `detach()` is called or the handle is dropped.
+//! It stays alive until [`AimDbHandle::shutdown`] — or [`AimDbHandle::detach`],
+//! which is the same call for an owner that has the handle by value — or until
+//! the handle is dropped.
 //!
 //! ## Quick Start
 //!
@@ -180,7 +182,30 @@
 //! cursor, so move it to a thread and give each thread its own via a separate
 //! `handle.consumer()` call. Every consumer then sees every value. To *split* one
 //! stream across workers instead, share one as `Arc<Mutex<SyncConsumer<T>>>`.
-//! The API ensures proper resource cleanup through RAII and explicit `detach()`.
+//! The API ensures proper resource cleanup through RAII and an explicit
+//! [`AimDbHandle::shutdown`].
+//!
+//! ## Shutting down from another language
+//!
+//! Four properties make a binding possible, and none of them is visible in a
+//! signature — so each is pinned by `tests/shutdown_contract_test.rs` rather
+//! than remembered:
+//!
+//! 1. [`AimDbHandle::shutdown`] takes `&self`. A C ABI's free function and a
+//!    `#[pymethods]` method never receive `self` by value, and a `&mut self`
+//!    shutdown collides at run time with a publish already in flight.
+//! 2. It is idempotent, so a `with` block ending inside a signal handler is not
+//!    an error.
+//! 3. It is safe to call while producers publish: they reach the database
+//!    through their own [`Weak`](alloc::sync::Weak) and never take the lock it
+//!    holds.
+//! 4. [`AimDbHandle::is_closed`] reads an atomic and never that lock, so a
+//!    caller holding an interpreter lock may ask it while a shutdown is joining
+//!    — including from aimdb's own runtime thread, where a logging bridge runs.
+//!
+//! A shutdown also releases the database, which closes the buffers and so wakes
+//! a consumer parked in `get()`. Shut down first, then join your reader
+//! threads.
 //!
 //! **A panic from this crate is a bug, not an error channel.** Every failure is
 //! a [`SyncError`]. The blocking surface is compiled under

--- a/aimdb-sync/src/lib.rs
+++ b/aimdb-sync/src/lib.rs
@@ -187,16 +187,11 @@
 //!
 //! ## Shutting down from another language
 //!
-//! Four properties make a binding possible, none of them visible in a
-//! signature, all pinned by `tests/shutdown_contract_test.rs`:
-//! [`AimDbHandle::shutdown`] takes `&self` (a C ABI's free function and a
-//! `#[pymethods]` method never receive `self` by value); it is idempotent; it
-//! is safe to call while producers publish; and [`AimDbHandle::is_closed`]
-//! reads an atomic rather than the lock it holds, so a caller may ask it from
-//! aimdb's runtime thread mid-shutdown.
-//!
-//! A shutdown also releases the database, closing the buffers and waking a
-//! consumer parked in `get()`. Shut down first, then join your readers.
+//! [`AimDbHandle::shutdown`] takes `&self` (an FFI door never receives `self`
+//! by value), is idempotent, is safe during a publish, and
+//! [`AimDbHandle::is_closed`] reads an atomic rather than the lock it holds.
+//! Pinned by `tests/shutdown_contract_test.rs`. A shutdown releases the
+//! database too, so shut down before joining your readers.
 //!
 //! **A panic from this crate is a bug, not an error channel.** Every failure is
 //! a [`SyncError`]. The blocking surface is compiled under

--- a/aimdb-sync/src/runtime.rs
+++ b/aimdb-sync/src/runtime.rs
@@ -50,22 +50,13 @@ pub(crate) struct Runtime {
     /// The way into the Tokio runtime. Reached only through [`Self::enter`].
     handle: tokio::runtime::Handle,
 
-    /// The database the thread built, held weakly. Reached only through
-    /// [`Self::db`].
+    /// The database the thread built. Reached only through [`Self::db`].
     ///
-    /// The strong reference lives in the handle's `OwnedThread`, so
-    /// [`AimDbHandle::shutdown`](crate::AimDbHandle::shutdown) can release it
-    /// through a shared reference. That release is not bookkeeping: dropping
-    /// the last `Arc<AimDb>` closes the buffers, and closing them is what wakes
-    /// a consumer parked in `get()` — `aimdb-core` has no explicit close. A
-    /// strong reference here would keep the database, and every parked reader,
-    /// alive until the last producer was dropped.
-    ///
-    /// So a failed upgrade is the same liveness check it always was, moved one
-    /// level down. It used to fire when the handle was dropped, because that is
-    /// what released the database; it now also fires for a shutdown through a
-    /// handle the caller still holds, where the `Weak<Runtime>` a producer
-    /// carries upgrades perfectly well.
+    /// Weak, because the strong reference lives in the handle's `OwnedThread`
+    /// where a `shutdown(&self)` can release it — and releasing it closes the
+    /// buffers, which is what wakes a parked consumer. A failed upgrade is
+    /// therefore the same liveness check it always was, now firing for a
+    /// shutdown as well as for a dropped handle.
     db: Weak<AimDb>,
 
     /// The fork generation this runtime's thread was spawned in.
@@ -76,8 +67,8 @@ pub(crate) struct Runtime {
 }
 
 impl Runtime {
-    /// Borrowed rather than taken: the caller keeps the strong reference, and
-    /// keeping it is what gives it something to release. See [`Self::db`].
+    /// Borrowed, not taken: the caller keeps the strong reference so it has
+    /// something to release. See [`Self::db`].
     pub(crate) fn new(handle: tokio::runtime::Handle, db: &Arc<AimDb>) -> Self {
         Self {
             handle,
@@ -107,18 +98,12 @@ impl Runtime {
         Ok(&self.handle)
     }
 
-    /// The database, or a reason there is none to reach.
+    /// The database, or why there is none to reach — the only way in, so
+    /// neither reason can be skipped. [`SyncError::ForkedChild`]: a child's
+    /// handle to the database is valid, which is the problem.
+    /// [`SyncError::RuntimeShutdown`]: the strong reference is gone.
     ///
-    /// The only way to reach it, so neither reason can be skipped:
-    /// [`SyncError::ForkedChild`] because a forked child's handle to the
-    /// database is valid, which is exactly the problem, and
-    /// [`SyncError::RuntimeShutdown`] because the handle that owns the strong
-    /// reference has shut down or been dropped.
-    ///
-    /// Returns an owned `Arc` — one atomic increment on the publish path,
-    /// against a `Weak` that cannot otherwise be handed out safely. The
-    /// alternative was a lock, which is the thing this crate keeps off that
-    /// path.
+    /// Owned, so one atomic increment per publish. A lock was the alternative.
     #[inline]
     pub(crate) fn db(&self) -> SyncResult<Arc<AimDb>> {
         self.check()?;
@@ -240,15 +225,13 @@ mod tests {
             })
             .expect("build database");
 
-        // Kept alive by the returned guard: the `Runtime` holds the database
-        // weakly, so nothing here may be the last strong reference.
+        // Kept alive by the returned guard: `Runtime` holds it weakly.
         let db = Arc::new(db);
         let mut runtime = Runtime::new(tokio_rt.handle().clone(), &db);
         runtime.made_in = crate::fork::generation().wrapping_sub(generations_behind);
 
-        // Returned so the caller keeps them alive: the handle we cloned out of
-        // the tokio runtime must not outlive it, and the database must outlive
-        // the `Runtime` that points at it weakly.
+        // Returned so the caller keeps both alive: the cloned handle must not
+        // outlive its runtime, nor the database the `Runtime` pointing at it.
         ((tokio_rt, db), runtime)
     }
 

--- a/aimdb-sync/src/runtime.rs
+++ b/aimdb-sync/src/runtime.rs
@@ -35,7 +35,7 @@
 //! keeping an OS thread alive with nobody owning it — the stranded thread #232
 //! had just removed.
 
-use alloc::sync::Arc;
+use alloc::sync::{Arc, Weak};
 
 use aimdb_core::AimDb;
 
@@ -50,8 +50,23 @@ pub(crate) struct Runtime {
     /// The way into the Tokio runtime. Reached only through [`Self::enter`].
     handle: tokio::runtime::Handle,
 
-    /// The database the thread built. Reached only through [`Self::db`].
-    db: Arc<AimDb>,
+    /// The database the thread built, held weakly. Reached only through
+    /// [`Self::db`].
+    ///
+    /// The strong reference lives in the handle's `OwnedThread`, so
+    /// [`AimDbHandle::shutdown`](crate::AimDbHandle::shutdown) can release it
+    /// through a shared reference. That release is not bookkeeping: dropping
+    /// the last `Arc<AimDb>` closes the buffers, and closing them is what wakes
+    /// a consumer parked in `get()` — `aimdb-core` has no explicit close. A
+    /// strong reference here would keep the database, and every parked reader,
+    /// alive until the last producer was dropped.
+    ///
+    /// So a failed upgrade is the same liveness check it always was, moved one
+    /// level down. It used to fire when the handle was dropped, because that is
+    /// what released the database; it now also fires for a shutdown through a
+    /// handle the caller still holds, where the `Weak<Runtime>` a producer
+    /// carries upgrades perfectly well.
+    db: Weak<AimDb>,
 
     /// The fork generation this runtime's thread was spawned in.
     ///
@@ -61,10 +76,12 @@ pub(crate) struct Runtime {
 }
 
 impl Runtime {
-    pub(crate) fn new(handle: tokio::runtime::Handle, db: Arc<AimDb>) -> Self {
+    /// Borrowed rather than taken: the caller keeps the strong reference, and
+    /// keeping it is what gives it something to release. See [`Self::db`].
+    pub(crate) fn new(handle: tokio::runtime::Handle, db: &Arc<AimDb>) -> Self {
         Self {
             handle,
-            db,
+            db: Arc::downgrade(db),
             made_in: crate::fork::generation(),
         }
     }
@@ -90,13 +107,22 @@ impl Runtime {
         Ok(&self.handle)
     }
 
-    /// The database, or [`SyncError::ForkedChild`]. The only way to reach it —
-    /// a forked child's handle to the database is valid, which is exactly the
-    /// problem.
+    /// The database, or a reason there is none to reach.
+    ///
+    /// The only way to reach it, so neither reason can be skipped:
+    /// [`SyncError::ForkedChild`] because a forked child's handle to the
+    /// database is valid, which is exactly the problem, and
+    /// [`SyncError::RuntimeShutdown`] because the handle that owns the strong
+    /// reference has shut down or been dropped.
+    ///
+    /// Returns an owned `Arc` — one atomic increment on the publish path,
+    /// against a `Weak` that cannot otherwise be handed out safely. The
+    /// alternative was a lock, which is the thing this crate keeps off that
+    /// path.
     #[inline]
-    pub(crate) fn db(&self) -> SyncResult<&Arc<AimDb>> {
+    pub(crate) fn db(&self) -> SyncResult<Arc<AimDb>> {
         self.check()?;
-        Ok(&self.db)
+        self.db.upgrade().ok_or(SyncError::RuntimeShutdown)
     }
 
     /// A view of this runtime that may outlive it. The only way to build one.
@@ -196,7 +222,10 @@ mod tests {
     /// No thread, no `fork`: the point of moving the stamp onto a value. Proving
     /// a refusal used to mean forking from a parent holding a live Tokio
     /// runtime, the least safe moment there is, and failed 11 runs in 60.
-    fn runtime_stamped(generations_behind: u64) -> (tokio::runtime::Runtime, Runtime) {
+    #[allow(clippy::type_complexity)]
+    fn runtime_stamped(
+        generations_behind: u64,
+    ) -> ((tokio::runtime::Runtime, Arc<AimDb>), Runtime) {
         let tokio_rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -211,12 +240,16 @@ mod tests {
             })
             .expect("build database");
 
-        let mut runtime = Runtime::new(tokio_rt.handle().clone(), Arc::new(db));
+        // Kept alive by the returned guard: the `Runtime` holds the database
+        // weakly, so nothing here may be the last strong reference.
+        let db = Arc::new(db);
+        let mut runtime = Runtime::new(tokio_rt.handle().clone(), &db);
         runtime.made_in = crate::fork::generation().wrapping_sub(generations_behind);
 
-        // Returned so the caller keeps it alive: the handle we cloned out of it
-        // must not outlive the runtime it came from.
-        (tokio_rt, runtime)
+        // Returned so the caller keeps them alive: the handle we cloned out of
+        // the tokio runtime must not outlive it, and the database must outlive
+        // the `Runtime` that points at it weakly.
+        ((tokio_rt, db), runtime)
     }
 
     #[test]

--- a/aimdb-sync/src/runtime.rs
+++ b/aimdb-sync/src/runtime.rs
@@ -52,11 +52,9 @@ pub(crate) struct Runtime {
 
     /// The database the thread built. Reached only through [`Self::db`].
     ///
-    /// Weak, because the strong reference lives in the handle's `OwnedThread`
-    /// where a `shutdown(&self)` can release it — and releasing it closes the
-    /// buffers, which is what wakes a parked consumer. A failed upgrade is
-    /// therefore the same liveness check it always was, now firing for a
-    /// shutdown as well as for a dropped handle.
+    /// Weak: the strong reference lives in the handle's `OwnedThread`, where a
+    /// `shutdown(&self)` can release it. A failed upgrade is the same liveness
+    /// check it always was, now firing for a shutdown too.
     db: Weak<AimDb>,
 
     /// The fork generation this runtime's thread was spawned in.
@@ -67,8 +65,8 @@ pub(crate) struct Runtime {
 }
 
 impl Runtime {
-    /// Borrowed, not taken: the caller keeps the strong reference so it has
-    /// something to release. See [`Self::db`].
+    /// Borrowed, not taken: the caller keeps the strong reference. See
+    /// [`Self::db`].
     pub(crate) fn new(handle: tokio::runtime::Handle, db: &Arc<AimDb>) -> Self {
         Self {
             handle,
@@ -98,12 +96,10 @@ impl Runtime {
         Ok(&self.handle)
     }
 
-    /// The database, or why there is none to reach — the only way in, so
-    /// neither reason can be skipped. [`SyncError::ForkedChild`]: a child's
-    /// handle to the database is valid, which is the problem.
-    /// [`SyncError::RuntimeShutdown`]: the strong reference is gone.
-    ///
-    /// Owned, so one atomic increment per publish. A lock was the alternative.
+    /// The database, or why there is none — the only way in, so neither reason
+    /// can be skipped: [`SyncError::ForkedChild`] (a child's handle is valid,
+    /// which is the problem) and [`SyncError::RuntimeShutdown`]. Owned, so one
+    /// atomic increment per publish; a lock was the alternative.
     #[inline]
     pub(crate) fn db(&self) -> SyncResult<Arc<AimDb>> {
         self.check()?;
@@ -225,13 +221,12 @@ mod tests {
             })
             .expect("build database");
 
-        // Kept alive by the returned guard: `Runtime` holds it weakly.
+        // Kept alive by the guard below: `Runtime` holds it weakly.
         let db = Arc::new(db);
         let mut runtime = Runtime::new(tokio_rt.handle().clone(), &db);
         runtime.made_in = crate::fork::generation().wrapping_sub(generations_behind);
 
-        // Returned so the caller keeps both alive: the cloned handle must not
-        // outlive its runtime, nor the database the `Runtime` pointing at it.
+        // Returned so the caller keeps both alive.
         ((tokio_rt, db), runtime)
     }
 

--- a/aimdb-sync/tests/fork_safety_test.rs
+++ b/aimdb-sync/tests/fork_safety_test.rs
@@ -94,8 +94,7 @@ fn dropping_an_inherited_handle_does_not_panic() {
         .expect("consumer");
 
     let code = in_forked_child(move || {
-        // Asked before it is asked to act: a binding calls this from a signal
-        // handler and must not be told the database is open.
+        // A binding asks this from a signal handler, before acting.
         let reports_closed = to_detach.is_closed() && to_drop.is_closed();
 
         // `detach` reports the situation rather than joining.

--- a/aimdb-sync/tests/fork_safety_test.rs
+++ b/aimdb-sync/tests/fork_safety_test.rs
@@ -94,6 +94,12 @@ fn dropping_an_inherited_handle_does_not_panic() {
         .expect("consumer");
 
     let code = in_forked_child(move || {
+        // An inherited handle answers the question before it is asked to act:
+        // the thread is not this process's, so it cannot reach the database.
+        // A binding in another language calls this from a signal handler and
+        // must not be told the database is open.
+        let reports_closed = to_detach.is_closed() && to_drop.is_closed();
+
         // `detach` reports the situation rather than joining.
         let refused = matches!(to_detach.detach(), Err(SyncError::ForkedChild));
 
@@ -125,7 +131,7 @@ fn dropping_an_inherited_handle_does_not_panic() {
         // Leak rather than free, per the module note in `fork_child`.
         std::mem::forget(inherited);
 
-        refused && producer_defers && no_consumer && still_refused
+        reports_closed && refused && producer_defers && no_consumer && still_refused
     });
     assert_eq!(code, 0, "detach in a child should be refused, not fatal");
 }

--- a/aimdb-sync/tests/fork_safety_test.rs
+++ b/aimdb-sync/tests/fork_safety_test.rs
@@ -94,10 +94,8 @@ fn dropping_an_inherited_handle_does_not_panic() {
         .expect("consumer");
 
     let code = in_forked_child(move || {
-        // An inherited handle answers the question before it is asked to act:
-        // the thread is not this process's, so it cannot reach the database.
-        // A binding in another language calls this from a signal handler and
-        // must not be told the database is open.
+        // Asked before it is asked to act: a binding calls this from a signal
+        // handler and must not be told the database is open.
         let reports_closed = to_detach.is_closed() && to_drop.is_closed();
 
         // `detach` reports the situation rather than joining.

--- a/aimdb-sync/tests/shutdown_contract_test.rs
+++ b/aimdb-sync/tests/shutdown_contract_test.rs
@@ -1,0 +1,289 @@
+//! The four properties a foreign-language binding needs from shutdown.
+//!
+//! `shutdown` takes `&self`, is idempotent, is safe to call while producers
+//! publish, and `is_closed` never waits on the lock it holds. None of that is
+//! visible in a signature — Rust has no interpreter lock and no `free`
+//! function — so each one is pinned here rather than remembered.
+//!
+//! They are not academic. A `#[pymethods]` method and a C ABI's free function
+//! both fail to receive `self` by value, so a binding that could only shut down
+//! by value had to reach for `&mut self`, and that collided at run time with a
+//! publish already in flight: 200/200 closes refused while one thread published
+//! in a loop. The station crate above this one solved it once; these tests are
+//! what stop the next binding from having to.
+#![cfg(feature = "std")]
+use aimdb_core::{buffer::BufferCfg, AimDbBuilder};
+use aimdb_sync::{AimDbBuilderSyncExt, AimDbHandle, SyncError};
+use aimdb_tokio_adapter::{TokioAdapter, TokioRecordRegistrarExt};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Reading {
+    value: u32,
+}
+
+fn attach() -> AimDbHandle {
+    let mut builder = AimDbBuilder::new().runtime(Arc::new(TokioAdapter));
+    builder.configure::<Reading>("sensor.reading", |reg| {
+        reg.buffer(BufferCfg::SpmcRing { capacity: 64 })
+            .tap(|_ctx, _consumer| async move {});
+    });
+    builder.attach().expect("attach")
+}
+
+/// The signature property: shutdown through a shared reference, from a thread
+/// that does not own the handle.
+///
+/// This is the shape a signal handler has, and the shape every FFI door has.
+#[test]
+fn shutdown_takes_a_shared_reference() {
+    let handle = Arc::new(attach());
+    assert!(!handle.is_closed(), "a fresh handle is open");
+
+    let from_elsewhere = Arc::clone(&handle);
+    thread::spawn(move || from_elsewhere.shutdown())
+        .join()
+        .expect("the shutting-down thread should not panic")
+        .expect("shutdown");
+
+    assert!(
+        handle.is_closed(),
+        "closed after another thread shut it down"
+    );
+}
+
+/// Idempotent, including when two threads race for it.
+///
+/// Both must succeed: a second caller finding the thread already taken is the
+/// ordinary outcome of a `with` block ending inside a signal handler, not an
+/// error to report.
+#[test]
+fn shutdown_is_idempotent() {
+    let handle = attach();
+    handle.shutdown().expect("first shutdown");
+    handle.shutdown().expect("second shutdown is a no-op");
+    handle.shutdown().expect("and so is the third");
+
+    let racing = Arc::new(attach());
+    let racers: Vec<_> = (0..4)
+        .map(|_| {
+            let h = Arc::clone(&racing);
+            thread::spawn(move || h.shutdown())
+        })
+        .collect();
+    for racer in racers {
+        racer
+            .join()
+            .expect("no racer panics")
+            .expect("no racer manufactures an error for losing");
+    }
+    assert!(racing.is_closed());
+}
+
+/// Shutdown while four threads publish: it must not queue behind a publish, and
+/// no publish may fail for any reason but the shutdown itself.
+///
+/// A producer reaches the database through its own `Weak`, so it never takes
+/// the lock shutdown holds. If that ever changes, this test times out instead
+/// of the next FFI door discovering it against a live broker.
+#[test]
+fn shutdown_completes_while_producers_publish() {
+    let handle = Arc::new(attach());
+    let stop = Arc::new(AtomicBool::new(false));
+    let unexpected = Arc::new(AtomicU64::new(0));
+    let published = Arc::new(AtomicU64::new(0));
+
+    let publishers: Vec<_> = (0..4)
+        .map(|_| {
+            let producer = handle
+                .producer::<Reading>("sensor.reading")
+                .expect("producer");
+            let stop = Arc::clone(&stop);
+            let unexpected = Arc::clone(&unexpected);
+            let published = Arc::clone(&published);
+            thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    match producer.set(Reading { value: 1 }) {
+                        Ok(()) => {
+                            published.fetch_add(1, Ordering::Relaxed);
+                        }
+                        // The one failure a shutdown is allowed to cause.
+                        Err(SyncError::RuntimeShutdown) => break,
+                        Err(_) => {
+                            unexpected.fetch_add(1, Ordering::Relaxed);
+                            break;
+                        }
+                    }
+                }
+            })
+        })
+        .collect();
+
+    // Let the publishers get into their loop, so the shutdown lands mid-flight
+    // rather than before the first `set`.
+    while published.load(Ordering::Relaxed) < 16 {
+        thread::yield_now();
+    }
+
+    let began = Instant::now();
+    handle.shutdown().expect("shutdown during publishes");
+    let took = began.elapsed();
+
+    stop.store(true, Ordering::Relaxed);
+    for publisher in publishers {
+        publisher.join().expect("no publisher panics");
+    }
+
+    assert!(
+        took < Duration::from_secs(5),
+        "shutdown queued behind a publish: took {:?}",
+        took
+    );
+    assert_eq!(
+        unexpected.load(Ordering::Relaxed),
+        0,
+        "a publish failed for something other than the shutdown"
+    );
+    assert!(handle.is_closed());
+}
+
+/// `is_closed` from another thread while a shutdown is in flight.
+///
+/// The reader must keep answering throughout — it reads an atomic and a relaxed
+/// fork check, never the lock shutdown holds. A getter that waited on that lock
+/// deadlocks a Python door under the GIL and a C++ door under whatever its log
+/// callback holds, and neither is a compile error.
+#[test]
+fn is_closed_never_waits_for_a_shutdown_in_flight() {
+    let handle = Arc::new(attach());
+    let stop = Arc::new(AtomicBool::new(false));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let saw_closed = Arc::new(AtomicBool::new(false));
+
+    let reader = {
+        let handle = Arc::clone(&handle);
+        let stop = Arc::clone(&stop);
+        let ticks = Arc::clone(&ticks);
+        let saw_closed = Arc::clone(&saw_closed);
+        thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                if handle.is_closed() {
+                    saw_closed.store(true, Ordering::Relaxed);
+                }
+                ticks.fetch_add(1, Ordering::Relaxed);
+            }
+        })
+    };
+
+    while ticks.load(Ordering::Relaxed) < 16 {
+        thread::yield_now();
+    }
+    let before = ticks.load(Ordering::Relaxed);
+
+    handle.shutdown().expect("shutdown");
+
+    // The reader ticked *across* the shutdown rather than parking in it.
+    assert!(
+        ticks.load(Ordering::Relaxed) > before,
+        "is_closed stopped answering while a shutdown was in flight"
+    );
+
+    stop.store(true, Ordering::Relaxed);
+    reader.join().expect("the reader thread should not panic");
+
+    assert!(
+        saw_closed.load(Ordering::Relaxed),
+        "the reader never observed the shutdown"
+    );
+    assert!(handle.is_closed());
+}
+
+/// A bounded shutdown reports what it left behind — and a later one does not
+/// wait again, because the thread was released rather than kept.
+#[test]
+fn shutdown_timeout_releases_the_thread() {
+    let handle = attach();
+    handle
+        .shutdown_timeout(Duration::from_secs(5))
+        .expect("a healthy runtime thread stops well inside five seconds");
+    assert!(handle.is_closed());
+
+    let began = Instant::now();
+    handle
+        .shutdown()
+        .expect("the second call has nothing to do");
+    assert!(
+        began.elapsed() < Duration::from_secs(1),
+        "a shutdown after a timed one waited again"
+    );
+}
+
+/// The by-value doors are the same call, so a caller who has the handle by
+/// value is not on a different contract.
+#[test]
+fn detach_is_shutdown_by_value() {
+    attach().detach().expect("detach");
+    attach()
+        .detach_timeout(Duration::from_secs(5))
+        .expect("detach_timeout");
+}
+
+/// A producer outliving the shutdown fails with `RuntimeShutdown`, not with
+/// silence — the property `is_closed` is a cheap proxy for.
+#[test]
+fn a_publish_after_shutdown_is_refused() {
+    let handle = attach();
+    let producer = handle
+        .producer::<Reading>("sensor.reading")
+        .expect("producer");
+    producer
+        .set(Reading { value: 1 })
+        .expect("publishes while open");
+
+    handle.shutdown().expect("shutdown");
+
+    assert!(matches!(
+        producer.set(Reading { value: 2 }),
+        Err(SyncError::RuntimeShutdown)
+    ));
+}
+
+/// A consumer parked in `get()` must be woken by a shutdown on another thread.
+///
+/// This is what makes `shutdown(&self)` a shutdown rather than a stop button.
+/// `aimdb-core` has no explicit close, so the wake comes from dropping the last
+/// `Arc<AimDb>` and closing the buffers with it — which is why the handle owns
+/// that reference and releases it here, rather than holding it until the
+/// caller drops the handle. Before, the wake arrived only when the whole handle
+/// went; an FFI door that shuts down and then joins its reader threads would
+/// have hung.
+#[test]
+fn a_parked_consumer_wakes_when_another_thread_shuts_down() {
+    let handle = Arc::new(attach());
+    let mut consumer = handle
+        .consumer::<Reading>("sensor.reading")
+        .expect("consumer");
+
+    let parked = thread::spawn(move || consumer.get());
+
+    // Nothing is ever published, so the reader is parked rather than racing.
+    thread::sleep(Duration::from_millis(50));
+
+    let began = Instant::now();
+    handle.shutdown().expect("shutdown");
+
+    let woken = parked.join().expect("the parked thread should not panic");
+    assert!(
+        began.elapsed() < Duration::from_secs(5),
+        "the parked consumer was not woken by the shutdown"
+    );
+    assert!(
+        matches!(woken, Err(SyncError::RuntimeShutdown)),
+        "a woken consumer reports the shutdown, got {:?}",
+        woken
+    );
+}

--- a/aimdb-sync/tests/shutdown_contract_test.rs
+++ b/aimdb-sync/tests/shutdown_contract_test.rs
@@ -1,16 +1,8 @@
-//! The four properties a foreign-language binding needs from shutdown.
-//!
-//! `shutdown` takes `&self`, is idempotent, is safe to call while producers
-//! publish, and `is_closed` never waits on the lock it holds. None of that is
-//! visible in a signature — Rust has no interpreter lock and no `free`
-//! function — so each one is pinned here rather than remembered.
-//!
-//! They are not academic. A `#[pymethods]` method and a C ABI's free function
-//! both fail to receive `self` by value, so a binding that could only shut down
-//! by value had to reach for `&mut self`, and that collided at run time with a
-//! publish already in flight: 200/200 closes refused while one thread published
-//! in a loop. The station crate above this one solved it once; these tests are
-//! what stop the next binding from having to.
+//! The four properties a foreign-language binding needs from shutdown:
+//! `&self`, idempotent, safe during a publish, and an `is_closed` that never
+//! waits on the shutdown's lock. None is visible in a signature, and the pyo3
+//! door measured what their absence costs — 200/200 closes refused while one
+//! thread published in a loop — so each is pinned here.
 #![cfg(feature = "std")]
 use aimdb_core::{buffer::BufferCfg, AimDbBuilder};
 use aimdb_sync::{AimDbBuilderSyncExt, AimDbHandle, SyncError};
@@ -35,10 +27,8 @@ fn attach() -> AimDbHandle {
     builder.attach().expect("attach")
 }
 
-/// The signature property: shutdown through a shared reference, from a thread
-/// that does not own the handle.
-///
-/// This is the shape a signal handler has, and the shape every FFI door has.
+/// Shutdown through a shared reference, from a thread that does not own the
+/// handle — the shape a signal handler and every FFI door has.
 #[test]
 fn shutdown_takes_a_shared_reference() {
     let handle = Arc::new(attach());
@@ -56,11 +46,8 @@ fn shutdown_takes_a_shared_reference() {
     );
 }
 
-/// Idempotent, including when two threads race for it.
-///
-/// Both must succeed: a second caller finding the thread already taken is the
-/// ordinary outcome of a `with` block ending inside a signal handler, not an
-/// error to report.
+/// Idempotent, including under a race: a second caller finding the thread gone
+/// is a `with` block ending inside a signal handler, not an error.
 #[test]
 fn shutdown_is_idempotent() {
     let handle = attach();
@@ -84,12 +71,9 @@ fn shutdown_is_idempotent() {
     assert!(racing.is_closed());
 }
 
-/// Shutdown while four threads publish: it must not queue behind a publish, and
-/// no publish may fail for any reason but the shutdown itself.
-///
-/// A producer reaches the database through its own `Weak`, so it never takes
-/// the lock shutdown holds. If that ever changes, this test times out instead
-/// of the next FFI door discovering it against a live broker.
+/// Shutdown while four threads publish: it must not queue behind one, and no
+/// publish may fail for anything but the shutdown. If a producer ever starts
+/// taking the shutdown's lock, this times out instead of the next FFI door.
 #[test]
 fn shutdown_completes_while_producers_publish() {
     let handle = Arc::new(attach());
@@ -151,12 +135,9 @@ fn shutdown_completes_while_producers_publish() {
     assert!(handle.is_closed());
 }
 
-/// `is_closed` from another thread while a shutdown is in flight.
-///
-/// The reader must keep answering throughout — it reads an atomic and a relaxed
-/// fork check, never the lock shutdown holds. A getter that waited on that lock
-/// deadlocks a Python door under the GIL and a C++ door under whatever its log
-/// callback holds, and neither is a compile error.
+/// `is_closed` must keep answering across a shutdown: an atomic and a relaxed
+/// fork check, never the shutdown's lock. A getter that waited on it deadlocks
+/// a Python door under the GIL, and that is not a compile error.
 #[test]
 fn is_closed_never_waits_for_a_shutdown_in_flight() {
     let handle = Arc::new(attach());
@@ -202,8 +183,8 @@ fn is_closed_never_waits_for_a_shutdown_in_flight() {
     assert!(handle.is_closed());
 }
 
-/// A bounded shutdown reports what it left behind — and a later one does not
-/// wait again, because the thread was released rather than kept.
+/// A bounded shutdown releases the thread rather than keeping it, so a later
+/// one does not wait again.
 #[test]
 fn shutdown_timeout_releases_the_thread() {
     let handle = attach();
@@ -222,8 +203,7 @@ fn shutdown_timeout_releases_the_thread() {
     );
 }
 
-/// The by-value doors are the same call, so a caller who has the handle by
-/// value is not on a different contract.
+/// The by-value doors are the same call, not a second contract.
 #[test]
 fn detach_is_shutdown_by_value() {
     attach().detach().expect("detach");
@@ -232,8 +212,8 @@ fn detach_is_shutdown_by_value() {
         .expect("detach_timeout");
 }
 
-/// A producer outliving the shutdown fails with `RuntimeShutdown`, not with
-/// silence — the property `is_closed` is a cheap proxy for.
+/// A producer outliving the shutdown fails, rather than publishing into
+/// silence.
 #[test]
 fn a_publish_after_shutdown_is_refused() {
     let handle = attach();
@@ -252,15 +232,10 @@ fn a_publish_after_shutdown_is_refused() {
     ));
 }
 
-/// A consumer parked in `get()` must be woken by a shutdown on another thread.
-///
-/// This is what makes `shutdown(&self)` a shutdown rather than a stop button.
+/// A consumer parked in `get()` is woken by a shutdown on another thread.
 /// `aimdb-core` has no explicit close, so the wake comes from dropping the last
-/// `Arc<AimDb>` and closing the buffers with it — which is why the handle owns
-/// that reference and releases it here, rather than holding it until the
-/// caller drops the handle. Before, the wake arrived only when the whole handle
-/// went; an FFI door that shuts down and then joins its reader threads would
-/// have hung.
+/// `Arc<AimDb>` — which is why the handle owns it and releases it here. Without
+/// that, "shut down, then join the readers" hangs.
 #[test]
 fn a_parked_consumer_wakes_when_another_thread_shuts_down() {
     let handle = Arc::new(attach());

--- a/aimdb-sync/tests/shutdown_contract_test.rs
+++ b/aimdb-sync/tests/shutdown_contract_test.rs
@@ -1,8 +1,6 @@
-//! The four properties a foreign-language binding needs from shutdown:
-//! `&self`, idempotent, safe during a publish, and an `is_closed` that never
-//! waits on the shutdown's lock. None is visible in a signature, and the pyo3
-//! door measured what their absence costs — 200/200 closes refused while one
-//! thread published in a loop — so each is pinned here.
+//! What a foreign-language binding needs from shutdown, none of it visible in
+//! a signature: `&self`, idempotent, safe during a publish, and an `is_closed`
+//! that never waits on the shutdown's lock.
 #![cfg(feature = "std")]
 use aimdb_core::{buffer::BufferCfg, AimDbBuilder};
 use aimdb_sync::{AimDbBuilderSyncExt, AimDbHandle, SyncError};
@@ -27,8 +25,7 @@ fn attach() -> AimDbHandle {
     builder.attach().expect("attach")
 }
 
-/// Shutdown through a shared reference, from a thread that does not own the
-/// handle — the shape a signal handler and every FFI door has.
+/// Shutdown from a thread that does not own the handle — a signal handler.
 #[test]
 fn shutdown_takes_a_shared_reference() {
     let handle = Arc::new(attach());
@@ -46,8 +43,7 @@ fn shutdown_takes_a_shared_reference() {
     );
 }
 
-/// Idempotent, including under a race: a second caller finding the thread gone
-/// is a `with` block ending inside a signal handler, not an error.
+/// Idempotent, including under a race.
 #[test]
 fn shutdown_is_idempotent() {
     let handle = attach();
@@ -71,9 +67,8 @@ fn shutdown_is_idempotent() {
     assert!(racing.is_closed());
 }
 
-/// Shutdown while four threads publish: it must not queue behind one, and no
-/// publish may fail for anything but the shutdown. If a producer ever starts
-/// taking the shutdown's lock, this times out instead of the next FFI door.
+/// Shutdown must not queue behind a publish, and no publish may fail for
+/// anything but the shutdown.
 #[test]
 fn shutdown_completes_while_producers_publish() {
     let handle = Arc::new(attach());
@@ -95,7 +90,7 @@ fn shutdown_completes_while_producers_publish() {
                         Ok(()) => {
                             published.fetch_add(1, Ordering::Relaxed);
                         }
-                        // The one failure a shutdown is allowed to cause.
+                        // The one failure a shutdown may cause.
                         Err(SyncError::RuntimeShutdown) => break,
                         Err(_) => {
                             unexpected.fetch_add(1, Ordering::Relaxed);
@@ -107,8 +102,7 @@ fn shutdown_completes_while_producers_publish() {
         })
         .collect();
 
-    // Let the publishers get into their loop, so the shutdown lands mid-flight
-    // rather than before the first `set`.
+    // So the shutdown lands mid-flight, not before the first `set`.
     while published.load(Ordering::Relaxed) < 16 {
         thread::yield_now();
     }
@@ -135,9 +129,8 @@ fn shutdown_completes_while_producers_publish() {
     assert!(handle.is_closed());
 }
 
-/// `is_closed` must keep answering across a shutdown: an atomic and a relaxed
-/// fork check, never the shutdown's lock. A getter that waited on it deadlocks
-/// a Python door under the GIL, and that is not a compile error.
+/// `is_closed` keeps answering across a shutdown — a getter that waited on the
+/// shutdown's lock deadlocks a Python door under the GIL.
 #[test]
 fn is_closed_never_waits_for_a_shutdown_in_flight() {
     let handle = Arc::new(attach());
@@ -167,7 +160,7 @@ fn is_closed_never_waits_for_a_shutdown_in_flight() {
 
     handle.shutdown().expect("shutdown");
 
-    // The reader ticked *across* the shutdown rather than parking in it.
+    // Ticked across the shutdown rather than parking in it.
     assert!(
         ticks.load(Ordering::Relaxed) > before,
         "is_closed stopped answering while a shutdown was in flight"
@@ -183,8 +176,7 @@ fn is_closed_never_waits_for_a_shutdown_in_flight() {
     assert!(handle.is_closed());
 }
 
-/// A bounded shutdown releases the thread rather than keeping it, so a later
-/// one does not wait again.
+/// A bounded shutdown releases the thread, so a later one does not wait.
 #[test]
 fn shutdown_timeout_releases_the_thread() {
     let handle = attach();
@@ -212,7 +204,7 @@ fn detach_is_shutdown_by_value() {
         .expect("detach_timeout");
 }
 
-/// A producer outliving the shutdown fails, rather than publishing into
+/// A producer outliving the shutdown fails rather than publishing into
 /// silence.
 #[test]
 fn a_publish_after_shutdown_is_refused() {
@@ -232,10 +224,8 @@ fn a_publish_after_shutdown_is_refused() {
     ));
 }
 
-/// A consumer parked in `get()` is woken by a shutdown on another thread.
-/// `aimdb-core` has no explicit close, so the wake comes from dropping the last
-/// `Arc<AimDb>` — which is why the handle owns it and releases it here. Without
-/// that, "shut down, then join the readers" hangs.
+/// A consumer parked in `get()` is woken by a shutdown on another thread —
+/// the wake is the last `Arc<AimDb>` dropping, so the handle must own it.
 #[test]
 fn a_parked_consumer_wakes_when_another_thread_shuts_down() {
     let handle = Arc::new(attach());
@@ -245,7 +235,7 @@ fn a_parked_consumer_wakes_when_another_thread_shuts_down() {
 
     let parked = thread::spawn(move || consumer.get());
 
-    // Nothing is ever published, so the reader is parked rather than racing.
+    // Nothing is published, so the reader parks rather than races.
     thread::sleep(Duration::from_millis(50));
 
     let began = Instant::now();

--- a/examples/hello-mailbox/src/main.rs
+++ b/examples/hello-mailbox/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Now we create the consumer — it will only see the last value in the Mailbox
         println!("2. Consumer created AFTER the burst — reads once:");
-        let consumer = handle.consumer::<Led>("actuator.led")?;
+        let mut consumer = handle.consumer::<Led>("actuator.led")?;
         thread::sleep(Duration::from_millis(100));
 
         match consumer.try_get() {
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_millis(100));
 
     println!("2. Consumer created AFTER the burst — reads once:");
-    let consumer2 = handle.consumer::<Led>("actuator.led")?;
+    let mut consumer2 = handle.consumer::<Led>("actuator.led")?;
     thread::sleep(Duration::from_millis(100));
 
     match consumer2.try_get() {


### PR DESCRIPTION
`shutdown(&self)`, `shutdown_timeout(&self, _)` and `is_closed()` on
`AimDbHandle`. Four properties, none of them expressible in a signature,
all four required by every language binding — and until now all four
living one crate up, in `weather-station::StationHandle`, rather than in
the crate whose thread they are about:

  - shutdown takes `&self`, because a C ABI's free function and a
    `#[pymethods]` method never receive `self` by value, and a
    `&mut self` shutdown collides at run time with a publish already in
    flight (the pyo3 door measured 200/200 closes refused);
  - it is idempotent, including when threads race for it;
  - it is safe to call while producers publish, since they reach the
    database through their own `Weak` and never take its lock;
  - `is_closed` reads an atomic and never that lock, so a caller holding
    an interpreter lock can ask it while a shutdown is joining — and in
    a forked child it reports closed.

`tests/shutdown_contract_test.rs` pins each one. `detach(self)` and
`detach_timeout(self, _)` are unchanged and now delegate.

A shutdown also releases the database, where dropping the handle used to:
the runtime holds it weakly and the handle owns the one strong
reference. Dropping the last `Arc<AimDb>` is what closes the buffers, and
that is what wakes a consumer parked in `get()` — so "shut down, then
join the reader threads" terminates instead of hanging, and the publish
after a shutdown is refused rather than accepted into a graph nobody
pumps. It costs one atomic increment on the publish path; the
alternative was a lock, which is the thing this crate keeps off it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Z3ehWPzAjjgQFHsKuhKpm