### PR TITLE
docs(design): revise 052 with the verification findings

### DIFF
--- a/docs/design/052-runtime-neutral-connectors.md
+++ b/docs/design/052-runtime-neutral-connectors.md
@@ -1,7 +1,14 @@
 # 052 — Runtime-neutral connectors
 
-**Status:** proposal, 2026-09-02. No code changes; a design worked out from the
-question below, with the mechanism compile-checked on the pinned toolchain.
+**Status:** proposal, revised 2026-09-02 after verification against the tree
+and a working prototype (rustc 1.98.0, `88d9e12ae`). The layering is unchanged
+and the mechanism holds; what changed is that four gaps the first draft left
+open are now closed by code (§3.2, §5.1, §5.5, §5.6), and four factual errors
+are corrected (§2 citations, §8's call-site audit, acceptance criteria 2 and
+5). Passages marked **[verified]** were executed, not reasoned about;
+**[revised]** marks a claim the prototype disproved. The review record, the
+evidence, and the effort assessment live in
+[052 — Verification](052-verification.md).
 **Predecessors:** [033 — Unify Embassy connectors](033-M17-unify-connectors-drop-send.md)
 (the centralized Embassy spine this design generalizes),
 [051 — FreeRTOS portability assessment](051-freertos-portability-assessment.md)
@@ -54,8 +61,8 @@ Two observations that shape the design:
   owns the whole tunnelling lifecycle behind a `TunnelIo` trait with three
   methods; the two client files differ only in socket, channel, timer and
   select glue. Both ignore `RuntimeOps` and call their runtime clock directly
-  ([`embassy_client.rs:283`](../../aimdb-knx-connector/src/embassy_client.rs),
-  [`tokio_client.rs:691`](../../aimdb-knx-connector/src/tokio_client.rs)).
+  ([`embassy_client.rs:281`](../../aimdb-knx-connector/src/embassy_client.rs),
+  [`tokio_client.rs:221`](../../aimdb-knx-connector/src/tokio_client.rs)).
 - The serial Embassy half is already the target shape: it contributes a COBS
   `Framer` and rides `EmbassyConnection<Rd, Wr, F>` from the adapter, generic
   over `embedded_io_async::{Read, Write}`. That type, minus its `unsafe`, is
@@ -68,16 +75,20 @@ module each, generic over the traits, with no runtime `cfg` on the code path.
 
 ### 3.1 Core traits (`aimdb-core`, feature `connector-session`)
 
+**[verified]** — implemented in `aimdb-core/src/session/io.rs`; core still
+contains zero `unsafe` and still cross-compiles to `thumbv7em-none-eabihf`.
+
 ```rust
 /// An unframed, bidirectional byte stream. Sits *below* `Connection`
 /// (which is framed) so the connector keeps its framing and the adapter
-/// keeps its socket.
+/// keeps its socket. `Ok(0)` from `read` is EOF, as in both
+/// `embedded_io_async::Read` and `tokio::io::AsyncRead`.
 pub trait ByteStream {
     fn read<'a>(&'a mut self, buf: &'a mut [u8])
-        -> impl Future<Output = Result<usize, IoError>> + Send + 'a;
+        -> impl Future<Output = TransportResult<usize>> + Send + 'a;
     fn write_all<'a>(&'a mut self, buf: &'a [u8])
-        -> impl Future<Output = Result<(), IoError>> + Send + 'a;
-    fn flush(&mut self) -> impl Future<Output = Result<(), IoError>> + Send + '_;
+        -> impl Future<Output = TransportResult<()>> + Send + 'a;
+    fn flush(&mut self) -> impl Future<Output = TransportResult<()>> + Send + '_;
 }
 
 /// Produces streams: the client side. `host` is unresolved; name
@@ -85,22 +96,36 @@ pub trait ByteStream {
 pub trait StreamDialer {
     type Stream: ByteStream + Send;
     fn connect<'a>(&'a self, host: &'a str, port: u16)
-        -> impl Future<Output = Result<Self::Stream, IoError>> + Send + 'a;
+        -> impl Future<Output = TransportResult<Self::Stream>> + Send + 'a;
 }
 
-/// Produces streams: the server side.
+/// Produces streams: the server side. One accept at a time, matching
+/// `Listener::accept` and the `serve` loop — see §3.2 for why that does
+/// **not** cost the Embassy socket pool its concurrency.
 pub trait StreamListener {
     type Stream: ByteStream + Send;
     fn accept(&mut self)
-        -> impl Future<Output = Result<(Self::Stream, PeerInfo), IoError>> + Send + '_;
+        -> impl Future<Output = TransportResult<(Self::Stream, PeerInfo)>> + Send + '_;
 }
 
 /// Connectionless I/O for KNX/IP (and SNTP).
 pub trait Datagram {
     fn send_to<'a>(&'a mut self, buf: &'a [u8], to: core::net::SocketAddr)
-        -> impl Future<Output = Result<(), IoError>> + Send + 'a;
+        -> impl Future<Output = TransportResult<()>> + Send + 'a;
     fn recv_from<'a>(&'a mut self, buf: &'a mut [u8])
-        -> impl Future<Output = Result<(usize, core::net::SocketAddr), IoError>> + Send + 'a;
+        -> impl Future<Output = TransportResult<(usize, core::net::SocketAddr)>> + Send + 'a;
+    /// The real bound address, when the stack exposes one. Not incidental:
+    /// the KNX handshake advertises the client's own endpoint (HPAI), and
+    /// gateways that reject the NAT-style `0.0.0.0:0` form need this.
+    fn local_addr(&self) -> Option<core::net::SocketAddr>;
+}
+
+/// Binds `Datagram` sockets on demand, so a protocol task can rebind across
+/// reconnect cycles — which the KNX engine's `Action::ResetSocket` requires.
+pub trait DatagramBinder {
+    type Socket: Datagram + Send;
+    fn bind(&self, port: u16)
+        -> impl Future<Output = TransportResult<Self::Socket>> + Send + '_;
 }
 
 /// A non-allocating sleep. `RuntimeOps::sleep` is dyn and must box; this
@@ -113,49 +138,149 @@ pub trait Delay {
 /// adapter's `connector-io` module unchanged.
 pub trait Framer { /* encode / push_bytes / next_frame, as today */ }
 
+/// Builds a fresh `Framer` per connection. A blanket impl covers closures,
+/// so a caller writes `|| CobsFramer::new()`.
+pub trait FramerFactory { type Framer: Framer + Send; fn framer(&self) -> Self::Framer; }
+
 /// `Connection` over any `ByteStream` + `Framer`. This is
 /// `EmbassyConnection` without the `unsafe impl Send`.
-pub struct FramedConnection<S: ByteStream, F: Framer, const RC: usize, const WC: usize> { /* … */ }
+pub struct FramedConnection<S, F, const RC: usize = 256, const WC: usize = 256> { /* … */ }
 impl<S: ByteStream + Send, F: Framer + Send, …> Connection for FramedConnection<S, F, …> { /* … */ }
 
 /// Adapt a `StreamDialer` / `StreamListener` plus a framer factory into
 /// the existing `Dialer` / `Listener`, so `run_client` / `serve` are untouched.
-pub struct FramingDialer<D, FF> { /* … */ }
-pub struct FramingListener<L, FF> { /* … */ }
+pub struct FramingDialer<D, FF, const RC: usize, const WC: usize> { /* … */ }
+pub struct FramingListener<L, FF, const RC: usize, const WC: usize> { /* … */ }
+
+/// The §5.5 cell, in core so no connector hand-rolls one: `Send + Sync`
+/// for any `T: Send`, with no `unsafe`.
+pub struct OneShot<T> { /* spin::Mutex<Option<T>> */ }
 ```
 
 All futures are return-position `impl Future … + Send`. That one decision is
 what makes the design zero-cost; §5.1 explains why.
 
+Three details the prototype settled:
+
+- **No new error type.** The sketch had an `IoError`; the traits use the
+  existing `TransportResult`/`TransportError`, so nothing converts at the
+  `Connection` boundary. `IoError` remains as an alias.
+- **`ByteStream` is unsplit** — one value with `&mut self` on both directions,
+  not `Rd`/`Wr` halves like today's `EmbassyConnection`. That is what lets it
+  wrap an owned `embassy_net::tcp::TcpSocket`, whose `split()` yields only
+  *borrowed* halves while `Connection` must own the socket — the exact reason
+  [`embassy_transport.rs`](../../aimdb-tcp-connector/src/embassy_transport.rs)
+  gives for not reusing `connector-io` today. It costs nothing: `Connection`'s
+  own `recv`/`send` already take `&mut self`, so reads and writes were already
+  serialized.
+- **`Datagram` grew two members** over the first sketch (`local_addr`, and the
+  `DatagramBinder` beside it). Without them a unified KNX task would silently
+  downgrade every Tokio deployment to the NAT-style HPAI and lose the
+  engine's socket-reset. See §5.6.
+
 ### 3.2 Adapters
+
+**[verified]** — `aimdb-tokio-adapter/src/net.rs` and
+`aimdb-embassy-adapter/src/net.rs`, both behind a `net` feature.
 
 - **`aimdb-tokio-adapter`**, new feature `net`: `TokioNet::tcp()` implementing
   `StreamDialer` over `tokio::net::TcpStream`, `TokioNet::listen(addr)` for
-  `StreamListener`, `TokioNet::udp(bind)` for `Datagram`, and `Delay` over
-  `tokio::time::sleep`. Opening a serial device with `tokio-serial` stays in the
+  `StreamListener`, `TokioNet::udp(bind)` for `Datagram`/`DatagramBinder`, and
+  `Delay` over `tokio::time::sleep`. Every future is a plain `async fn` and the
+  module contains **no `unsafe`** — the compiler discharges the `+ Send` the
+  traits declare. Opening a serial device with `tokio-serial` stays in the
   serial connector under `std`; that dependency does not belong in the adapter.
 - **`aimdb-embassy-adapter`**: `EmbassyNet::tcp(stack, rx, tx)`,
   `EmbassyNet::listen::<N>(stack, endpoint, rx[N], tx[N])` (the socket-slot pool
-  moves here from [`aimdb-tcp-connector/src/embassy_transport.rs`](../../aimdb-tcp-connector/src/embassy_transport.rs)
-  unchanged), `EmbassyNet::udp(stack, …)`, `EmbassyUart::split(rx, tx)`, and
-  `Delay` returning `embassy_time::Timer`. Each stream/datagram newtype is
+  moves here from [`aimdb-tcp-connector/src/embassy_transport.rs`](../../aimdb-tcp-connector/src/embassy_transport.rs)),
+  `EmbassyNet::udp(stack, …)`, `EmbassyUart::split(rx, tx)`, and `Delay`
+  returning `embassy_time::Timer`. Each stream/datagram newtype is
   `unsafe impl Send` and wraps the inner future in `SendFutureWrapper`. The
   `unsafe` stays exactly where design 033 put it. `NetStack` construction moves
   inside these constructors, so it leaves user and connector code.
-- **A future `aimdb-freertos-adapter`** implements the same five traits over
-  lwIP or FreeRTOS+TCP. lwIP handles are plain integers, so its types are
-  `Send` naturally and need no wrapper at all.
+- **A future `aimdb-freertos-adapter`** implements the same traits over lwIP or
+  FreeRTOS+TCP. lwIP handles are plain integers, so its types are `Send`
+  naturally and need no wrapper at all.
+
+#### The accept pool: `StreamListener` is enough, but the pool must be reshaped
+
+**[revised]** — §6 of the first draft said the N-socket pool "moves into the
+adapter unchanged". It moves *reshaped*, and the reshaping is the point.
+
+The worry was that a single-shot `accept(&mut self)` can only hold one socket
+in `accept()`, so an `N`-socket pool driven by core's serial `serve` loop would
+collapse to one pending listener. Reading `embassy-net` settles it:
+`TcpSocket::accept` is a **synchronous** `s.listen(endpoint)` followed by a
+bare `poll_fn` that waits for the state to leave
+`Listen`/`SynSent`/`SynReceived`. Two consequences:
+
+1. Dropping an `accept()` future does **not** un-listen the socket.
+2. But *re-entering* `accept()` on a socket that is already listening is
+   `InvalidState`, so a pool that rebuilds its futures each call must
+   `abort()` first — and that abort is what takes the socket out of `LISTEN`.
+
+`EmbassyNet::listen::<N>` therefore **stores** one accept future per slot and
+consumes only the one that completes. The other `N-1` stay pending and
+untouched, still in `LISTEN`. Nothing is ever cancelled, and no socket leaves
+`LISTEN` between calls — strictly better than today's behaviour, which has an
+`abort()`/re-`accept()` window.
+
+`aimdb-tcp-connector/tests/neutral_pool.rs` proves both halves over the two
+crossover-wired `embassy-net` stacks the existing loopback smoke uses, driven
+in exactly the shape `serve` accepts in:
+
+| Test | Result |
+|---|---|
+| `pool_keeps_every_slot_listening_between_accepts` | A connects and round-trips; **then**, while the server sits between accepts, B dials, connects and round-trips |
+| `naive_pool_loses_the_syn_that_arrives_between_accepts` | Same scenario against a rebuild-and-cancel pool: B's dial is refused with `TransportError::Io`, asserted |
+
+The second is what makes the first a finding rather than a coincidence, and it
+is a live regression guard: if embassy-net's cancellation semantics ever
+change, it says the stored-accept design can be simplified.
+
+#### Sockets and clock must stay separable features
+
+**[verified]** — found by building, not reading. Making the adapter's `net`
+feature imply `embassy-time` turns on the workspace's `defmt-timestamp-uptime`,
+which defines `_defmt_timestamp` and collides with the `defmt::timestamp!`
+every host test binary must supply (`duplicate symbol: _defmt_timestamp`). So
+`net` covers sockets only, and `EmbassyDelay` is gated on `embassy-time`
+separately.
 
 ### 3.3 Connectors
 
 | Crate | Becomes | Deleted |
 |---|---|---|
 | `aimdb-tcp-connector` | `framing.rs` + `TcpClient::new(dialer)` / `TcpServer::new(listener)` generic over the traits | `tokio_transport.rs`, `embassy_transport.rs` |
-| `aimdb-serial-connector` | `framing.rs` + `SerialClient::new(stream)` / `SerialServer::new(stream)` generic over `ByteStream`; the `tokio-serial` open helper stays under `std` | `embassy_transport.rs`, most of `tokio_transport.rs` |
-| `aimdb-knx-connector` | `tunnel.rs` + one `connection_task<U: Datagram, T: Delay>` | `tokio_client.rs`, `embassy_client.rs` |
+| `aimdb-serial-connector` | `neutral.rs` (COBS `Framer` + one `ByteStream` per byte source) + sugar; the `tokio-serial` open helper stays under `std` | `embassy_transport.rs`, most of `tokio_transport.rs` |
+| `aimdb-knx-connector` | `tunnel.rs` + one `connection_task<B: DatagramBinder, D: Delay>` | `tokio_client.rs`, `embassy_client.rs` |
 | `aimdb-mqtt-connector` | One `MqttConnector` type with two backends: `Native` (`rumqttc`, `std`) and `Embedded<N: StreamDialer + Delay>` (`mountain-mqtt` over `handle_messages`, as `embassy_tls.rs` already does) | `embassy_client.rs`'s stack plumbing; `tokio_client.rs` shrinks to the backend |
 | `aimdb-uds-connector` | Unchanged (std-only by nature); could be `FramedConnection<…, NdjsonFramer>` for uniformity | — |
 | `aimdb-websocket-connector` | Unchanged (axum, std-only) | — |
+
+**[verified] for serial.** `aimdb-serial-connector/src/neutral.rs` is the
+shape: one `CobsFramer` written against core's `Framer`, one `ByteStream` per
+byte source, and core's `FramedConnection` doing the rest. It needs **no**
+`aimdb-tokio-adapter` dependency — the manifest deliberately avoids one — and
+no `tokio/net`: `tokio` for `io-util` alone is enough for a single generic impl
+over `AsyncRead + AsyncWrite` that covers `SerialStream` and the
+`tokio::io::duplex()` pipe the tests use alike. `tests/neutral_framed.rs` runs
+it under `--features tokio-runtime` (pointedly *not* `_test-tokio`, so no
+adapter is linked), covering round-trip, frame boundaries across a payload
+larger than `WRITE_CHUNK`, EOF-on-close as `Ok(None)`, and the boxed
+`dyn Connection` crossing a `tokio::spawn`. A companion type assertion
+compiles the *same* `FramedConnection<_, CobsFramer, _, _>` over
+`embedded-io-async` halves on `thumbv7em`, so "one connector module, no runtime
+`cfg` on the code path" is enforced by the compiler rather than asserted.
+
+**[verified] for KNX.** `aimdb-knx-connector/src/neutral.rs` is the single
+`connection_task`, generic over `DatagramBinder + Delay`, compiling for
+Embassy on `thumbv7em` and for Tokio from one body. Two tests hold it to the
+contract that matters: `unified_task_is_boxable_as_the_runners_send_future`
+(the `Pin<Box<dyn Future + Send + 'static>>` that `ConnectorBuilder::build`
+returns) and `unified_task_advertises_the_real_local_endpoint`, which drives it
+against a real UDP gateway and asserts the CONNECT_REQUEST's control HPAI
+carries the socket's actual bound address rather than `0.0.0.0:0`.
 
 ## 4. The first cut, and what it cost
 
@@ -210,12 +335,38 @@ This was compile-checked on rustc 1.98.0 with a `!Send` socket standing in for
 `SendFutureWrapper`, a Tokio-style `async fn` impl, a generic framed connection,
 and a generic protocol task returned as the runner's `Send + 'static` boxed
 future. The adapter's `EmbassySinkRaw` at
-[`connectors.rs:75`](../../aimdb-embassy-adapter/src/connectors.rs) already
+[`connectors.rs:74`](../../aimdb-embassy-adapter/src/connectors.rs) already
 uses this return-position shape, minus the `Send` bound.
 
 The trait is not dyn-compatible. That is fine: connectors are generic
-(`TcpServer<L>`, `KnxConnector<U, T>`), and the dyn boundary stays where it is
+(`TcpServer<L>`, `KnxConnector<B, D>`), and the dyn boundary stays where it is
 today, at `Box<dyn Connection>` per frame.
+
+**[verified], and it applies one layer up too.** Both halves of the asymmetry
+are now real code: the Tokio adapter's `ByteStream` impls are plain `async fn`s
+the compiler discharges, and the Embassy adapter's return
+`SendFutureWrapper(...)` over `!Send` socket futures.
+
+The prototype also found a *second* instance of the same problem, which the
+first draft missed: `TunnelIo::send` — the KNX connector's own three-method I/O
+trait — is a bare `async fn`, so `drain_actions`, which is generic over
+`impl TunnelIo`, produces a future that is not provably `Send`. A generic
+connection task therefore cannot be boxed as the runner requires. A probe
+reproduced it exactly, with rustc prescribing the fix verbatim:
+
+```
+error[E0277]: future cannot be sent between threads safely
+help: `Send` can be made part of the associated future's guarantees for all
+      implementations of `tunnel::TunnelIo::send`
+-     async fn send(&mut self, frame: &[u8]) -> bool;
++     fn send(&mut self, frame: &[u8]) -> impl Future<Output = bool> + Send;
+```
+
+Applied, with `tunnel::tests::drain_actions_future_is_send_in_generic_code` as
+the guard, and the two existing impls then split along exactly the predicted
+line. The general rule: **every trait a generic connector task calls through
+needs the bound on its return type**, not just the ones in §3.1. §11 carries
+this as its own step.
 
 ### 5.2 Channels: keep `embassy-sync`, it never depended on the executor
 
@@ -242,6 +393,36 @@ allocation at build, several connectors per host process, consistent with
 design 037's allocate-at-build model). Both are zero per message. The Tokio
 `with_command_queue_size` becomes a const generic either way.
 
+**[revised] — on std this is a link-time obligation, not just a test detail.**
+A std binary using `Channel<CriticalSectionRawMutex, _, N>` does not link:
+
+```
+rust-lld: error: undefined symbol: _critical_section_1_0_acquire
+rust-lld: error: undefined symbol: _critical_section_1_0_release
+```
+
+and `NoopRawMutex` cannot substitute — it is `!Sync`
+(`*mut () cannot be shared between threads safely`), so it cannot back a shared
+channel at all. `CriticalSectionRawMutex` is the only `Sync` raw mutex
+`embassy-sync` offers, so the choice is forced and the obligation comes with
+it.
+
+It is fully mitigable in one line, and the connector must carry it rather than
+push it downstream: the KNX crate's `tokio-runtime` feature enables
+`critical-section/std` itself, so no std user of the connector ever sees the
+error. `neutral::tests::shared_embassy_channels_carry_telegrams_on_tokio` then
+runs this section's claim rather than asserting it — the unified task on Tokio,
+against a real UDP gateway, carrying a full handshake, an inbound telegram with
+its ACK, and an outbound command, all through the same `embassy_sync` channel
+types the MCU uses.
+
+One caveat to state explicitly: the workspace `[patch.crates-io]`-es
+`embassy-sync` to a local checkout, and that patch already blocks publishing
+`aimdb-embassy-adapter` (008 §6). Putting `embassy-sync` on the std side of a
+connector widens that constraint's reach. The KNX channel needs none of the
+patched APIs, so a published build resolves the crates.io version — but it is
+an assumption, not an accident.
+
 MQTT's embedded backend keeps the `NoopRawMutex` channels that
 `mountain-mqtt-embassy`'s `handle_messages` dictates; they belong to that
 backend, not to the neutral layer.
@@ -256,8 +437,10 @@ and allocates nothing. Tokio returns `tokio::time::Sleep`.
 
 ### 5.4 Select: `embassy-futures` is dependency-free
 
-`embassy-futures` has no dependencies beyond optional `defmt`/`log` (upstream
-manifest, checked). Its `select3` is what the KNX Embassy loop uses now, and it
+**[verified]** — `embassy-futures` 0.1.2 has an empty `[dependencies]` section
+beyond optional `defmt`/`log` (manifest read from the resolved registry copy),
+and it is now an unconditional dependency of the KNX connector, driving the
+unified loop on both runtimes with no effect on the std graph. Its `select3` is what the KNX Embassy loop uses now, and it
 runs unchanged on Tokio. `futures_util::select_biased`, which core's client
 engine already uses in `no_std`, is the other zero-cost option. Either works.
 
@@ -268,7 +451,66 @@ must be taken through interior mutability. `spin::Mutex<Option<L>>` with
 `L: Send` is `Send + Sync` without `unsafe`, replacing the adapter's
 `OneShotCell` and its `unsafe impl Sync`. Taken once at build; no cost after.
 
-### 5.6 Cost table, revised
+**[verified]** — it lives in core as `session::OneShot<T>`, so no connector
+hand-rolls one, and `spin` was already an `aimdb-core` dependency, so the
+mechanism costs nothing to adopt. A compile-time assertion in core holds
+`OneShot<T>: Send + Sync` for `T: Send`, so a regression surfaces there rather
+than in a connector.
+
+**The `T: Send` bound is the whole contract, and it bites.** `TlsOptions`
+carries `rng: &'static mut dyn CryptoRngCore` — a trait object with no `Send`
+bound, so the struct is `!Send`, so `OneShot` cannot hold it, so
+`aimdb-mqtt-connector` cannot drop the `unsafe impl Send`/`Sync` on its
+`TlsSlot`. That collides head-on with §6's promise that "`TlsOptions` keeps its
+signature" and with acceptance criterion 2. A type assertion on the real struct
+confirmed it rather than leaving it to argument:
+
+```
+error[E0277]: `(dyn CryptoRngCore + 'static)` cannot be sent between threads safely
+note: required because it appears within the type `TlsOptions`
+```
+
+**[revised]** — the signature is what gives. The fix is one `+ Send` on the
+trait object (`&'static mut (dyn CryptoRngCore + Send)`), which every concrete
+CSPRNG a caller passes already satisfies; the whole `embassy-tls` path still
+cross-compiles to `thumbv7em`, so `embedded-tls` accepts it. With that,
+`TlsSlot` becomes an alias for `OneShot<TlsOptions>` and
+**`aimdb-mqtt-connector` carries zero `unsafe impl`s** (was two). §6 is amended
+accordingly: `TlsOptions` keeps its *shape*, and gains a `Send` bound on its
+RNG.
+
+This is a **public, breaking** change to `TlsOptions::new`, whose only call
+site is `examples/embassy-mqtt-connector-demo` under `--features tls` — a
+configuration `make examples` does **not** build (it builds default features
+only), so CI will not catch a break there. The demo passes
+`&'static mut Rng<'static, peripherals::RNG>`, and embassy peripheral types
+should be `Send`, so no source change is expected; it wants either a human
+check on hardware or a CI job that builds that feature.
+
+The rule generalises: wherever a connector today reaches for `unsafe impl Send`
+on a moved-in resource, `OneShot` will refuse it, and the refusal is the signal
+to fix the type rather than to force the bound.
+
+### 5.6 Sockets that must be rebound: `DatagramBinder`, not a moved-in socket
+
+**[revised]** — the first draft handed the KNX task a `Datagram`. It cannot be
+one: both hand-written clients drop and re-create the UDP socket on every
+reconnect cycle, because that is what the engine's `Action::ResetSocket` means.
+A moved-in socket has nothing to rebind.
+
+So the task takes a `DatagramBinder` and binds per cycle. Both runtimes
+implement it without contortion: Tokio binds a fresh `UdpSocket`; Embassy
+`close()`s and re-`bind()`s the *same* socket, since `embassy_net::udp::UdpSocket`
+owns its buffers for its whole lifetime and recreating it would strand them.
+
+The same section covers `local_addr` (§3.1). The Tokio half reads it after bind
+and feeds `LocalEndpoint::Explicit`, which gateways that reject the NAT-style
+`0.0.0.0:0` HPAI require; unifying without it would have silently downgraded
+every Tokio deployment. Embassy can answer it too — the socket's bound port
+plus the stack's IPv4 config — so unification *fixes* the Embassy half, which
+never set the explicit endpoint at all.
+
+### 5.7 Cost table, revised
 
 | Cost in the first cut | Replacement | MCU delta vs today |
 |---|---|---|
@@ -276,8 +518,15 @@ must be taken through interior mutability. `spin::Mutex<Option<L>>` with
 | `async-channel` | `embassy_sync::channel::Channel<CriticalSectionRawMutex, …>` | None; KNX already uses it |
 | `RuntimeOps::sleep` per iteration | `Delay` returning `embassy_time::Timer` | None |
 | `futures_util::select_biased` | `embassy_futures::select` or keep | None |
-| `OneShotCell` `unsafe impl Sync` | `spin::Mutex<Option<L>>` in core | None after build |
+| `OneShotCell` `unsafe impl Sync` | `session::OneShot<T>` in core | None after build |
 | Force-`Send` | `SendFutureWrapper` inside adapter impls | None; transparent newtype |
+
+Two costs the prototype added to the ledger, neither on the MCU:
+
+| Cost | Where | Delta |
+|---|---|---|
+| `critical-section` impl must be linked | std binaries only (§5.2) | None on MCU — the HAL already provides one |
+| One pending accept future per idle socket slot | Embassy TCP listener (§3.2) | `N` small futures held in the listener instead of rebuilt per call; no heap churn, and it removes the `abort()`/re-`accept()` window |
 
 ## 6. What stays platform-specific, by necessity
 
@@ -290,12 +539,14 @@ must be taken through interior mutability. `spin::Mutex<Option<L>>` with
   through the embedded backend. The adapter's stream newtype implements
   `embedded_io_async::{Read, Write}` by delegation as well, so `mountain-mqtt`
   and `embedded-tls` see the type they expect.
-- **TLS time source.** `TlsOptions` keeps its signature and `embedded-tls`
-  layers over any `ByteStream`. The SNTP task becomes generic over `Datagram`,
+- **TLS time source.** `TlsOptions` keeps its shape — gaining only a `Send`
+  bound on its RNG, per §5.5 — and `embedded-tls` layers over any `ByteStream`. The SNTP task becomes generic over `Datagram`,
   but the wall-clock anchor it sets (`EmbassyAdapter::set_unix_time`) has no
   neutral home yet, so the `mqtts://` path stays Embassy-only until it does.
 - **Embassy TCP accept pool.** The N-socket slot recycling moves into the
-  adapter unchanged. It is the adapter's problem to solve, not the connector's.
+  adapter — **reshaped**, not unchanged: it stores one pending accept per slot
+  rather than rebuilding them per call (§3.2). Either way it is the adapter's
+  problem to solve, not the connector's.
 - **WebSocket and UDS** are std-only by nature.
 
 ## 7. User-facing result
@@ -380,6 +631,14 @@ What moved:
 - **Two new statics.** The TCP socket buffers are the only genuinely new lines
   on the Embassy side. They replace buffers `mountain-mqtt-embassy` allocated
   out of sight, so RAM use is unchanged and now visible.
+- **The TRNG must be `Send`.** `TlsOptions::new` now takes
+  `&'static mut (dyn CryptoRngCore + Send)` (§5.5). The call above is unchanged
+  textually — `embassy_stm32::rng::Rng` satisfies it — but a caller passing an
+  RNG that does not will see the error at this line rather than a stray
+  `unsafe impl` deep in the connector, which is the point.
+- **The serial UART goes through the adapter.** `SerialServer::new(rx, tx)`
+  becomes `SerialServer::new(EmbassyUart::split(rx, tx))`, so the connector
+  names no `embedded-io-async` halves of its own.
 
 Behind the scenes the type is `MqttConnector<Embedded<N>>` for the
 `.transport(...)` path and `MqttConnector<Native>` for the rumqttc path.
@@ -397,21 +656,38 @@ No connector crate is touched to get there.
 
 ## 8. API impact, quantified
 
-No tool or library crate constructs these connectors. The call sites are all
-examples:
+**[revised]** — the first draft said "no tool or library crate constructs these
+connectors". [`aimdb-codegen`](../../aimdb-codegen/src/rust.rs) does: it emits
+`MqttConnector::new(&mqtt_url)` (lines 268, 1421) and
+`KnxConnector::new(&knx_gateway)` (lines 269, 1424) into generated user code.
+MQTT is unaffected — the `Native` backend keeps that signature — but **KNX is
+not**: once `KnxConnector` is generic over `DatagramBinder + Delay`, the
+generated line must carry a transport. So `aimdb-codegen` changes, and
+`make codegen-drift` must be re-baselined.
 
-- `embassy-knx-connector-demo`, `embassy-mqtt-connector-demo`,
-  `embassy-serial-connector-demo`
-- `tokio-knx-connector-demo`, `tokio-mqtt-connector-demo`
-- the four `weather-mesh-demo` binaries
+The remaining call sites are examples and two crate-local demos:
+
+| Site | Change |
+|---|---|
+| `embassy-knx-connector-demo`, `embassy-mqtt-connector-demo`, `embassy-serial-connector-demo` | one line each: the stack goes to the adapter |
+| `weather-station-gamma` (Embassy MQTT) | one line |
+| `tokio-knx-connector-demo` | gains a transport argument |
+| `tokio-mqtt-connector-demo`, `weather-hub`, `weather-station-alpha`, `weather-station-beta` | **no change** — the Tokio MQTT path is untouched |
+| [`aimdb-tcp-connector/examples/tcp_demo.rs`](../../aimdb-tcp-connector/examples/tcp_demo.rs), [`aimdb-serial-connector/examples/serial_demo.rs`](../../aimdb-serial-connector/examples/serial_demo.rs) | the string-sugar change below — these are the two the first draft's list omitted |
+| `aimdb-knx-connector/tests/topic_provider_tests.rs`, `aimdb-mqtt-connector/tests/{link_ext,topic_provider}_tests.rs` | instantiation only |
 
 The Embassy sites already pass a stack and static buffers explicitly, so
-wrapping those in an adapter call is a one-line change. The Tokio MQTT sites do
-not change. The Tokio TCP/serial string sugar (`TcpServer::new("127.0.0.1:7001")`)
-becomes `TcpServer::new(TokioNet::listen("127.0.0.1:7001")?)`. Preserving the
+wrapping those in an adapter call is a one-line change. The Tokio TCP/serial
+string sugar (`TcpServer::new("127.0.0.1:7001")`) becomes
+`TcpServer::new(TokioNet::listen("127.0.0.1:7001").await?)`. Preserving the
 string form would require the connector to depend on `aimdb-tokio-adapter`,
 which the serial connector's manifest deliberately avoids today; accept the
 one-line change instead.
+
+Two API changes beyond the constructors, both covered above: `TlsOptions::new`
+gains `+ Send` on its RNG (§5.5, public and breaking), and `TunnelIo::send`
+gains `+ Send` on its return type (§5.1, `pub(crate)`, so invisible outside
+the crate).
 
 Design 012 (connector development guide) needs its Tokio and Embassy
 implementation sections rewritten around the traits in §3.1.
@@ -427,37 +703,62 @@ implementation sections rewritten around the traits in §3.1.
 
 ## 10. Acceptance criteria
 
+Two of the first draft's six were unsound as written; both are corrected here.
+
 1. `cargo check -p aimdb-core --no-default-features --features alloc,connector-session,remote --target thumbv7em-none-eabihf`
    passes with the new traits and `FramedConnection`; core still contains zero
-   `unsafe`.
-2. Every `unsafe impl Send`/`Sync` in the workspace remains inside
-   `aimdb-embassy-adapter`. Connector crates contain none.
+   `unsafe`. **[verified] — met.**
+2. **[revised]** Every `unsafe impl Send`/`Sync` **in the connector crates and
+   the two adapters** stays inside `aimdb-embassy-adapter`; the connector
+   crates contain none. The original wording said "in the workspace", which is
+   false today and after the change: `aimdb-wasm-adapter` carries 16
+   (`buffer.rs` 9, `ws_bridge.rs` 4, `time.rs` 3) and `aimdb-bench/src/alloc.rs`
+   one, none of them in scope here. Progress: MQTT is at zero (§5.5), serial was
+   already at zero, and the TCP connector's remaining three live in the module
+   this design deletes.
 3. `aimdb-tcp-connector`, `aimdb-serial-connector` and `aimdb-knx-connector`
-   have no `tokio_*` / `embassy_*` source modules and no `embassy-net`,
-   `embassy-time` or `tokio` dependency except the serial connector's
-   `tokio-serial` open helper under `std`.
+   have no `tokio_*` / `embassy_*` source modules and no `embassy-net` or
+   `embassy-time` dependency. The serial connector keeps `tokio-serial` for its
+   open helper **and `tokio` for `io-util`** — one generic `ByteStream` impl
+   over `AsyncRead + AsyncWrite`, with no `tokio/net` and no adapter
+   dependency (§3.3). The KNX connector keeps `embassy-sync` and
+   `embassy-futures`, which are executor-independent by §5.2/§5.4.
 4. The existing host tests pass unchanged in behaviour: TCP loopback
    (`_test-embassy-loopback`), serial duplex-pipe tests, the KNX fake-gateway
    tests, and the MQTT `build_internal` tests, each now instantiated through
-   the adapter's transport types.
-5. `examples/embassy-bench-stm32h5` shows no change in cycles per message or
-   in allocations after `build()`: the connector path does not touch the
-   buffer hot path, and no per-message allocation was introduced (§5.6).
+   the adapter's transport types. Note the MQTT ones are Tokio-only unit tests
+   inside `tokio_client.rs`; **neither Embassy MQTT path has a host test at
+   all**, which is why criterion 6 matters more than it looks.
+5. **[revised]** The original — "`examples/embassy-bench-stm32h5` shows no
+   change in cycles per message or allocations after `build()`" — is vacuous:
+   that example depends only on `aimdb-core`, `aimdb-embassy-adapter` and
+   `aimdb-bench`, with no connector crate in its graph, so it will show no
+   change whatever this design does. Replace it with an allocation-counting
+   test that actually exercises a connector path, asserting zero allocations
+   per message after `build()`.
 6. The embedded MQTT backend builds and connects on the host over
-   `TokioNet::tcp()` (the parity line in §7.1).
+   `TokioNet::tcp()` (the parity line in §7.1). This is the only host coverage
+   either Embassy MQTT path would ever get, so **build it first**, not last
+   (§11).
 
 ## 11. Sequencing
 
-1. Core: `ByteStream`, `StreamDialer`, `StreamListener`, `Datagram`, `Delay`,
-   `Framer`, `FramedConnection`, `FramingDialer`/`FramingListener`. Lift the
-   `Framer` and framed connection out of the adapter's `connector-io` module.
-2. Adapters: `TokioNet` (feature `net`) and `EmbassyNet`/`EmbassyUart`, moving
-   the Embassy TCP slot pool in. Keep the old spine types for one release with
-   deprecation notes.
-3. TCP connector as the pilot: it exercises every new trait except `Datagram`.
-4. Serial, then KNX (adds `Datagram` and `Delay`).
-5. MQTT: split into `Native` and `Embedded<N>` backends; route the plain
-   embedded path through `handle_messages`.
-6. Examples, design 012, CHANGELOG; connector crates bump major.
-7. Then the FreeRTOS adapter, per design 051 §8 step 3, with the network
-   connectors coming along for free.
+Steps 1, 2 and the load-bearing parts of 4 are prototyped; the rest is not.
+Effort, recalibrated against that prototype, is in
+[052 — Verification](052-verification.md) §6: **4–6 weeks** for one engineer
+fluent in these crates, with the risk now concentrated almost entirely in
+step 6.
+
+| # | Step | State |
+|---|---|---|
+| 1 | Core: the §3.1 traits, `FramedConnection`, `FramingDialer`/`FramingListener`, `OneShot`. Lift the `Framer` and framed connection out of the adapter's `connector-io` module. | **done** |
+| 2 | Adapters: `TokioNet` (feature `net`) and `EmbassyNet`/`EmbassyUart`, moving the Embassy TCP slot pool in and reshaping it per §3.2. Keep the old spine types for one release with deprecation notes. | **done** |
+| 3 | Add `+ Send` to the return type of every trait a generic connector task calls through — `TunnelIo::send` is the one the audit missed (§5.1). Cheap, but it gates step 5. | **done** |
+| 4 | TCP connector as the pilot: it exercises every new trait except `Datagram`. Migrate `embassy_loopback` onto the adapter's transports. | not started; the adapter side it depends on is done |
+| 5 | Serial, then KNX (adds `Datagram`, `DatagramBinder` and `Delay`). | framing, streams and the unified KNX task **done**; connector sugar, channel wiring, and deleting the four runtime modules remain |
+| 6 | MQTT: split into `Native` and `Embedded<N>` backends; route the plain embedded path through `handle_messages`. **Build acceptance 6 first** — it is the only host coverage this path will have, and moving off `run_with_subscriptions` means re-implementing the reconnect-and-resubscribe loop `mountain-mqtt-embassy` owns today, which is behaviour, not plumbing. | not started |
+| 7 | Examples, `aimdb-codegen` + `make codegen-drift` re-baseline (§8), design 012, CHANGELOGs; connector crates bump major. | not started |
+| 8 | Then the FreeRTOS adapter, per design 051 §8 step 3, with the network connectors coming along for free. | unblocked once 1–2 land |
+
+Steps 1–3 are purely additive — nothing consumes the new code yet — so they
+carry no regression risk and can land ahead of the connector work.

--- a/docs/design/052-verification.md
+++ b/docs/design/052-verification.md
@@ -1,0 +1,325 @@
+# 052 — Verification against the codebase, and effort assessment
+
+**Status:** review + prototype, 2026-09-02. Verifies
+[052 — Runtime-neutral connectors](052-runtime-neutral-connectors.md) against
+the tree at `58c1951`, on the pinned toolchain (rustc 1.98.0, `88d9e12ae`).
+**Verdict:** the architecture is sound and the core mechanism is real — it
+compile-checks exactly as claimed. Four factual errors and four open design
+gaps were found; **all four gaps are now closed with working code** (§3), not
+with argument, and every correction has been folded back into design 052
+itself. Effort, recalibrated against the prototype: **4–6 weeks** for one
+engineer already fluent in the crates.
+
+Every claim below that says "verified" or "answered" was executed. The
+prototype lives on `claude/design-doc-52-verify-1lsexa` and is **not** on
+`main`: this document and the revised design are merged ahead of it, so the
+findings are not stranded behind an unmerged change. It is ~2 300 lines across
+seven crates — core's neutral I/O layer, both adapters, a unified KNX
+connection task, the serial connector reduced to framing, and the tests that
+settle each question. §7 lists what landed where.
+
+---
+
+## 1. What checks out
+
+Every load-bearing claim in §2, §5 and §6 was checked against the source.
+Line references are to `main` at `58c1951`; where the prototype later
+changes a cited item, the change is called out in §3.
+
+| Claim | Verified |
+|---|---|
+| §5.1 return-type notation is experimental on 1.98 | Yes — `error[E0658]: return type notation is experimental`, issue #109417 |
+| §5.1 the trait-declared `+ Send` shape works instead | Yes — a standalone crate with a `!Send` socket, a `SendFutureWrapper` newtype impl, a plain `async fn` impl, a generic `FramedConnection`, and a generic task boxed as `Send + 'static` compiles clean under `rustup run 1.98.0` |
+| §5.2 `embassy-sync` pulls in no executor | Yes — `_external/embassy/embassy-sync/Cargo.toml` deps are exactly `critical-section`, `heapless`, `futures-core`, `futures-sink`, `embedded-io-async`, `cfg-if` (+ optional `defmt`/`log`) |
+| §5.2 KNX Embassy already uses `StaticCell<Channel<CriticalSectionRawMutex, …, N>>` | Yes — [`embassy_client.rs:76-107`](../../aimdb-knx-connector/src/embassy_client.rs) |
+| §5.2 Tokio's `with_command_queue_size` becomes a const generic | Yes — it exists at [`tokio_client.rs:64`](../../aimdb-knx-connector/src/tokio_client.rs); the Embassy side already notes the size must be a constant |
+| §5.5 `spin::Mutex` needs no new dependency | Yes — `aimdb-core/Cargo.toml:120` already declares `spin` with `mutex`/`spin_mutex` |
+| §4 `RuntimeOps::sleep` boxes | Yes — `fn sleep(&self, d) -> BoxFuture` at [`executor.rs:50`](../../aimdb-core/src/executor.rs); `now_nanos` is a plain call |
+| §2 KNX is ~90 % shared behind a three-method `TunnelIo` | Yes — `send`/`forward`/`warn_ack_timeout` at [`tunnel.rs:536`](../../aimdb-knx-connector/src/tunnel.rs); `drain_actions` is the shared driver |
+| §2 both KNX halves bypass `RuntimeOps` for the clock | Yes — `embassy_time::Instant::now()` at `embassy_client.rs:281`, `tokio::time::Instant` at `tokio_client.rs:221` |
+| §2 the serial Embassy half is already the target shape | Yes — it contributes only `CobsFramer` and rides `EmbassyConnection<Rd, Wr, F, RC, WC>`; the file carries **zero** `unsafe` |
+| §5.4 `embassy-futures` is dependency-free | Yes — its `[dependencies]` is empty bar optional `defmt`/`log`, and `select_array` exists for the pooled case |
+| §6 `embassy_tls.rs` already bypasses `run_with_subscriptions` | Yes — `handle_messages` at [`embassy_tls.rs:372`](../../aimdb-mqtt-connector/src/embassy_tls.rs); the plain path still uses `run_with_subscriptions` at `embassy_client.rs:575` |
+| §6 `set_unix_time` has no neutral home | Yes — it is an inherent `EmbassyAdapter` method ([`runtime.rs:48`](../../aimdb-embassy-adapter/src/runtime.rs)), not on `RuntimeOps` |
+| §7.2 hostname resolution is a genuine gain | Yes — the plain Embassy path rejects non-IPv4-literal hosts today ("plain mqtt:// needs an IPv4 literal") |
+| §8 design 012 exists and needs a rewrite | Yes — `012-M5-connector-development-guide.md`, marked "✅ Implemented (Reference Documentation)" |
+| Acceptance 1 baseline | Yes — `cargo check -p aimdb-core --no-default-features --features alloc,connector-session,remote --target thumbv7em-none-eabihf` passes today, and core's only `unsafe` is a word inside a doc comment (`transport.rs:165`) |
+
+One structural point the design gets right without saying so: the Embassy TCP
+half documents that "`connector-io` cannot be reused directly because
+`TcpSocket::split()` only yields borrowed halves, while AimDB's `Connection`
+must own the socket". An unsplit `ByteStream` with `&mut self` on both
+directions dissolves that blocker, and it costs nothing, because
+`Connection::recv`/`send` already take `&mut self` and so already serialize.
+
+## 2. Factual errors
+
+1. **§8: "No tool or library crate constructs these connectors."** False.
+   [`aimdb-codegen/src/rust.rs`](../../aimdb-codegen/src/rust.rs) emits
+   `MqttConnector::new(&mqtt_url)` (lines 268, 1421) and
+   `KnxConnector::new(&knx_gateway)` (lines 269, 1424) into generated user
+   code. MQTT is unaffected (the `Native` backend keeps that signature), but
+   **KNX is not**: once `KnxConnector` is generic over `Datagram + Delay`, the
+   generated line must carry a transport, so `aimdb-codegen` changes and
+   `make codegen-drift` has to be re-baselined.
+2. **§8's call-site list is incomplete.** It omits
+   [`aimdb-tcp-connector/examples/tcp_demo.rs`](../../aimdb-tcp-connector/examples/tcp_demo.rs)
+   and
+   [`aimdb-serial-connector/examples/serial_demo.rs`](../../aimdb-serial-connector/examples/serial_demo.rs)
+   — precisely the two crates whose sugar §8 says will change. It also lists
+   all four `weather-mesh-demo` binaries when only `weather-station-gamma`
+   (Embassy MQTT) is affected; hub/alpha/beta use the unchanged Tokio path.
+3. **§2 cites `tokio_client.rs:691`.** That file is 632 lines. The clock is at
+   `tokio_client.rs:221-222`. (`embassy_client.rs:283` is off by two — the fn
+   is at 281.) `connectors.rs:75` in §5.1 should be `:74`.
+4. **Acceptance 2: "Every `unsafe impl Send`/`Sync` in the workspace remains
+   inside `aimdb-embassy-adapter`."** False today and after the change:
+   `aimdb-wasm-adapter` carries 16 (`buffer.rs` 9, `ws_bridge.rs` 4,
+   `time.rs` 3) and `aimdb-bench/src/alloc.rs` one. The criterion needs
+   scoping to the connector crates, which is what it evidently means.
+
+## 3. The four gaps, closed
+
+Each was flagged as needing design work before step 1. Each is now answered by
+code on the prototype branch, with a test that fails if the answer is wrong.
+
+### 3.1 `StreamListener` **can** back the Embassy N-socket accept pool
+
+The concern was that `accept(&mut self)` is single-shot while the pool exists
+to keep `N` sockets in `accept()` at once, so routing it through core's serial
+`serve` loop would drop concurrency to one — and that §6's "moves into the
+adapter unchanged" therefore could not hold.
+
+Reading `embassy-net` settles the mechanism. `TcpSocket::accept` is a
+*synchronous* `s.listen(endpoint)` followed by a bare `poll_fn` that waits for
+the state to leave `Listen`/`SynSent`/`SynReceived`. So **dropping the future
+does not un-listen the socket** — but *re-entering* `accept()` on a listening
+socket is `InvalidState`, and the `abort()` that makes it re-enterable is what
+drops the `LISTEN`.
+
+`EmbassyNet::listen::<N>` therefore stores one accept future per slot and
+consumes only the one that completes; the other `N-1` stay pending, untouched,
+still listening. Nothing is ever cancelled and no socket leaves `LISTEN`
+between calls.
+
+`aimdb-tcp-connector/tests/neutral_pool.rs` proves it over the same two
+crossover-wired `embassy-net` stacks the existing loopback smoke uses, driven
+in exactly the shape `serve` accepts in:
+
+- `pool_keeps_every_slot_listening_between_accepts` — client A connects and
+  round-trips bytes; **then**, while the server sits between accepts, client B
+  dials and also connects and round-trips. A pool holding only one socket in
+  `LISTEN` would have had B's SYN refused.
+- `naive_pool_loses_the_syn_that_arrives_between_accepts` — the same scenario
+  against a pool that re-creates its accepts each call. B's dial fails with
+  `TransportError::Io`, asserted. This is what makes the first test a finding
+  rather than a coincidence, and it is a regression guard: if embassy-net's
+  cancellation semantics ever change, it tells you the stored-accept design
+  can be simplified.
+
+So §6's wording needs one correction — the pool moves *reshaped*, not
+unchanged — but the trait set is sufficient, and the result is strictly better
+than today's: no `abort()`/`LISTEN` window at all.
+
+### 3.2 `Datagram` needed `local_addr` and a binder — both added, both work
+
+Confirmed as a real gap and closed by widening the trait, not by dropping
+behaviour. `Datagram::local_addr` is now part of the contract and
+`DatagramBinder` supplies sockets, so the engine's `Action::ResetSocket` can
+rebind.
+
+Both are implementable on both runtimes. Tokio reads `UdpSocket::local_addr`;
+Embassy assembles the address from the socket's bound port and the stack's
+IPv4 config, and rebinds by `close()` + `bind()` on the same socket rather
+than recreating it (which would strand its buffers).
+
+`neutral::tests::unified_task_advertises_the_real_local_endpoint` drives the
+unified task against a real UDP gateway socket and asserts the bytes: the
+CONNECT_REQUEST's control HPAI carries `127.0.0.1` and the socket's actual
+bound port, not `0.0.0.0:0`. Worth noting the Embassy half never set the
+explicit endpoint *at all* today, so unification fixes it rather than
+regressing it.
+
+### 3.3 `TunnelIo::send` did block generic code — fixed, and it cost one line
+
+Reproduced exactly. A probe asserting `Send` on `drain_actions`' future in
+generic code gave `E0277: future cannot be sent between threads safely`, with
+rustc prescribing the fix verbatim:
+
+```
+help: `Send` can be made part of the associated future's guarantees for all
+      implementations of `tunnel::TunnelIo::send`
+-     async fn send(&mut self, frame: &[u8]) -> bool;
++     fn send(&mut self, frame: &[u8]) -> impl Future<Output = bool> + Send;
+```
+
+Applied, with `tunnel::tests::drain_actions_future_is_send_in_generic_code` as
+the guard. The two existing impls then split exactly along §5.1's predicted
+line: the Tokio one stays a plain `async fn`, and the Embassy one — whose
+`embassy_net::udp::UdpSocket` future is `!Send` — returns the adapter's
+transparent `SendFutureWrapper`. That is §5.1's mechanism exercised on a real
+trait in a real connector rather than on a standalone sketch.
+
+### 3.4 §6 and acceptance 2 really did conflict — the signature is what gives
+
+A type assertion on the real struct confirmed it: `TlsOptions` is `!Send`
+because its RNG is a bare `&'static mut dyn CryptoRngCore`, so §5.5's
+`spin::Mutex<Option<T>>` cannot hold it and the `unsafe impl`s cannot go.
+
+The resolution is one `+ Send` on the trait object — a signature change §6
+says will not happen, and the cheapest of the available options, since every
+concrete CSPRNG a caller passes already satisfies it. With that:
+
+- core gains `session::OneShot<T>`, §5.5's cell: `Send + Sync` for any
+  `T: Send`, no `unsafe`, with a compile-time assertion of that property so a
+  regression surfaces in core rather than in a connector;
+- `TlsSlot` becomes an alias for it, and **`aimdb-mqtt-connector` now carries
+  zero `unsafe impl`s** (was two);
+- the whole `embassy-tls` path still cross-compiles to thumbv7em, so
+  `embedded-tls` accepts the bound.
+
+§6 should be amended to say `TlsOptions` keeps its *shape* but gains a `Send`
+bound on its RNG.
+
+## 4. The two understated consequences, measured
+
+### 4.1 `CriticalSectionRawMutex` on std is a link-time obligation
+
+§5.2 mentions `critical-section/std` only as a host-test detail. A standalone
+std binary using `Channel<CriticalSectionRawMutex, _, N>` fails to link:
+
+```
+rust-lld: error: undefined symbol: _critical_section_1_0_acquire
+rust-lld: error: undefined symbol: _critical_section_1_0_release
+```
+
+`NoopRawMutex` cannot substitute — it is `!Sync`, so it cannot back a shared
+channel at all (`*mut () cannot be shared between threads safely`).
+`CriticalSectionRawMutex` is therefore forced on std, and the obligation with
+it.
+
+It is also fully mitigable in one line, which the branch does: the KNX
+connector's `tokio-runtime` feature now enables `critical-section/std` itself,
+so no downstream std user ever sees the error.
+`neutral::tests::shared_embassy_channels_carry_telegrams_on_tokio` then runs
+§5.2's claim rather than asserting it — the unified task on Tokio, against a
+real UDP gateway, carrying a full handshake, an inbound telegram with its ACK,
+and an outbound command, all through the same `embassy_sync` channel types the
+MCU uses.
+
+### 4.2 The `embassy-sync` patch, and one feature-unification trap
+
+§5.4's "dependency-free" claim is exact: `embassy-futures` 0.1.2 has an empty
+`[dependencies]` bar optional `defmt`/`log`, and its `select3` drives the
+unified KNX loop on both runtimes. It is now an unconditional dependency of
+the KNX connector, and the std build is unaffected.
+
+One trap found by building rather than reading: making the adapter's `net`
+feature imply `embassy-time` turns on the workspace's
+`defmt-timestamp-uptime`, which defines `_defmt_timestamp` and collides with
+the `defmt::timestamp!` every host test binary must supply. Sockets and clock
+have to stay separable features — `net` does not imply `embassy-time`, and
+`EmbassyDelay` is gated separately.
+
+## 5. Acceptance criteria, re-reviewed against the prototype
+
+| # | Assessment |
+|---|---|
+| 1 | **Met.** Core carries the new traits, `FramedConnection`, `FramingDialer`/`FramingListener` and `OneShot`, and still cross-compiles to `thumbv7em-none-eabihf` with zero `unsafe`. |
+| 2 | Needs rewording (it overlooks `aimdb-wasm-adapter`'s 16 `unsafe impl`s and `aimdb-bench`'s one), but now reachable: MQTT is at zero, serial was already at zero, and the TCP connector's remaining three live in the module this design deletes — the adapter's `net` module already replaces them. |
+| 3 | **Met for serial**, and the doubt was unfounded: `tokio` for `io-util` alone suffices, with no `aimdb-tokio-adapter` dependency. See §3 of `neutral_framed.rs`. |
+| 4 | Still the sharpest criterion. `two_concurrent_sessions` and the three other loopback tests pass unchanged, and `neutral_pool.rs` adds the pooled-`StreamListener` equivalent. Note MQTT's `build_internal` tests are Tokio-only unit tests; there is still **no** host test for either Embassy MQTT path. |
+| 5 | **Near-vacuous, unchanged.** `examples/embassy-bench-stm32h5` depends only on `aimdb-core`, `aimdb-embassy-adapter` and `aimdb-bench` — no connector — so it will show no change whatever the refactor does. Replace it with an allocation-counting test on a connector path. |
+| 6 | Still the most valuable, and still unbuilt. Build it first, not last (§6.3). |
+
+## 6. Effort assessment, recalibrated
+
+### 6.1 Code in scope
+
+Runtime-specific connector code the design deletes or restructures:
+
+| Crate | Files | Lines |
+|---|---|---|
+| `aimdb-tcp-connector` | `embassy_transport.rs` 591 + `tokio_transport.rs` 302 | 893 |
+| `aimdb-serial-connector` | `embassy_transport.rs` 237 + most of `tokio_transport.rs` 312 | 549 |
+| `aimdb-knx-connector` | `embassy_client.rs` 468 + `tokio_client.rs` 632 | 1 100 |
+| `aimdb-mqtt-connector` | `embassy_client.rs` 712 + `embassy_tls.rs` 415 + `tokio_client.rs` 457 | 1 584 |
+| **Total** | | **~4 130** |
+
+Untouched and load-bearing: `tunnel.rs` (1 400), the two `framing.rs`
+(93 + 139), `sntp*.rs` (281), `link_ext.rs` (68).
+
+The prototype is 2 324 lines added across 22 files, which is
+the first hard data point on the "new code" estimate. It covers step 1 in
+full, both halves of step 2, the load-bearing parts of steps 4a and 4b, and
+none of steps 3, 5 or 6.
+
+### 6.2 Stage estimates
+
+| Step | Work | Days | Status |
+|---|---|---|---|
+| 1 | Core traits, `FramedConnection`, framing adapters, `OneShot` | 2–3 | **done on the prototype branch** |
+| 2a | `aimdb-tokio-adapter` `net` feature | 1–2 | **done** |
+| 2b | `EmbassyNet`/`EmbassyUart`/`Delay` + slot-pool move | 3–5 | **done**; §3.1 resolved, so the risk that inflated this is gone |
+| 3 | TCP pilot: port the connector onto the traits, migrate `embassy_loopback` | 3–4 | not started; the adapter side it depends on is done |
+| 4a | Serial | 1–2 | framing + streams **done**; connector sugar and test migration remain |
+| 4b | KNX | 3–5 | unified task **done**; builder/channel wiring and deleting the two clients remain |
+| 5 | MQTT `Native`/`Embedded` split | 5–8 | not started |
+| 6 | Examples, codegen + drift re-baseline, design 012, CHANGELOGs, major bumps | 2–3 | not started |
+| | **Total** | **20–32 days ≈ 4–6 weeks** | |
+
+The estimate holds. What changed is its shape: the week of contingency I
+attached to §3.1 is no longer needed, and the four gaps that could each have
+forced a rethink are closed. The remaining risk is concentrated almost
+entirely in step 5.
+
+### 6.3 Where the risk actually sits
+
+- **MQTT is the long pole and the thinnest-covered.** 1 584 lines restructured
+  with no host integration test for either Embassy path. Moving the plain path
+  from `run_with_subscriptions` to `handle_messages` means re-implementing the
+  reconnect-and-resubscribe loop mountain-mqtt-embassy currently owns
+  (`embassy_client.rs:562-577` — "the manager re-subscribes these topics on
+  every connection, so inbound routing survives reconnects"). That is
+  behaviour, not plumbing. Acceptance 6 is the mitigation and should be built
+  **first**.
+- **Everything else is now de-risked by running code.** The traits, both
+  adapters, the accept pool, the unified KNX task and the neutral framed
+  connection all exist and are tested.
+- **What is well covered:** CI cross-compiles every Embassy connector to
+  `thumbv7em-none-eabihf` (`make test-embedded`, 8 connector configurations),
+  and the TCP and serial halves have real host smokes.
+
+## 7. What is on the prototype branch
+
+New:
+
+- `aimdb-core/src/session/io.rs` — `ByteStream`, `StreamDialer`,
+  `StreamListener`, `Datagram`, `DatagramBinder`, `Delay`, `Framer`,
+  `FramerFactory`, `FramedConnection`, `FramingDialer`, `FramingListener`,
+  `OneShot`. Additive; core still has zero `unsafe`.
+- `aimdb-embassy-adapter/src/net.rs` (feature `net`) — `EmbassyNet::tcp` /
+  `listen::<N>` / `udp`, `EmbassyTcpStream`, the stored-accept pool,
+  `EmbassyUdpSocket`/`EmbassyUdpBinder`, `EmbassyDelay`. All the force-`Send`
+  for the TCP and UDP paths lives here.
+- `aimdb-tokio-adapter/src/net.rs` (feature `net`) — the std duals, every
+  future a plain `async fn`, no `unsafe`.
+- `aimdb-knx-connector/src/neutral.rs` — one `connection_task` generic over
+  `DatagramBinder + Delay`, plus the `embassy_sync` channel bridges.
+- `aimdb-serial-connector/src/neutral.rs` — the COBS framer against core's
+  trait, and one `ByteStream` per byte source.
+- Tests: `aimdb-tcp-connector/tests/neutral_pool.rs`,
+  `aimdb-serial-connector/tests/neutral_framed.rs`, and unit tests in
+  `neutral.rs` and `tunnel.rs`.
+
+Changed: `TunnelIo::send` gains `+ Send`; `TlsOptions`'s RNG gains `+ Send`
+and `TlsSlot` becomes `OneShot`; the KNX `tokio-runtime` feature adopts
+`embassy-sync` + `critical-section/std`; `embassy-futures` becomes
+unconditional.
+
+Verification run: `make test-embedded` passes (all 8 Embassy connector
+configurations), every connector test suite passes, and clippy is clean on
+the changed crates. Two pre-existing failures are unrelated to this work and
+reproduce on `main`: `aimdb-data-contracts`' `compile_fail` trybuild suite,
+and `cargo clippy --target thumbv7em-none-eabihf`, which fails in this
+environment for untouched crates too.


### PR DESCRIPTION
Docs only — no code. The prototype that produced these findings stays on `claude/design-doc-52-verify-1lsexa`; this lands the corrected design ahead of it so the findings aren't stranded behind an unmerged change.

Design 052 was written before any of it was built. Verifying it against the tree, and prototyping the parts that looked uncertain, turned up four factual errors and closed four gaps the draft left open.

## Corrected in 052

- **§2** cited `tokio_client.rs:691` in a 632-line file, plus two more stale line references.
- **§3.2 / §6** said the Embassy N-socket accept pool "moves into the adapter unchanged". It moves *reshaped*: `TcpSocket::accept` is a synchronous `listen()` plus a bare `poll_fn`, so dropping the future does not un-listen — but re-entering it on a listening socket errors, and the `abort()` that fixes that is what loses the SYN. Storing one pending accept per slot avoids both.
- **§5.5**'s `T: Send` bound is incompatible with §6's "TlsOptions keeps its signature" — its RNG is a bare trait object, so the struct is `!Send`. The signature is what gives; this is a public breaking change whose only call site is an example configuration CI never builds.
- **§8** claimed no tool constructs these connectors. `aimdb-codegen` emits `KnxConnector::new`, so codegen and its drift baseline are in scope. The call-site list also omitted two crate-local examples.
- **Acceptance 2** was scoped "in the workspace", which `aimdb-wasm-adapter`'s 16 `unsafe impl`s falsify in both directions. **Acceptance 5** names a benchmark with no connector in its graph, so it can never fail.

## Added

Rebinding sockets via `DatagramBinder` and the `local_addr` the KNX handshake needs; the `critical-section` link obligation on std and its one-line mitigation; the feature-separation trap that keeps sockets and clock apart; and a sequencing table marking what is built.

Passages are marked **[verified]** (executed) or **[revised]** (the prototype disproved it), so a reader can tell reasoning from evidence.

`052-verification.md` carries the review record, the test names behind each claim, and a 4–6 week effort assessment recalibrated against the prototype.

## Review notes

Status stays **proposal, revised** rather than *accepted* — that call is the maintainers'. Nothing here builds or runs, so CI has no code to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYLAPup9oSrmKkwMT9cPin

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYLAPup9oSrmKkwMT9cPin)_