### PR TITLE
Enforce with_max_clients at http handler

### DIFF
--- a/aimdb-websocket-connector/src/server/builder.rs
+++ b/aimdb-websocket-connector/src/server/builder.rs
@@ -62,7 +62,8 @@ use super::{
 ///     .bind("0.0.0.0:8080")
 ///     .path("/ws")
 ///     .with_late_join(true)
-///     .with_max_clients(500);
+///     .with_max_clients(500)
+///     .with_max_subs_per_connection(500);
 /// ```
 pub struct WebSocketConnectorBuilder {
     bind_addr: SocketAddr,
@@ -70,6 +71,7 @@ pub struct WebSocketConnectorBuilder {
     auth: DynAuthHandler,
     late_join: bool,
     max_clients: usize,
+    max_subs_per_connection: usize,
     channel_capacity: usize,
     additional_routes: Option<AxumRouter>,
     /// Topics to subscribe every new client to automatically on connect.
@@ -93,6 +95,7 @@ impl Default for WebSocketConnectorBuilder {
             auth: Arc::new(NoAuth),
             late_join: true,
             max_clients: 1024,
+            max_subs_per_connection: 1024,
             channel_capacity: 256,
             additional_routes: None,
             auto_subscribe_topics: Vec::new(),
@@ -111,6 +114,7 @@ impl WebSocketConnectorBuilder {
     /// - auth: allow all
     /// - late-join snapshots: enabled
     /// - max clients: 1 024
+    /// - max subscriptions per connection: 1 024
     /// - per-client channel capacity: 256
     pub fn new() -> Self {
         Self::default()
@@ -154,13 +158,28 @@ impl WebSocketConnectorBuilder {
         self
     }
 
-    /// Set the per-connection subscription ceiling (default: 1 024).
+    /// Set the live-connection ceiling (default: 1 024).
     ///
-    /// Despite the name, this bounds live subscriptions per connection
-    /// (`max_subs_per_connection`), not the client count — connection count is the
-    /// axum accept loop's concern, not enforced here.
+    /// Enforced at the HTTP upgrade: once this many clients are connected,
+    /// further upgrades are refused with `503 Service Unavailable` before the
+    /// socket opens. A slot is claimed when the upgrade is admitted and released
+    /// when that connection's session ends.
+    ///
+    /// Note that a connection lost *without* a TCP FIN — a cut cable, a NAT or
+    /// firewall silently dropping the flow — holds its slot until the socket is
+    /// noticed as dead, since the server neither pings nor times out idle
+    /// connections. Size the cap with that in mind.
+    ///
+    /// This method previously set the per-connection subscription cap; that knob
+    /// is now [`with_max_subs_per_connection`](Self::with_max_subs_per_connection).
     pub fn with_max_clients(mut self, max: usize) -> Self {
         self.max_clients = max;
+        self
+    }
+
+    /// Set the per-connection subscription ceiling (default: 1 024).
+    pub fn with_max_subs_per_connection(mut self, max: usize) -> Self {
+        self.max_subs_per_connection = max;
         self
     }
 
@@ -317,9 +336,8 @@ impl ConnectorBuilder for WebSocketConnectorBuilder {
                 auth: self.auth.clone(),
                 client_mgr,
                 auto_subscribe: Arc::new(self.auto_subscribe_topics.clone()),
-                // `max_clients` now supplies the per-connection subscription cap;
-                // connection count stays axum's concern (see `with_max_clients`).
-                max_subs_per_connection: self.max_clients.max(1),
+                max_clients: self.max_clients.max(1),
+                max_subs_per_connection: self.max_subs_per_connection.max(1),
                 started_at: Instant::now(),
             };
             let additional = self.additional_routes.clone();

--- a/aimdb-websocket-connector/src/server/client_manager.rs
+++ b/aimdb-websocket-connector/src/server/client_manager.rs
@@ -91,11 +91,34 @@ impl ClientManager {
         self.connections.load(Ordering::Relaxed) as usize
     }
 
-    /// RAII guard: increments the connection count now, decrements on drop.
-    pub(crate) fn connection_guard(&self) -> ConnectionGuard {
-        self.connections.fetch_add(1, Ordering::Relaxed);
-        ConnectionGuard {
-            connections: self.connections.clone(),
+    /// Claim a connection slot, or `None` once `max_clients` are live.
+    ///
+    /// The check and the increment are one compare-exchange, so concurrent
+    /// upgrades cannot all pass on the same observed count — hence the retry
+    /// loop, which re-reads the value another thread just claimed. The returned
+    /// guard releases the slot on drop, so it must be held for as long as the
+    /// connection lives (see `ws_upgrade_handler`).
+    pub(crate) fn try_connection_guard(&self, max_clients: u64) -> Option<ConnectionGuard> {
+        let mut current = self.connections.load(Ordering::Relaxed);
+        // Try to claim the slot till success
+        loop {
+            if current >= max_clients {
+                return None;
+            }
+
+            match self.connections.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return Some(ConnectionGuard {
+                        connections: self.connections.clone(),
+                    })
+                }
+                Err(actual) => current = actual,
+            }
         }
     }
 

--- a/aimdb-websocket-connector/src/server/dispatch.rs
+++ b/aimdb-websocket-connector/src/server/dispatch.rs
@@ -25,7 +25,7 @@ use serde_json::Value;
 
 use super::{
     auth::{AuthHandler, ClientId, ClientInfo, Permissions},
-    client_manager::{ClientManager, ConnectionGuard},
+    client_manager::ClientManager,
     session::{QueryHandler, Router, SnapshotProvider},
 };
 
@@ -82,7 +82,6 @@ impl Dispatch for WsDispatch {
             late_join: self.late_join,
             runtime_ctx: self.runtime_ctx.clone(),
             info,
-            _conn_guard: self.client_mgr.connection_guard(),
         })
     }
 }
@@ -99,8 +98,6 @@ struct WsSession {
     late_join: bool,
     runtime_ctx: aimdb_core::RuntimeContext,
     info: Arc<ClientInfo>,
-    /// Decrements the live-connection count on drop.
-    _conn_guard: ConnectionGuard,
 }
 
 impl Session for WsSession {

--- a/aimdb-websocket-connector/src/server/http.rs
+++ b/aimdb-websocket-connector/src/server/http.rs
@@ -4,6 +4,14 @@
 //! address, mounts the WebSocket endpoint at the configured path, and
 //! optionally mounts additional user-provided Axum routes.
 //!
+//! # Upgrade gates
+//!
+//! [`ws_upgrade_handler`] refuses a connection before the socket opens, with the
+//! status saying why: `426` for an incompatible AimX version, `503` once
+//! `with_max_clients` connections are live, `401` when the [`AuthHandler`]
+//! rejects. A slot for the cap is claimed at admission and released when the
+//! session ends, so `/health`'s count is exact from the moment the 101 goes out.
+//!
 //! # Health endpoint
 //!
 //! `GET /health` returns `200 OK` with a JSON body:
@@ -69,6 +77,8 @@ pub(crate) struct ServerState {
     pub client_mgr: ClientManager,
     /// Patterns to auto-subscribe each client to on connect.
     pub auto_subscribe: Arc<Vec<String>>,
+    /// Maximum number connection allowed
+    pub max_clients: usize,
     /// Per-connection subscription cap.
     pub max_subs_per_connection: usize,
     pub started_at: Instant,
@@ -154,6 +164,29 @@ async fn ws_upgrade_handler(
         query_params,
         remote_addr,
     };
+    // Connection cap, refused with 503 before the socket opens. The slot is
+    // claimed here rather than in `WsDispatch::open` so the check and the
+    // increment are one atomic step: `open` runs inside `run_session`, after the
+    // 101 is already on the wire, so a count read here would not yet include the
+    // connection admitted a moment ago and concurrent upgrades would all pass.
+    //
+    // WARNING: a connection lost without a TCP FIN (cut cable, NAT or firewall
+    // dropping the flow) holds its slot until the socket is noticed as dead —
+    // the server neither pings nor times out idle connections.
+    let max_clients = state.max_clients as u64;
+    let Some(conn_guard) = state.client_mgr.try_connection_guard(max_clients) else {
+        #[cfg(feature = "tracing")]
+        tracing::warn!(
+            "WebSocket upgrade from {} refused: {} clients connected",
+            remote_addr,
+            max_clients
+        );
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("maximum connected clients of {} reached", max_clients),
+        )
+            .into_response();
+    };
 
     // Protocol-version gate, before auth: the socket transports negotiate the
     // version inside `hello`, but the WS server runs `reads_hello:false` and a
@@ -212,7 +245,9 @@ async fn ws_upgrade_handler(
     let auto_subscribe = state.auto_subscribe.clone();
     let config = SessionConfig {
         limits: SessionLimits {
-            max_connections: usize::MAX, // axum owns the accept loop
+            // The engine's own connection limit stays off: axum owns the accept
+            // loop, and the cap is enforced above by `try_connection_guard`.
+            max_connections: usize::MAX,
             max_subs_per_connection: state.max_subs_per_connection,
         },
         reads_hello: false,
@@ -220,6 +255,9 @@ async fn ws_upgrade_handler(
     };
 
     ws.on_upgrade(move |socket: WebSocket| async move {
+        // Move the guard here, dropped when connection ends
+        // WsSession will no longer hold the guard, as the api currently does not allow that
+        let _conn_guard = conn_guard;
         let peer = PeerInfo::default().with_ext(Arc::new(info));
         let conn: Box<dyn Connection> =
             Box::new(WsServerConnection::new(socket, peer, &auto_subscribe));

--- a/aimdb-websocket-connector/tests/e2e.rs
+++ b/aimdb-websocket-connector/tests/e2e.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
-use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::{http::StatusCode, Error, Message};
 
 // ── Injector record ──────────────────────────────────────────────────
 // Producing one pushes `payload` out on `topic` via the real outbound path.
@@ -254,6 +254,33 @@ async fn http_get(addr: SocketAddr, path: &str) -> (String, String) {
     let (head, body) = raw.split_once("\r\n\r\n").expect("no header/body split");
     let status = head.lines().next().unwrap_or_default().to_string();
     (status, body.to_string())
+}
+
+/// The live client count `/health` reports.
+async fn health_clients(addr: SocketAddr) -> usize {
+    let (status, body) = http_get(addr, "/health").await;
+    assert!(
+        status.contains("200"),
+        "unexpected /health status: {status}"
+    );
+    let parsed: Value = serde_json::from_str(&body).expect("health body is JSON");
+    parsed["clients"].as_u64().expect("clients field") as usize
+}
+
+/// [`health_clients`] polled until it reports `want`, returning the last value
+/// seen. A slot is *claimed* synchronously at the upgrade, so the admit side
+/// needs no wait — but it is *released* when the session future unwinds, one
+/// scheduler hop after the peer's close, so the disconnect side does.
+async fn health_clients_reaches(addr: SocketAddr, want: usize) -> usize {
+    let mut seen = health_clients(addr).await;
+    for _ in 0..200 {
+        if seen == want {
+            return seen;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        seen = health_clients(addr).await;
+    }
+    seen
 }
 
 /// Send one raw AimX frame (a JSON value) as a WS text message.
@@ -621,6 +648,111 @@ async fn server_rejects_incompatible_protocol_version() {
     )))
     .await;
     assert!(ok.is_ok(), "current version must upgrade");
+}
+
+/// The connection cap is enforced at the upgrade: once `with_max_clients` are
+/// connected, further upgrades are refused with 503 before the socket opens, and
+/// closing one frees its slot. A refused upgrade must not consume a slot itself.
+#[tokio::test]
+async fn server_rejects_upgrade_past_the_client_cap() {
+    const LIMIT: usize = 3;
+    let (addr, _db) = spawn(WebSocketConnector::new().with_max_clients(LIMIT)).await;
+
+    // Hold the sockets — dropping one would free its slot mid-test.
+    let mut live: Vec<WsClient> = Vec::new();
+    for _ in 0..LIMIT {
+        live.push(ws_connect(addr).await);
+    }
+    assert_eq!(
+        health_clients(addr).await,
+        LIMIT,
+        "a slot is claimed at the upgrade, so the count is exact once the 101 lands"
+    );
+
+    let err = tokio_tungstenite::connect_async(aimdb_core::remote::ws_url_with_version(&format!(
+        "ws://{addr}/ws"
+    )))
+    .await
+    .expect_err("the client past the cap must be refused");
+    let Error::Http(resp) = err else {
+        panic!("expected an HTTP rejection, got {err:?}");
+    };
+    // Asserting the status, not just the failure: the same dial would also fail
+    // with 426 or 401, and those would mean the cap never ran.
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "over-capacity upgrade must be refused with 503, body: {:?}",
+        resp.body().as_deref().map(String::from_utf8_lossy),
+    );
+    assert_eq!(
+        health_clients(addr).await,
+        LIMIT,
+        "a refused upgrade must not consume a slot"
+    );
+
+    // Closing one connection frees its slot for the next client.
+    drop(live.pop().expect("a live client"));
+    assert_eq!(
+        health_clients_reaches(addr, LIMIT - 1).await,
+        LIMIT - 1,
+        "a closed connection must release its slot"
+    );
+    live.push(ws_connect(addr).await);
+}
+
+/// The cap must hold when upgrades arrive *together*, not just one at a time.
+///
+/// A sequential test cannot catch this: on a current-thread runtime each dial is
+/// awaited to completion, so the server's session task is always scheduled before
+/// the next dial reads the count. Under concurrent dials every in-flight handler
+/// observes the same value, so the admission check and the counter's increment
+/// have to be one atomic step ([`ClientManager::try_connection_guard`]) — with a
+/// plain load-then-increment they all wave each other through.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn client_cap_holds_under_concurrent_upgrades() {
+    const LIMIT: usize = 3;
+    const DIALS: usize = 8;
+    let (addr, _db) = spawn(WebSocketConnector::new().with_max_clients(LIMIT)).await;
+    let url = aimdb_core::remote::ws_url_with_version(&format!("ws://{addr}/ws"));
+
+    // All dials in flight at once, so they race the admission gate.
+    let mut set = tokio::task::JoinSet::new();
+    for _ in 0..DIALS {
+        let url = url.clone();
+        set.spawn(async move { tokio_tungstenite::connect_async(url).await });
+    }
+
+    // Hold the admitted sockets — dropping one would free its slot mid-assertion.
+    let mut admitted: Vec<WsClient> = Vec::new();
+    let mut refused = 0usize;
+    while let Some(joined) = set.join_next().await {
+        match joined.expect("dial task panicked") {
+            Ok((sock, _)) => admitted.push(sock),
+            Err(Error::Http(resp)) => {
+                assert_eq!(
+                    resp.status(),
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "over-capacity dials must be refused with 503"
+                );
+                refused += 1;
+            }
+            Err(e) => panic!("unexpected dial failure: {e:?}"),
+        }
+    }
+
+    // Exact, not `<=`: this also catches a gate that refuses while slots are free.
+    assert_eq!(
+        admitted.len(),
+        LIMIT,
+        "cap of {LIMIT} not held under concurrent dials"
+    );
+    assert_eq!(
+        refused,
+        DIALS - LIMIT,
+        "every dial past the cap must be refused"
+    );
+    assert_eq!(health_clients(addr).await, LIMIT);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description
What's new:
- Enforces `with_max_client` at http handler level by introducing `try_connection_guard` which implements a Compare And Swap on the atomic connection counter;
- Updates `WsDispatch` and `WsSession` as they can no longer hold a `conn_guard` generated externally given current signagure;
- Adds `with_max_subs_per_connection` to `WebSocketConnectorBuilder` which is now the real cap on subs per connection;
- Adds test cases for the `with_max_client` cap featuring two scenarios: 1) clients sequentially connect; 2) clients concurrently connect

## Related Issue
- Closes #216 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/aimdb-dev/aimdb/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the project's coding standards.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed (`make check`).
- [x] I have updated the documentation accordingly.
