### PR TITLE
docs(persistence): teach the segment-wildcard grammar in the README

### DIFF
--- a/aimdb-client/CHANGELOG.md
+++ b/aimdb-client/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     record cannot kill a wildcard stream fanning in many;
   - `skipped` — updates lost immediately before this one;
   - `snapshot_end` — this update closes the late-join snapshot burst; every
-    update after it is a live event. Set only when the burst produced a final
-    snapshot to carry it, so its absence is not a signal (see below).
+    update after it is a live event. Only set when the burst produced a final
+    snapshot to carry it (see below).
   `ClientHandle`-level streams carry `SubUpdate` (see `aimdb-core`).
 - **Dead protocol helpers removed** (retired with the hand-rolled client in
   PR #124, deleted now): `RequestExt`, `ResponseExt`, `serialize_message`,
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Loss visibility on the subscription stream.** `RecordUpdate` exposes the delivery gap the engine already tracks (`SubUpdate::skipped`) — previously reachable only from raw `ClientHandle` streams, so ordinary client/CLI/bridge consumers could not tell a buffer overrun from an idle producer — plus `snapshot_end`, which marks the last update of a late-join snapshot burst. The engine reserves a sink slot for that final update, so an overrun cannot cost you the marker and a burst closes even when no live event ever follows; the client boundary preserves that by delivering every frame as exactly one stream item (an undecodable payload arrives as `value: None` rather than being dropped and folded into a *next* update that may never come). The marker rides the last snapshot's frame, so a burst that produced none — nothing matched, nothing has a value yet, an exact-topic subscribe, or a tail that failed to encode — ends without one: `snapshot_end` means the initial state is complete, while its absence means nothing and must not be waited on.
+- **Loss visibility on the subscription stream.** `RecordUpdate` exposes the delivery gap the engine already tracks (`SubUpdate::skipped`) — previously reachable only from raw `ClientHandle` streams, so ordinary client/CLI/bridge consumers could not tell a buffer overrun from an idle producer — plus `snapshot_end`, which marks the last update of a late-join snapshot burst. The engine reserves a sink slot for that final update, so an overrun cannot cost you the marker and a burst closes even when no live event ever follows; the client boundary preserves that by delivering every frame as exactly one stream item (an undecodable payload arrives as `value: None` rather than being dropped and folded into a *next* update that may never come). The marker rides the last snapshot's frame, so a burst that produced none — nothing matched, nothing has a value yet, an exact-topic subscribe, a tail that failed to encode — ends without one; its absence is not a signal and must not be waited on.
 
 - **A refused subscription is observable.** A terminal rejection (denied, subscription limit reached) now arrives as one `Err` item that ends the stream, instead of a silent end of stream indistinguishable from a disconnect or a closed record. `aimdb watch` exits non-zero on one (see `aimdb-cli`).
 

--- a/aimdb-client/CHANGELOG.md
+++ b/aimdb-client/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     record cannot kill a wildcard stream fanning in many;
   - `skipped` — updates lost immediately before this one;
   - `snapshot_end` — this update closes the late-join snapshot burst; every
-    update after it is a live event.
+    update after it is a live event. Set only when the burst produced a final
+    snapshot to carry it, so its absence is not a signal (see below).
   `ClientHandle`-level streams carry `SubUpdate` (see `aimdb-core`).
 - **Dead protocol helpers removed** (retired with the hand-rolled client in
   PR #124, deleted now): `RequestExt`, `ResponseExt`, `serialize_message`,
@@ -34,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Loss visibility on the subscription stream.** `RecordUpdate` exposes the delivery gap the engine already tracks (`SubUpdate::skipped`) — previously reachable only from raw `ClientHandle` streams, so ordinary client/CLI/bridge consumers could not tell a buffer overrun from an idle producer — plus `snapshot_end`, which marks the last update of a late-join snapshot burst. The engine reserves a sink slot for that final update, so a burst closes even when it overran the sink and even when no live event ever follows; the client boundary preserves that guarantee by delivering every frame as exactly one stream item (an undecodable payload arrives as `value: None` rather than being dropped and folded into a *next* update that may never come).
+- **Loss visibility on the subscription stream.** `RecordUpdate` exposes the delivery gap the engine already tracks (`SubUpdate::skipped`) — previously reachable only from raw `ClientHandle` streams, so ordinary client/CLI/bridge consumers could not tell a buffer overrun from an idle producer — plus `snapshot_end`, which marks the last update of a late-join snapshot burst. The engine reserves a sink slot for that final update, so an overrun cannot cost you the marker and a burst closes even when no live event ever follows; the client boundary preserves that by delivering every frame as exactly one stream item (an undecodable payload arrives as `value: None` rather than being dropped and folded into a *next* update that may never come). The marker rides the last snapshot's frame, so a burst that produced none — nothing matched, nothing has a value yet, an exact-topic subscribe, or a tail that failed to encode — ends without one: `snapshot_end` means the initial state is complete, while its absence means nothing and must not be waited on.
 
 - **A refused subscription is observable.** A terminal rejection (denied, subscription limit reached) now arrives as one `Err` item that ends the stream, instead of a silent end of stream indistinguishable from a disconnect or a closed record. `aimdb watch` exits non-zero on one (see `aimdb-cli`).
 

--- a/aimdb-client/src/engine.rs
+++ b/aimdb-client/src/engine.rs
@@ -76,23 +76,11 @@ pub struct RecordUpdate {
     /// [`skipped`](Self::skipped) here — the engine reserves a slot for this
     /// update, so an overrun cannot cost you the marker.
     ///
-    /// **Its absence is not a signal.** The marker rides the last snapshot's
-    /// frame rather than a terminator of its own, so a burst with no such frame
-    /// simply ends without one:
-    ///
-    /// - the pattern matched no records, or matched only records that have not
-    ///   produced a value yet — ordinary against a fresh database, not an edge
-    ///   case;
-    /// - the subscription was exact-topic, which takes no snapshots at all;
-    /// - the burst's last snapshot failed to encode and was dropped, taking the
-    ///   `last` flag with it.
-    ///
-    /// The first two are benign and the third is a genuine snapshot loss, but
-    /// none of them will ever set `snapshot_end`. So a consumer must not wait on
-    /// it to decide whether the burst is still arriving — that wait does not
-    /// end. Treat the marker as "the initial state was non-empty and is now
-    /// complete", and read [`skipped`](Self::skipped) — here, or on the first
-    /// live event after the burst — for whether anything was lost.
+    /// **Its absence is not a signal**, and must never be waited on. The marker
+    /// rides the last snapshot's frame, so a burst that produced none never
+    /// sets it: nothing matched, nothing has a value yet, an exact-topic
+    /// subscribe, or a tail that failed to encode. Only the last of those is a
+    /// real loss, and [`skipped`](Self::skipped) reports it.
     pub snapshot_end: bool,
 }
 

--- a/aimdb-client/src/engine.rs
+++ b/aimdb-client/src/engine.rs
@@ -73,12 +73,26 @@ pub struct RecordUpdate {
     pub skipped: u64,
     /// Final update of a late-join snapshot burst: every update after it is a
     /// live event. A burst that overran the sink carries its whole loss in
-    /// [`skipped`](Self::skipped) here.
+    /// [`skipped`](Self::skipped) here — the engine reserves a slot for this
+    /// update, so an overrun cannot cost you the marker.
     ///
-    /// The engine reserves a sink slot for this update, so it arrives even from
-    /// a burst that overran — a subscription over static records may never fire
-    /// an event, and a consumer still has to tell a complete initial state from
-    /// a truncated one.
+    /// **Its absence is not a signal.** The marker rides the last snapshot's
+    /// frame rather than a terminator of its own, so a burst with no such frame
+    /// simply ends without one:
+    ///
+    /// - the pattern matched no records, or matched only records that have not
+    ///   produced a value yet — ordinary against a fresh database, not an edge
+    ///   case;
+    /// - the subscription was exact-topic, which takes no snapshots at all;
+    /// - the burst's last snapshot failed to encode and was dropped, taking the
+    ///   `last` flag with it.
+    ///
+    /// The first two are benign and the third is a genuine snapshot loss, but
+    /// none of them will ever set `snapshot_end`. So a consumer must not wait on
+    /// it to decide whether the burst is still arriving — that wait does not
+    /// end. Treat the marker as "the initial state was non-empty and is now
+    /// complete", and read [`skipped`](Self::skipped) — here, or on the first
+    /// live event after the burst — for whether anything was lost.
     pub snapshot_end: bool,
 }
 

--- a/aimdb-core/src/session/client.rs
+++ b/aimdb-core/src/session/client.rs
@@ -391,13 +391,10 @@ enum Delivery {
     /// [`SubUpdate::snapshot_end`], delivered into the slot
     /// [`Delivery::BurstBody`] stopped short of.
     ///
-    /// That slot is only reserved if a `BurstBody` ran, so a single-snapshot
-    /// burst lands on ordering instead: the sink is created when the
-    /// subscription is issued and the server sends every snapshot before it
-    /// registers the event pump, so nothing has competed for the capacity yet.
-    /// A burst with no snapshots sends no `BurstEnd` at all — see
-    /// [`SubUpdate::snapshot_end`] for what a subscriber may conclude from
-    /// that (nothing).
+    /// Only a `BurstBody` reserves that slot, so a single-snapshot burst rests
+    /// on ordering instead: the sink predates the subscribe reply, and the
+    /// server sends every snapshot before registering the event pump. A burst
+    /// with no snapshots sends no `BurstEnd` at all.
     BurstEnd,
 }
 

--- a/aimdb-core/src/session/client.rs
+++ b/aimdb-core/src/session/client.rs
@@ -387,9 +387,17 @@ enum Delivery {
     /// full, and additionally stops one slot short so [`Delivery::BurstEnd`]
     /// always fits.
     BurstBody,
-    /// The burst's final snapshot: guaranteed delivery into the slot
-    /// [`Delivery::BurstBody`] kept free, carrying the burst's whole loss count
-    /// and [`SubUpdate::snapshot_end`].
+    /// The burst's final snapshot: carries the burst's whole loss count and
+    /// [`SubUpdate::snapshot_end`], delivered into the slot
+    /// [`Delivery::BurstBody`] stopped short of.
+    ///
+    /// That slot is only reserved if a `BurstBody` ran, so a single-snapshot
+    /// burst lands on ordering instead: the sink is created when the
+    /// subscription is issued and the server sends every snapshot before it
+    /// registers the event pump, so nothing has competed for the capacity yet.
+    /// A burst with no snapshots sends no `BurstEnd` at all — see
+    /// [`SubUpdate::snapshot_end`] for what a subscriber may conclude from
+    /// that (nothing).
     BurstEnd,
 }
 

--- a/aimdb-core/src/session/mod.rs
+++ b/aimdb-core/src/session/mod.rs
@@ -82,9 +82,9 @@ pub struct SubUpdate {
     pub skipped: u64,
     /// Set on the last update of the late-join snapshot burst, carrying its total `skipped`.
     ///
-    /// Present only when the burst produced a final update to set it on: an
-    /// empty burst, an exact-topic subscription, or a tail that failed to
-    /// encode all end without it, so its absence tells a subscriber nothing.
+    /// Only set when the burst produced a final update to carry it — an empty
+    /// burst, an exact-topic subscribe, or a tail that failed to encode end
+    /// without one — so its absence says nothing.
     pub snapshot_end: bool,
 }
 

--- a/aimdb-core/src/session/mod.rs
+++ b/aimdb-core/src/session/mod.rs
@@ -80,7 +80,11 @@ pub struct SubUpdate {
     pub data: Payload,
     /// Count of skipped records
     pub skipped: u64,
-    /// Set on the last update of the late-join snapshot burst, carrying its total `skipped`
+    /// Set on the last update of the late-join snapshot burst, carrying its total `skipped`.
+    ///
+    /// Present only when the burst produced a final update to set it on: an
+    /// empty burst, an exact-topic subscription, or a tail that failed to
+    /// encode all end without it, so its absence tells a subscriber nothing.
     pub snapshot_end: bool,
 }
 

--- a/aimdb-persistence-sqlite/README.md
+++ b/aimdb-persistence-sqlite/README.md
@@ -57,8 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let db = builder.build().await?;
 
-    // Patterns are MQTT-style over dot-separated keys: `*` is exactly one
-    // segment, `#` is zero or more. See the aimdb-persistence README.
+    // `*` is exactly one segment, `#` zero or more (see aimdb-persistence).
     let latest: Vec<Accuracy> = db.query_latest("accuracy.*", 5).await?;
     println!("{} rows returned", latest.len());
 

--- a/aimdb-persistence-sqlite/README.md
+++ b/aimdb-persistence-sqlite/README.md
@@ -51,13 +51,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .runtime(runtime)
         .with_persistence(backend, Duration::from_secs(7 * 24 * 3600));
 
-    builder.configure::<Accuracy>("accuracy::vienna", |reg| {
-        reg.persist("accuracy::vienna");
+    builder.configure::<Accuracy>("accuracy.vienna", |reg| {
+        reg.persist("accuracy.vienna");
     });
 
     let db = builder.build().await?;
 
-    let latest: Vec<Accuracy> = db.query_latest("accuracy::*", 5).await?;
+    // Patterns are MQTT-style over dot-separated keys: `*` is exactly one
+    // segment, `#` is zero or more. See the aimdb-persistence README.
+    let latest: Vec<Accuracy> = db.query_latest("accuracy.*", 5).await?;
     println!("{} rows returned", latest.len());
 
     Ok(())

--- a/aimdb-persistence/README.md
+++ b/aimdb-persistence/README.md
@@ -14,7 +14,7 @@ pluggable storage backend into the AimDB builder and query API:
 |---|---|
 | [`PersistenceBackend`] trait | Interface for concrete backends (SQLite, Postgres, …) |
 | `AimDbBuilderPersistExt` | `.with_persistence(backend, retention)` on the builder |
-| `RecordRegistrarPersistExt` | `.persist("my_record::key")` on record configuration |
+| `RecordRegistrarPersistExt` | `.persist("my_record.key")` on record configuration |
 | `AimDbQueryExt` | `.query_latest()` / `.query_range()` on a live `AimDb<R>` |
 
 For a concrete backend, add [`aimdb-persistence-sqlite`](../aimdb-persistence-sqlite/README.md).
@@ -64,22 +64,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_persistence(backend, Duration::from_secs(7 * 24 * 3600));
 
     // 2. Opt individual records into persistence.
-    builder.configure::<Accuracy>("accuracy::vienna", |reg| {
-        reg.persist("accuracy::vienna");
+    builder.configure::<Accuracy>("accuracy.vienna", |reg| {
+        reg.persist("accuracy.vienna");
     });
-    builder.configure::<Accuracy>("accuracy::berlin", |reg| {
-        reg.persist("accuracy::berlin");
+    builder.configure::<Accuracy>("accuracy.berlin", |reg| {
+        reg.persist("accuracy.berlin");
     });
 
     let db = builder.build().await?;
 
-    // 3. Query historical data.
-    let latest: Vec<Accuracy> = db.query_latest("accuracy::*", 10).await?;
+    // 3. Query historical data. `*` is exactly one segment, so `accuracy.*`
+    //    covers both cities — see "Query methods" for `*` vs `#`.
+    let latest: Vec<Accuracy> = db.query_latest("accuracy.*", 10).await?;
     println!("Latest 10 per city: {} rows total", latest.len());
 
     let since = 1_700_000_000_000_u64; // Unix ms
     let until = 1_800_000_000_000_u64;
-    let range: Vec<Accuracy> = db.query_range("accuracy::vienna", since, until, None).await?;
+    let range: Vec<Accuracy> = db.query_range("accuracy.vienna", since, until, None).await?;
     println!("Vienna in range: {} rows", range.len());
 
     Ok(())
@@ -134,10 +135,10 @@ builder.with_persistence(
 ### Record registration
 
 ```rust
-builder.configure::<MyRecord>("my_record::key", |reg| {
-    reg.persist("my_record::key");
+builder.configure::<MyRecord>("my_record.key", |reg| {
+    reg.persist("my_record.key");
     // .persist() accepts anything that converts to String:
-    // reg.persist(format!("my_record::{}", city));
+    // reg.persist(format!("my_record.{}", city));
 });
 ```
 
@@ -146,25 +147,38 @@ required — the persistence subscriber taps the typed buffer directly.
 
 ### Query methods
 
+A record pattern is MQTT-style over dot-separated keys — the grammar
+subscriptions already use. `*` covers exactly one segment, `#` covers zero or
+more, and a wildcard is always a whole segment of its own. So `my_record.*`
+matches `my_record.vienna` but not `my_record.vienna.raw`, while `my_record.#`
+matches both.
+
+Reach for `*` when the keys you want sit at a known depth and `#` when that
+depth varies. The choice matters for the key layout too: a key with no dots —
+`my_record::vienna`, say — is one whole segment, so no pattern can partition a
+key space built that way.
+
 ```rust
 use aimdb_persistence::AimDbQueryExt;
 
-// Latest N values per matching record (pattern supports `*` wildcard).
-let latest: Vec<MyRecord> = db.query_latest("my_record::*", 5).await?;
+// Latest N values per matching record.
+let latest: Vec<MyRecord> = db.query_latest("my_record.*", 5).await?;
 
 // All values in a time range (Unix milliseconds), no row limit.
 let range: Vec<MyRecord> = db
-    .query_range("my_record::vienna", start_ms, end_ms, None)
+    .query_range("my_record.vienna", start_ms, end_ms, None)
     .await?;
 
 // Time range with at most 100 rows per matching record.
 let capped: Vec<MyRecord> = db
-    .query_range("my_record::*", start_ms, end_ms, Some(100))
+    .query_range("my_record.*", start_ms, end_ms, Some(100))
     .await?;
 
 // Untyped query (returns raw JSON — used by the AimX protocol handler).
+// `#` rather than `*`: this path serves remote callers whose keys sit at
+// whatever depth they were registered at.
 use aimdb_persistence::QueryParams;
-let raw = db.query_raw("my_record::*", QueryParams {
+let raw = db.query_raw("my_record.#", QueryParams {
     limit_per_record: Some(1),
     ..Default::default()
 }).await?;
@@ -179,7 +193,7 @@ matching rows, or `Some(n)` to cap results per record name.
 ```rust
 use aimdb_persistence::PersistenceError;
 
-match db.query_latest::<MyRecord>("my_record::*", 10).await {
+match db.query_latest::<MyRecord>("my_record.*", 10).await {
     Ok(rows) => { /* … */ }
     Err(PersistenceError::NotConfigured) => {
         // .with_persistence() was not called on the builder

--- a/aimdb-persistence/README.md
+++ b/aimdb-persistence/README.md
@@ -73,8 +73,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let db = builder.build().await?;
 
-    // 3. Query historical data. `*` is exactly one segment, so `accuracy.*`
-    //    covers both cities — see "Query methods" for `*` vs `#`.
+    // 3. Query historical data. `*` is one segment, so `accuracy.*` covers
+    //    both cities.
     let latest: Vec<Accuracy> = db.query_latest("accuracy.*", 10).await?;
     println!("Latest 10 per city: {} rows total", latest.len());
 
@@ -147,16 +147,12 @@ required — the persistence subscriber taps the typed buffer directly.
 
 ### Query methods
 
-A record pattern is MQTT-style over dot-separated keys — the grammar
-subscriptions already use. `*` covers exactly one segment, `#` covers zero or
-more, and a wildcard is always a whole segment of its own. So `my_record.*`
-matches `my_record.vienna` but not `my_record.vienna.raw`, while `my_record.#`
-matches both.
-
-Reach for `*` when the keys you want sit at a known depth and `#` when that
-depth varies. The choice matters for the key layout too: a key with no dots —
-`my_record::vienna`, say — is one whole segment, so no pattern can partition a
-key space built that way.
+A record pattern is MQTT-style over dot-separated keys, the grammar
+subscriptions use: `*` covers exactly one segment, `#` zero or more, and a
+wildcard is always a whole segment. So `my_record.*` matches `my_record.vienna`
+but not `my_record.vienna.raw`; `my_record.#` matches both. Reach for `*` at a
+known depth, `#` where it varies. A key with no dots is a single segment, so no
+pattern can partition it.
 
 ```rust
 use aimdb_persistence::AimDbQueryExt;
@@ -175,8 +171,7 @@ let capped: Vec<MyRecord> = db
     .await?;
 
 // Untyped query (returns raw JSON — used by the AimX protocol handler).
-// `#` rather than `*`: this path serves remote callers whose keys sit at
-// whatever depth they were registered at.
+// `#`, not `*`: remote callers key at whatever depth they registered.
 use aimdb_persistence::QueryParams;
 let raw = db.query_raw("my_record.#", QueryParams {
     limit_per_record: Some(1),

--- a/aimdb-persistence/src/backend.rs
+++ b/aimdb-persistence/src/backend.rs
@@ -16,7 +16,8 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// A stored value returned by [`PersistenceBackend::query`].
 #[derive(Debug, Clone)]
 pub struct StoredValue {
-    /// The record name this value belongs to (e.g. `"accuracy::vienna"`).
+    /// The record name this value belongs to (e.g. `"accuracy.vienna"`) — a
+    /// concrete key, never a pattern.
     pub record_name: String,
     /// The JSON-serialized value.
     pub value: Value,

--- a/aimdb-persistence/src/query_ext.rs
+++ b/aimdb-persistence/src/query_ext.rs
@@ -14,16 +14,13 @@ use crate::error::PersistenceError;
 /// Import `use aimdb_persistence::AimDbQueryExt;` to call `.query_latest()` /
 /// `.query_range()` on a live `AimDb` handle.
 ///
-/// `record_pattern` is the grammar
-/// [`PersistenceBackend::query`] defines for
-/// every method here: MQTT-style over dot-separated record keys, `*` covering
-/// exactly one segment and `#` zero or more.
+/// `record_pattern` throughout is the grammar [`PersistenceBackend::query`]
+/// defines: `*` covers exactly one segment, `#` zero or more.
 pub trait AimDbQueryExt {
     /// Query the latest N values per matching record.
     ///
-    /// `"accuracy.*"` returns the latest N from each record exactly one segment
-    /// below `accuracy`, `"accuracy.#"` from every record at any depth under
-    /// it, and a wildcard-free pattern from that one record.
+    /// `"accuracy.*"` covers each record one segment below `accuracy`,
+    /// `"accuracy.#"` any depth under it, a wildcard-free pattern just itself.
     ///
     /// Rows that fail to deserialize as `T` are **skipped** with a tracing
     /// warning rather than failing the entire query.
@@ -53,10 +50,8 @@ pub trait AimDbQueryExt {
     /// `record_pattern` matches.
     ///
     /// This is the non-generic variant used by the AimX `record.query` handler
-    /// which doesn't know the concrete Rust type — and which defaults to
-    /// [`QUERY_ALL_PATTERN`](aimdb_core::remote::QUERY_ALL_PATTERN), `#`,
-    /// since a remote caller's keys sit at whatever depth they were
-    /// registered at.
+    /// which doesn't know the concrete Rust type; it defaults to
+    /// [`QUERY_ALL_PATTERN`](aimdb_core::remote::QUERY_ALL_PATTERN), `#`.
     fn query_raw(
         &self,
         record_pattern: &str,

--- a/aimdb-persistence/src/query_ext.rs
+++ b/aimdb-persistence/src/query_ext.rs
@@ -13,12 +13,17 @@ use crate::error::PersistenceError;
 ///
 /// Import `use aimdb_persistence::AimDbQueryExt;` to call `.query_latest()` /
 /// `.query_range()` on a live `AimDb` handle.
+///
+/// `record_pattern` is the grammar
+/// [`PersistenceBackend::query`] defines for
+/// every method here: MQTT-style over dot-separated record keys, `*` covering
+/// exactly one segment and `#` zero or more.
 pub trait AimDbQueryExt {
     /// Query the latest N values per matching record.
     ///
-    /// Pattern support: `"accuracy::*"` returns latest N from each matching
-    /// record. Single record: `"accuracy::vienna"` returns latest N from that
-    /// record only.
+    /// `"accuracy.*"` returns the latest N from each record exactly one segment
+    /// below `accuracy`, `"accuracy.#"` from every record at any depth under
+    /// it, and a wildcard-free pattern from that one record.
     ///
     /// Rows that fail to deserialize as `T` are **skipped** with a tracing
     /// warning rather than failing the entire query.
@@ -28,7 +33,8 @@ pub trait AimDbQueryExt {
         limit_per_record: usize,
     ) -> BoxFuture<'_, Result<Vec<T>, PersistenceError>>;
 
-    /// Query values within a time range for a single record or pattern.
+    /// Query values within a time range for every record `record_pattern`
+    /// matches.
     ///
     /// Pass `None` for `limit_per_record` to return all matching rows, or
     /// `Some(n)` to cap results per matching record name.
@@ -43,10 +49,14 @@ pub trait AimDbQueryExt {
         limit_per_record: Option<usize>,
     ) -> BoxFuture<'_, Result<Vec<T>, PersistenceError>>;
 
-    /// Query raw stored values (untyped, returns JSON).
+    /// Query raw stored values (untyped, returns JSON) for every record
+    /// `record_pattern` matches.
     ///
     /// This is the non-generic variant used by the AimX `record.query` handler
-    /// which doesn't know the concrete Rust type.
+    /// which doesn't know the concrete Rust type — and which defaults to
+    /// [`QUERY_ALL_PATTERN`](aimdb_core::remote::QUERY_ALL_PATTERN), `#`,
+    /// since a remote caller's keys sit at whatever depth they were
+    /// registered at.
     fn query_raw(
         &self,
         record_pattern: &str,

--- a/aimdb-persistence/tests/query_skip_invalid.rs
+++ b/aimdb-persistence/tests/query_skip_invalid.rs
@@ -47,13 +47,11 @@ impl PersistenceBackend for MockBackend {
     }
 
     /// Returns the pre-configured rows the pattern matches, decided by
-    /// [`topic_matches`] — the matcher [`PersistenceBackend::query`] requires,
-    /// so this mock is bound by the same grammar a real backend is.
+    /// [`topic_matches`] — the matcher a real backend must use, so the mock is
+    /// bound by the same grammar.
     ///
-    /// `QueryParams` stays ignored: the row-level filtering under test lives in
-    /// `AimDbQueryExt`, not here. The pattern does not, because a mock that
-    /// ignored it would leave the whole crate unable to tell the current
-    /// grammar from the prefix-glob one it replaced.
+    /// `QueryParams` stays ignored: row-level filtering is `AimDbQueryExt`'s
+    /// job. The pattern is not, or nothing here would notice the grammar.
     fn query<'a>(
         &'a self,
         record_pattern: &'a str,
@@ -98,8 +96,7 @@ async fn build_db(mock: Arc<MockBackend>) -> aimdb_core::AimDb {
 /// Shared fixture: four rows where rows at indices 1 and 3 cannot be
 /// deserialized as `SensorReading`.
 ///
-/// All four sit one segment below `sensor`, so `sensor.*` matches every one of
-/// them and the pattern never narrows what these tests see.
+/// All four sit one segment below `sensor`, so `sensor.*` matches every one.
 ///
 /// | idx | record_name | value                         | valid? |
 /// |-----|-------------|-------------------------------|--------|
@@ -341,10 +338,8 @@ fn rows_at_two_depths() -> Vec<StoredValue> {
     ]
 }
 
-/// The regression #201 was made for: `*` covers *exactly one* segment, so a
-/// `sensor.*` query must not reach `sensor.deep.nested`. Under the prefix-glob
-/// contract it did, which is what made one pattern mean two different things
-/// live and historically.
+/// The regression #201 was made for: `*` covers *exactly one* segment, so
+/// `sensor.*` must not reach `sensor.deep.nested`. The old prefix glob did.
 #[tokio::test]
 async fn a_single_segment_wildcard_does_not_descend() {
     let db = build_db(Arc::new(MockBackend {
@@ -364,9 +359,8 @@ async fn a_single_segment_wildcard_does_not_descend() {
     );
 }
 
-/// The counterpart that keeps the test above honest: `#` covers zero or more
-/// segments, so the row `sensor.*` excluded is reachable — the row is in the
-/// backend, and it is the pattern that decides.
+/// Keeps the test above honest: `#` reaches the row `sensor.*` excluded, so the
+/// exclusion is the pattern's doing and not a missing fixture.
 #[tokio::test]
 async fn a_multi_segment_wildcard_spans_every_depth() {
     let db = build_db(Arc::new(MockBackend {
@@ -387,8 +381,8 @@ async fn a_multi_segment_wildcard_spans_every_depth() {
     );
 }
 
-/// A key that is not dot-separated is one whole segment, so no wildcard can
-/// address it — the trap the persistence docs used to lead readers into.
+/// A key that is not dot-separated is one segment no wildcard can address —
+/// the trap the persistence docs used to lead readers into.
 #[tokio::test]
 async fn a_wildcard_cannot_partition_an_undotted_key() {
     let db = build_db(Arc::new(MockBackend {

--- a/aimdb-persistence/tests/query_skip_invalid.rs
+++ b/aimdb-persistence/tests/query_skip_invalid.rs
@@ -10,8 +10,8 @@ use std::time::Duration;
 
 use aimdb_core::AimDbBuilder;
 use aimdb_persistence::{
-    AimDbBuilderPersistExt, AimDbQueryExt, BoxFuture, PersistenceBackend, PersistenceError,
-    QueryParams, StoredValue,
+    topic_matches, AimDbBuilderPersistExt, AimDbQueryExt, BoxFuture, PersistenceBackend,
+    PersistenceError, QueryParams, StoredValue,
 };
 use aimdb_tokio_adapter::TokioAdapter;
 use serde::{Deserialize, Serialize};
@@ -29,7 +29,7 @@ struct SensorReading {
 }
 
 // ---------------------------------------------------------------------------
-// Mock backend — returns a fixed list of StoredValues regardless of params
+// Mock backend — a fixed list of StoredValues, narrowed by the record pattern
 // ---------------------------------------------------------------------------
 
 struct MockBackend {
@@ -46,15 +46,25 @@ impl PersistenceBackend for MockBackend {
         Box::pin(async { Ok(()) })
     }
 
-    /// Returns all pre-configured rows unconditionally (params ignored).
-    /// This keeps the mock trivial — the filtering under test lives in
-    /// `AimDbQueryExt`, not in the backend.
+    /// Returns the pre-configured rows the pattern matches, decided by
+    /// [`topic_matches`] — the matcher [`PersistenceBackend::query`] requires,
+    /// so this mock is bound by the same grammar a real backend is.
+    ///
+    /// `QueryParams` stays ignored: the row-level filtering under test lives in
+    /// `AimDbQueryExt`, not here. The pattern does not, because a mock that
+    /// ignored it would leave the whole crate unable to tell the current
+    /// grammar from the prefix-glob one it replaced.
     fn query<'a>(
         &'a self,
-        _record_pattern: &'a str,
+        record_pattern: &'a str,
         _params: QueryParams,
     ) -> BoxFuture<'a, Result<Vec<StoredValue>, PersistenceError>> {
-        let rows = self.rows.clone();
+        let rows: Vec<StoredValue> = self
+            .rows
+            .iter()
+            .filter(|row| topic_matches(record_pattern, &row.record_name))
+            .cloned()
+            .collect();
         Box::pin(async move { Ok(rows) })
     }
 
@@ -88,31 +98,34 @@ async fn build_db(mock: Arc<MockBackend>) -> aimdb_core::AimDb {
 /// Shared fixture: four rows where rows at indices 1 and 3 cannot be
 /// deserialized as `SensorReading`.
 ///
-/// | idx | record_name  | value                             | valid? |
-/// |-----|--------------|-----------------------------------|--------|
-/// | 0   | sensor::a    | `{"celsius": 21.5}`               | ✅     |
-/// | 1   | sensor::b    | `"not_an_object"`                 | ❌ wrong JSON type |
-/// | 2   | sensor::c    | `{"celsius": 99.0}`               | ✅     |
-/// | 3   | sensor::d    | `{"celsius": "not_a_number"}`     | ❌ wrong value type |
+/// All four sit one segment below `sensor`, so `sensor.*` matches every one of
+/// them and the pattern never narrows what these tests see.
+///
+/// | idx | record_name | value                         | valid? |
+/// |-----|-------------|-------------------------------|--------|
+/// | 0   | sensor.a    | `{"celsius": 21.5}`           | ✅     |
+/// | 1   | sensor.b    | `"not_an_object"`             | ❌ wrong JSON type |
+/// | 2   | sensor.c    | `{"celsius": 99.0}`           | ✅     |
+/// | 3   | sensor.d    | `{"celsius": "not_a_number"}` | ❌ wrong value type |
 fn mixed_rows() -> Vec<StoredValue> {
     vec![
         StoredValue {
-            record_name: "sensor::a".into(),
+            record_name: "sensor.a".into(),
             value: json!({"celsius": 21.5}),
             stored_at: 1_000,
         },
         StoredValue {
-            record_name: "sensor::b".into(),
+            record_name: "sensor.b".into(),
             value: json!("not_an_object"),
             stored_at: 2_000,
         },
         StoredValue {
-            record_name: "sensor::c".into(),
+            record_name: "sensor.c".into(),
             value: json!({"celsius": 99.0}),
             stored_at: 3_000,
         },
         StoredValue {
-            record_name: "sensor::d".into(),
+            record_name: "sensor.d".into(),
             value: json!({"celsius": "not_a_number"}),
             stored_at: 4_000,
         },
@@ -130,7 +143,7 @@ async fn query_latest_skips_invalid_rows_and_returns_valid_ones() {
     let db = build_db(Arc::new(MockBackend { rows: mixed_rows() })).await;
 
     let results: Vec<SensorReading> = db
-        .query_latest("sensor::*", 10)
+        .query_latest("sensor.*", 10)
         .await
         .expect("query_latest returned Err");
 
@@ -146,11 +159,11 @@ async fn query_latest_skips_invalid_rows_and_returns_valid_ones() {
     let celsius_values: Vec<f64> = results.iter().map(|r| r.celsius).collect();
     assert!(
         celsius_values.contains(&21.5),
-        "missing sensor::a (celsius=21.5)"
+        "missing sensor.a (celsius=21.5)"
     );
     assert!(
         celsius_values.contains(&99.0),
-        "missing sensor::c (celsius=99.0)"
+        "missing sensor.c (celsius=99.0)"
     );
 }
 
@@ -160,17 +173,17 @@ async fn query_latest_skips_invalid_rows_and_returns_valid_ones() {
 async fn query_latest_all_invalid_returns_empty_vec() {
     let all_bad = vec![
         StoredValue {
-            record_name: "sensor::x".into(),
+            record_name: "sensor.x".into(),
             value: json!(null),
             stored_at: 1_000,
         },
         StoredValue {
-            record_name: "sensor::y".into(),
+            record_name: "sensor.y".into(),
             value: json!([1, 2, 3]),
             stored_at: 2_000,
         },
         StoredValue {
-            record_name: "sensor::z".into(),
+            record_name: "sensor.z".into(),
             value: json!({"celsius": "oops"}),
             stored_at: 3_000,
         },
@@ -179,7 +192,7 @@ async fn query_latest_all_invalid_returns_empty_vec() {
     let db = build_db(Arc::new(MockBackend { rows: all_bad })).await;
 
     let results: Vec<SensorReading> = db
-        .query_latest("sensor::*", 10)
+        .query_latest("sensor.*", 10)
         .await
         .expect("query_latest returned Err");
 
@@ -196,12 +209,12 @@ async fn query_latest_all_invalid_returns_empty_vec() {
 async fn query_latest_all_valid_returns_all_rows() {
     let all_good = vec![
         StoredValue {
-            record_name: "sensor::a".into(),
+            record_name: "sensor.a".into(),
             value: json!({"celsius": 10.0}),
             stored_at: 1_000,
         },
         StoredValue {
-            record_name: "sensor::b".into(),
+            record_name: "sensor.b".into(),
             value: json!({"celsius": 20.0}),
             stored_at: 2_000,
         },
@@ -210,7 +223,7 @@ async fn query_latest_all_valid_returns_all_rows() {
     let db = build_db(Arc::new(MockBackend { rows: all_good })).await;
 
     let results: Vec<SensorReading> = db
-        .query_latest("sensor::*", 10)
+        .query_latest("sensor.*", 10)
         .await
         .expect("query_latest returned Err");
 
@@ -234,7 +247,7 @@ async fn query_range_skips_invalid_rows_and_returns_valid_ones() {
 
     // The mock ignores start/end — it always returns all rows.
     let results: Vec<SensorReading> = db
-        .query_range("sensor::*", 0, u64::MAX, None)
+        .query_range("sensor.*", 0, u64::MAX, None)
         .await
         .expect("query_range returned Err");
 
@@ -247,15 +260,15 @@ async fn query_range_skips_invalid_rows_and_returns_valid_ones() {
     );
 
     let celsius_values: Vec<f64> = results.iter().map(|r| r.celsius).collect();
-    assert!(celsius_values.contains(&21.5), "missing sensor::a");
-    assert!(celsius_values.contains(&99.0), "missing sensor::c");
+    assert!(celsius_values.contains(&21.5), "missing sensor.a");
+    assert!(celsius_values.contains(&99.0), "missing sensor.c");
 }
 
 /// `query_range` with all-invalid rows must return an empty `Vec`, not an error.
 #[tokio::test]
 async fn query_range_all_invalid_returns_empty_vec() {
     let all_bad = vec![StoredValue {
-        record_name: "sensor::x".into(),
+        record_name: "sensor.x".into(),
         value: json!("wrong"),
         stored_at: 5_000,
     }];
@@ -263,7 +276,7 @@ async fn query_range_all_invalid_returns_empty_vec() {
     let db = build_db(Arc::new(MockBackend { rows: all_bad })).await;
 
     let results: Vec<SensorReading> = db
-        .query_range("sensor::*", 0, u64::MAX, None)
+        .query_range("sensor.*", 0, u64::MAX, None)
         .await
         .expect("query_range returned Err");
 
@@ -276,17 +289,17 @@ async fn query_range_all_invalid_returns_empty_vec() {
 async fn query_range_all_valid_returns_all_rows() {
     let all_good = vec![
         StoredValue {
-            record_name: "sensor::a".into(),
+            record_name: "sensor.a".into(),
             value: json!({"celsius": 5.5}),
             stored_at: 1_000,
         },
         StoredValue {
-            record_name: "sensor::b".into(),
+            record_name: "sensor.b".into(),
             value: json!({"celsius": 6.6}),
             stored_at: 2_000,
         },
         StoredValue {
-            record_name: "sensor::c".into(),
+            record_name: "sensor.c".into(),
             value: json!({"celsius": 7.7}),
             stored_at: 3_000,
         },
@@ -295,7 +308,7 @@ async fn query_range_all_valid_returns_all_rows() {
     let db = build_db(Arc::new(MockBackend { rows: all_good })).await;
 
     let results: Vec<SensorReading> = db
-        .query_range("sensor::*", 0, u64::MAX, None)
+        .query_range("sensor.*", 0, u64::MAX, None)
         .await
         .expect("query_range returned Err");
 
@@ -304,5 +317,96 @@ async fn query_range_all_valid_returns_all_rows() {
         3,
         "expected 3 valid rows, got: {:?}",
         results
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests: the record-pattern grammar reaches the backend
+// ---------------------------------------------------------------------------
+
+/// Rows at two depths under `sensor.`, all valid for `SensorReading`, so that
+/// what a query returns is decided by the pattern alone.
+fn rows_at_two_depths() -> Vec<StoredValue> {
+    vec![
+        StoredValue {
+            record_name: "sensor.a".into(),
+            value: json!({"celsius": 1.0}),
+            stored_at: 1_000,
+        },
+        StoredValue {
+            record_name: "sensor.deep.nested".into(),
+            value: json!({"celsius": 2.0}),
+            stored_at: 2_000,
+        },
+    ]
+}
+
+/// The regression #201 was made for: `*` covers *exactly one* segment, so a
+/// `sensor.*` query must not reach `sensor.deep.nested`. Under the prefix-glob
+/// contract it did, which is what made one pattern mean two different things
+/// live and historically.
+#[tokio::test]
+async fn a_single_segment_wildcard_does_not_descend() {
+    let db = build_db(Arc::new(MockBackend {
+        rows: rows_at_two_depths(),
+    }))
+    .await;
+
+    let results: Vec<SensorReading> = db
+        .query_latest("sensor.*", 10)
+        .await
+        .expect("query_latest returned Err");
+
+    assert_eq!(
+        results,
+        vec![SensorReading { celsius: 1.0 }],
+        "`sensor.*` must match `sensor.a` only, never `sensor.deep.nested`"
+    );
+}
+
+/// The counterpart that keeps the test above honest: `#` covers zero or more
+/// segments, so the row `sensor.*` excluded is reachable — the row is in the
+/// backend, and it is the pattern that decides.
+#[tokio::test]
+async fn a_multi_segment_wildcard_spans_every_depth() {
+    let db = build_db(Arc::new(MockBackend {
+        rows: rows_at_two_depths(),
+    }))
+    .await;
+
+    let results: Vec<SensorReading> = db
+        .query_latest("sensor.#", 10)
+        .await
+        .expect("query_latest returned Err");
+
+    assert_eq!(
+        results.len(),
+        2,
+        "`sensor.#` must span both depths, got: {:?}",
+        results
+    );
+}
+
+/// A key that is not dot-separated is one whole segment, so no wildcard can
+/// address it — the trap the persistence docs used to lead readers into.
+#[tokio::test]
+async fn a_wildcard_cannot_partition_an_undotted_key() {
+    let db = build_db(Arc::new(MockBackend {
+        rows: vec![StoredValue {
+            record_name: "sensor::legacy".into(),
+            value: json!({"celsius": 3.0}),
+            stored_at: 1_000,
+        }],
+    }))
+    .await;
+
+    let results: Vec<SensorReading> = db
+        .query_latest("sensor.*", 10)
+        .await
+        .expect("query_latest returned Err");
+
+    assert!(
+        results.is_empty(),
+        "`sensor::legacy` is a single segment; no pattern over `sensor.` reaches it"
     );
 }


### PR DESCRIPTION
`PersistenceBackend::query` moved from a prefix glob to the MQTT-style
grammar subscriptions use, but the README still keyed every example with
`::` and queried it with `::*`. A wildcard is a whole dot-separated
segment, so `accuracy::vienna` is a single segment no pattern can
partition and `accuracy::*` is a literal key that matches nothing — a
reader copying the examples got zero rows and no error.

Migrate the example keys to dot-separated form, then fix the patterns over
them, and state the grammar once where the reader has to choose: `*` for a
known depth, `#` where it varies. `query_raw` takes `#` because it feeds
the AimX `record.query` handler, whose callers key at their own depth.


**Issue §6 — the out-of-scope `::` keys stay, deliberately.** The keys in
`examples/remote-access-demo/src/server.rs` and
`aimdb-wasm-adapter/tests/transform_join_integration_tests.rs` are unchanged.
They are exact-match only — the demo subscribes to one literal key
(`client.rs:179`) and exact lookup is separator-agnostic — and nothing in the
repo pairs a `::` key with a wildcard outside the historical CHANGELOG entries
and the superseded design 022. The `::` there qualifies a Rust type name rather
than addressing a topic, which is a coherent separate convention, not the same
mistake. Revisit if the demo ever grows a wildcard subscribe: those four
`server::*` records are a set under a common prefix, which is the shape that
would want one.

Closes #214
